### PR TITLE
Add probability threshold metrics for ML and Meta models

### DIFF
--- a/3. XAUUSD_Binary_ML.ipynb
+++ b/3. XAUUSD_Binary_ML.ipynb
@@ -2693,6 +2693,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate ML model using a 0.7 probability threshold for class 1\n",
+    "y_proba = ml_model.predict_proba(X_test)[:, 1]\n",
+    "y_pred_threshold = (y_proba >= 0.7).astype(int)\n",
+    "\n",
+    "conf_matrix_threshold = confusion_matrix(y_true, y_pred_threshold)\n",
+    "print(\"Confusion Matrix (Threshold 0.7):\")\n",
+    "print(conf_matrix_threshold)\n",
+    "\n",
+    "class_report_threshold = classification_report(y_true, y_pred_threshold)\n",
+    "print(\"\\nClassification Report (Threshold 0.7):\")\n",
+    "print(class_report_threshold)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 286,
    "id": "dCEg0X2E04iQ",
    "metadata": {
@@ -3008,6 +3027,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate Meta ML model using a 0.7 probability threshold for class 1\n",
+    "meta_y_proba = meta_ml_model.predict_proba(X_test)[:, 1]\n",
+    "meta_y_pred_threshold = (meta_y_proba >= 0.7).astype(int)\n",
+    "\n",
+    "meta_conf_matrix_threshold = confusion_matrix(y_true, meta_y_pred_threshold)\n",
+    "print(\"Confusion Matrix (Threshold 0.7):\")\n",
+    "print(meta_conf_matrix_threshold)\n",
+    "\n",
+    "meta_class_report_threshold = classification_report(y_true, meta_y_pred_threshold)\n",
+    "print(\"\\nClassification Report (Threshold 0.7):\")\n",
+    "print(meta_class_report_threshold)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "tAR97BLJu44I",
    "metadata": {
     "id": "tAR97BLJu44I"
@@ -3281,6 +3319,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate ML model on the test set using a 0.7 probability threshold for class 1\n",
+    "test['label_ml_prob_70'] = np.where(test['prob_1'] >= 0.7, 1, 0)\n",
+    "\n",
+    "conf_matrix_prob_70 = confusion_matrix(test['label'], test['label_ml_prob_70'])\n",
+    "print(\"Confusion Matrix (Threshold 0.7):\")\n",
+    "print(conf_matrix_prob_70)\n",
+    "\n",
+    "class_report_prob_70 = classification_report(test['label'], test['label_ml_prob_70'])\n",
+    "print(\"\\nClassification Report (Threshold 0.7):\")\n",
+    "print(class_report_prob_70)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 268,
    "id": "O0tSbMwArC8a",
    "metadata": {
@@ -3361,6 +3417,24 @@
     "class_report = classification_report(test['label'], test['meta_label'])\n",
     "print(\"\\nClassification Report:\")\n",
     "print(class_report)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate Meta ML model on the test set using a 0.7 probability threshold for class 1\n",
+    "test['meta_label_prob_70'] = np.where(test['meta_prob_1'] >= 0.7, 1, 0)\n",
+    "\n",
+    "meta_conf_matrix_prob_70 = confusion_matrix(test['label'], test['meta_label_prob_70'])\n",
+    "print(\"Confusion Matrix (Threshold 0.7):\")\n",
+    "print(meta_conf_matrix_prob_70)\n",
+    "\n",
+    "meta_class_report_prob_70 = classification_report(test['label'], test['meta_label_prob_70'])\n",
+    "print(\"\\nClassification Report (Threshold 0.7):\")\n",
+    "print(meta_class_report_prob_70)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add evaluation cells that compute confusion matrices and classification reports using a 0.7 probability threshold for the ML model on the validation split
- add equivalent 0.7-threshold evaluation for the Meta model and extend the held-out test set analysis with threshold-based predictions

## Testing
- not run (notebook-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9cdab1cf4832895db084aceae331e