### PR TITLE
Disable automatic position closing

### DIFF
--- a/5_4_MetaApi_Conda_Kal_Optimize.ipynb
+++ b/5_4_MetaApi_Conda_Kal_Optimize.ipynb
@@ -1937,7 +1937,7 @@
         "    Bucle principal:\n",
         "      • Crea/migra el CSV inicial (ATR interno, señales Kalman).\n",
         "      • Sin posición → espera al cierre del TF, procesa última vela cerrada y evalúa entrada.\n",
-        "      • Con posición → cada 20s recalcula, cierra si corresponde, actualiza SL dinámico y\n",
+        "      • Con posición → cada 20s recalcula, actualiza SL dinámico y\n",
         "        ENVÍA SIEMPRE la modificación de SL cuando cambie Stop_Loss_$ (usa los dos últimos\n",
         "        valores distintos). Registra en log una línea adicional confirmando el envío.\n",
         "    \"\"\"\n",
@@ -2227,8 +2227,8 @@
         "                s1, s2, s3, s4 = SMOOTHS\n",
         "                generate_trade_signals(df_all, l1, l2, l3, l4, s1, s2, s3, s4)\n",
         "\n",
-        "                # 5) Intentar cerrar si hay señal de cierre (pendiente de kal_4)\n",
-        "                await close_order(df_all, rpc_conn, symbol=SYMBOL, magic=MAGIC, close_col=\"Close_Trade\")\n",
+        "                # 5) Cierre automático deshabilitado (solo TP/SL)\n",
+        "                # await close_order(df_all, rpc_conn, symbol=SYMBOL, magic=MAGIC, close_col=\"Close_Trade\")\n",
         "\n",
         "                # 6) Recalcular métricas y stop dinámico\n",
         "                atr_close(df_all)\n",
@@ -2258,7 +2258,7 @@
         "\n",
         "                # 10) Logs (incluye segunda línea cuando SL se envió/intentó enviar)\n",
         "                base = (dt.datetime.utcnow().strftime(\"%H:%M:%S\")\n",
-        "                        + \" | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\")\n",
+        "                        + \" | seguimiento 20s: señales, atr_close + tick_dyn_atr + sync_market\")\n",
         "                print(base)\n",
         "                if sl_res.get(\"changed\"):\n",
         "                    if sl_res.get(\"sent\"):\n",
@@ -2292,39 +2292,7 @@
         "id": "yI6v2q_xfRtg",
         "outputId": "442d5713-66bc-4239-db02-f286c89cd59f"
       },
-      "outputs": [
-        {
-          "metadata": {
-            "tags": null
-          },
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "14:00:04 | actualización (modo búsqueda de entrada)\n",
-            "✅ SELL placed | orderId=1213383479 positionId=1213383479 openPrice=112880.5 | SL sent=113438.2314 | Type=Short\n",
-            "14:05:04 | actualización (modo búsqueda de entrada)\n",
-            "▶ Modo seguimiento: posición con magic 900001 detectada\n",
-            "14:05:20 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:05:42 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:06:01 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:06:21 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:06:41 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:07:01 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:07:20 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL actualizado en broker a 112880.50 (positionId=1213383479)\n",
-            "14:07:40 | seguimiento 20s: señales, posible cierre, atr_close + tick_dyn_atr + sync_market\n",
-            "   ↳ SL cambió a 112880.50 pero no se pudo enviar (No hay posición con ese magic)\n",
-            "⏹ La posición con magic 900001 se cerró → regreso a búsqueda de entrada\n",
-            "14:10:03 | actualización (modo búsqueda de entrada)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "###############################################################################\n",
         "# EJECUCIÓN\n",


### PR DESCRIPTION
## Summary
- remove 20-second auto-closing logic so trades close only via stop-loss or take-profit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb148d66a88328a90e470426aceacd