### PR TITLE
Flip indicators for short trades in feature notebook

### DIFF
--- a/7_XAUUSD_Long_Short_Features.ipynb
+++ b/7_XAUUSD_Long_Short_Features.ipynb
@@ -4516,7 +4516,29 @@
     {
       "cell_type": "code",
       "source": [
-        "#### Cell to work ON"
+        "# Align indicator values so short trades mirror the long setup",
+        "if \'Open_Trade\' not in df_diff.columns:",
+        "    if \'Open_Trade\' in df.columns:",
+        "        df_diff = pd.merge(",
+        "            df_diff,",
+        "            df[[\'Date\', \'Open_Trade\']],",
+        "            on=\'Date\',",
+        "            how=\'left\'",
+        "        )",
+        "    else:",
+        "        raise KeyError(\"'Open_Trade' column not found in df_diff or source df.\")",
+        "",
+        "numeric_indicator_cols = [",
+        "    col",
+        "    for col in df_diff.columns",
+        "    if col not in [\'Date\', \'label\', \'Open_Trade\']",
+        "    and pd.api.types.is_numeric_dtype(df_diff[col])",
+        "]",
+        "",
+        "short_mask = df_diff['Open_Trade'] == -1",
+        "df_diff.loc[short_mask, numeric_indicator_cols] = (",
+        "    df_diff.loc[short_mask, numeric_indicator_cols].mul(-1)",
+        ")"
       ],
       "metadata": {
         "id": "4TPpba7UChUY"


### PR DESCRIPTION
## Summary
- flip numeric indicator features to align short trades with long trades when `Open_Trade` is -1
- merge the `Open_Trade` column into the diff feature frame when it is missing so the adjustment can be applied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cac422a7d883288a3c3083bd0e2497