### PR TITLE
Adjust meta training to rely on prob_1 only

### DIFF
--- a/3. XAUUSD_Binary_ML.ipynb
+++ b/3. XAUUSD_Binary_ML.ipynb
@@ -2789,7 +2789,7 @@
         "train['prob_0'] = prediction_probabilities[:, 0]\n",
         "train['prob_1'] = prediction_probabilities[:, 1]\n",
         "\n",
-        "meta_features = train_features + ['prob_1']#['label_ml']\n",
+        "meta_features = ['prob_1']  # use only the base model probability for meta features\n",
         "X_meta_features = train[meta_features]\n",
         "\n",
         "#train.head()"
@@ -2832,7 +2832,7 @@
       ],
       "source": [
         "#meta = train_features + ['label_ml', 'prob_1', 'prob_0']\n",
-        "meta = train_features + ['prob_1']\n",
+        "meta = ['prob_1']  # train meta-model using only prob_1\n",
         "X_meta_features = train[meta]\n",
         "\n",
         "X = train[meta]\n",


### PR DESCRIPTION
## Summary
- update the meta feature set so that the meta-training step only consumes the base model's prob_1 output

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9c3f48908832888fc1e36a7a83c67