### PR TITLE
Fix label column missing after merge in binary ML notebook

### DIFF
--- a/3. XAUUSD_Binary_ML.ipynb
+++ b/3. XAUUSD_Binary_ML.ipynb
@@ -1314,8 +1314,21 @@
       "outputs": [],
       "source": [
         "columns_to_drop = ['st_row_PnL_Low']\n",
-        "feat_obj = feat_obj.drop(columns=columns_to_drop)\n",
-        "feat_obj.dropna(inplace=True)"
+        "feat_obj = feat_obj.drop(columns=columns_to_drop, errors='ignore')\n",
+        "\n",
+        "label_sources = [col for col in ['label_x', 'label_y'] if col in feat_obj.columns]\n",
+        "if label_sources:\n",
+        "    feat_obj['label'] = (\n",
+        "        feat_obj[label_sources]\n",
+        "        .bfill(axis=1)\n",
+        "        .iloc[:, 0]\n",
+        "    )\n",
+        "    feat_obj.drop(columns=label_sources, inplace=True)\n",
+        "\n",
+        "feat_obj.dropna(inplace=True)\n",
+        "\n",
+        "if 'label' in feat_obj.columns:\n",
+        "    feat_obj['label'] = feat_obj['label'].astype('int8')"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- consolidate the merged label columns into a single `label` field after combining label and feature data
- drop redundant `label_x`/`label_y` columns, keep the column dtype, and retain downstream preprocessing steps

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c89fc0a8d08328921109fe245c84ba