### PR TITLE
fix missing HARDCODED_META_TOKEN

### DIFF
--- a/5_3_MetaApi_Conda_Kal+ML.ipynb
+++ b/5_3_MetaApi_Conda_Kal+ML.ipynb
@@ -365,7 +365,7 @@
     "\n",
     "\n",
     "# Lee primero del entorno; si no existe, usa el respaldo (si lo pusieras)\n",
-    "META_API_TOKEN = os.getenv(\"META_API_TOKEN\", HARDCODED_META_TOKEN).strip()\n",
+    "META_API_TOKEN = os.getenv(\"META_API_TOKEN\", \"\").strip()\n",
     "if not META_API_TOKEN:\n",
     "    raise RuntimeError(\n",
     "        \"META_API_TOKEN no est\u00e1 definido. \"\n",


### PR DESCRIPTION
## Summary
- prevent NameError by initializing meta API token from environment with an empty fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf516cf5e48328a1aac02bd9fdb817