### PR TITLE
Save per-block feature dataframes for XAUUSD

### DIFF
--- a/7_XAUUSD_Long_Short_Features.ipynb
+++ b/7_XAUUSD_Long_Short_Features.ipynb
@@ -1,4148 +1,4296 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "bf83164c",
-      "metadata": {
-        "id": "bf83164c"
-      },
-      "source": [
-        "# Pendientes\n",
-        "\n",
-        "Nada"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Ysa-7eLvEMpE",
-      "metadata": {
-        "id": "Ysa-7eLvEMpE"
-      },
-      "source": [
-        "# Gpu"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9GJAW8qAEM8f",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9GJAW8qAEM8f",
-        "outputId": "5430e5b2-c26a-468f-8c59-a09545f7e189"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Mon Sep 22 17:36:34 2025       \n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
-            "|-----------------------------------------+------------------------+----------------------+\n",
-            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
-            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
-            "|                                         |                        |               MIG M. |\n",
-            "|=========================================+========================+======================|\n",
-            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
-            "| N/A   43C    P8             11W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
-            "|                                         |                        |                  N/A |\n",
-            "+-----------------------------------------+------------------------+----------------------+\n",
-            "                                                                                         \n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| Processes:                                                                              |\n",
-            "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
-            "|        ID   ID                                                               Usage      |\n",
-            "|=========================================================================================|\n",
-            "|  No running processes found                                                             |\n",
-            "+-----------------------------------------------------------------------------------------+\n"
-          ]
-        }
-      ],
-      "source": [
-        "!nvidia-smi"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "FcIdAmrNERw-",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "FcIdAmrNERw-",
-        "outputId": "4f0b0aae-99aa-4f36-ee7d-f2b4d43d7461"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
-            ]
-          },
-          "execution_count": 5,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import tensorflow as tf\n",
-        "tf.config.list_physical_devices('GPU')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "m8CIB8vltFfH",
-      "metadata": {
-        "id": "m8CIB8vltFfH"
-      },
-      "source": [
-        "# Set_Up"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "EB5RqjoAtFwl",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "EB5RqjoAtFwl",
-        "outputId": "34781d46-a966-4ed8-b8e8-a853290f305a"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "/content/drive/MyDrive/Course Folder/Forex/XAUUSD/\n"
-          ]
-        }
-      ],
-      "source": [
-        "\n",
-        "root_data = f'/content/drive/MyDrive/Course Folder/Forex/XAUUSD/'\n",
-        "print(root_data)\n",
-        "\n",
-        "direction = 'Short'\n",
-        "direction_number = -1\n",
-        "\n",
-        "symbol = 'XAUUSD'\n",
-        "strategy = 'Kalman'\n",
-        "time_frame = 'M5'\n",
-        "\n",
-        "trade_evolution = 'st_Max'\n",
-        "result_field = 'st_PnL'\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "y6QRdBKwrX98",
-      "metadata": {
-        "id": "y6QRdBKwrX98"
-      },
-      "source": [
-        "# Libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "R9bTNmBwK_Up",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "R9bTNmBwK_Up",
-        "outputId": "4257f600-81e5-42ac-e4a0-84a5cae26c09"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Collecting ta-lib\n",
-            "  Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (24 kB)\n",
-            "Requirement already satisfied: build in /usr/local/lib/python3.12/dist-packages (from ta-lib) (1.3.0)\n",
-            "Requirement already satisfied: cython in /usr/local/lib/python3.12/dist-packages (from ta-lib) (3.0.12)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.12/dist-packages (from ta-lib) (2.0.2)\n",
-            "Requirement already satisfied: packaging>=19.1 in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (25.0)\n",
-            "Requirement already satisfied: pyproject_hooks in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (1.2.0)\n",
-            "Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl (4.1 MB)\n",
-            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/4.1 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-            "\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m220.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m114.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hInstalling collected packages: ta-lib\n",
-            "Successfully installed ta-lib-0.6.7\n",
-            "0.6.7\n"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install ta-lib\n",
-        "import talib as ta\n",
-        "print(ta.__version__)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bda1a01c",
-      "metadata": {
-        "id": "bda1a01c"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import os\n",
-        "import joblib\n",
-        "import math\n",
-        "import time\n",
-        "\n",
-        "from itertools import combinations, product\n",
-        "\n",
-        "from tqdm.auto import tqdm\n",
-        "\n",
-        "from tensorflow.keras.models import Sequential\n",
-        "from tensorflow.keras.layers import Dense\n",
-        "\n",
-        "from sklearn.cluster import KMeans\n",
-        "from sklearn.preprocessing import StandardScaler\n",
-        "from sklearn.ensemble import RandomForestClassifier\n",
-        "from sklearn.feature_selection import RFECV\n",
-        "from sklearn.model_selection import StratifiedKFold\n",
-        "from sklearn.feature_selection import SelectFromModel\n",
-        "from sklearn.metrics import roc_auc_score, r2_score\n",
-        "from sklearn.model_selection import TimeSeriesSplit\n",
-        "from sklearn.linear_model import LogisticRegression\n",
-        "from sklearn.model_selection import cross_val_score\n",
-        "\n",
-        "from scipy.cluster.hierarchy import linkage, fcluster\n",
-        "from scipy.spatial.distance import squareform\n",
-        "\n",
-        "from xgboost import XGBClassifier, XGBRegressor\n",
-        "\n",
-        "import tensorflow as tf\n",
-        "\n",
-        "import sys\n",
-        "sys.path.append(\"..\")\n",
-        "\n",
-        "from __future__ import annotations\n",
-        "from typing import Tuple, List, Optional, Dict, Any\n",
-        "\n",
-        "from xgboost import XGBClassifier, XGBRegressor\n",
-        "from sklearn.metrics import (roc_auc_score, f1_score, accuracy_score, log_loss, r2_score)\n",
-        "\n",
-        "from sklearn.preprocessing import LabelEncoder\n",
-        "\n",
-        "import warnings\n",
-        "warnings.filterwarnings('ignore')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7JweuZy755ym",
-      "metadata": {
-        "id": "7JweuZy755ym"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "%matplotlib inline\n",
-        "plt.style.use(\"seaborn-v0_8-darkgrid\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "KFfn45ty82qv",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "KFfn45ty82qv",
-        "outputId": "b61f1ebd-525f-484d-8ebe-3b78a61caf7c"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Mounted at /content/drive\n"
-          ]
-        }
-      ],
-      "source": [
-        "from google.colab import drive\n",
-        "drive.mount('/content/drive')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9aa65d54",
-      "metadata": {
-        "id": "9aa65d54"
-      },
-      "source": [
-        "# Calculate_Features\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "I23127P7lBq_",
-      "metadata": {
-        "id": "I23127P7lBq_"
-      },
-      "source": [
-        "## Features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "kp4yJdGAjoeA",
-      "metadata": {
-        "id": "kp4yJdGAjoeA"
-      },
-      "outputs": [],
-      "source": [
-        "def kalman_line(source, kalman_length: int, smooth: int):\n",
-        "    \"\"\"\n",
-        "    Pine -> Python (solo 'kalman_line'), replicando la EMA de TradingView con\n",
-        "    *semilla SMA* (como ta.ema) sobre el núcleo Kalman kf_c.\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    source : pd.Series o array-like de floats (precio crudo, sin diff/returns)\n",
-        "    kalman_length : int   (equivale a length_kal en Pine)\n",
-        "    smooth : int          (equivale a smooth_kal en Pine -> ta.ema(kf_c, smooth))\n",
-        "\n",
-        "    Retorna\n",
-        "    -------\n",
-        "    Mismo tipo que `source`: pd.Series o np.ndarray con la línea Kalman suavizada.\n",
-        "    \"\"\"\n",
-        "    import numpy as np\n",
-        "    import pandas as pd\n",
-        "\n",
-        "    # normalizamos tipos\n",
-        "    is_series = hasattr(source, \"index\")\n",
-        "    idx = source.index if is_series else None\n",
-        "    x = np.asarray(source, dtype=np.float64)\n",
-        "    n = x.shape[0]\n",
-        "    if n == 0:\n",
-        "        return source\n",
-        "\n",
-        "    # ---------- núcleo Kalman idéntico al Pine ----------\n",
-        "    sqrt_term   = np.sqrt((kalman_length / 10000.0) * 2.0)\n",
-        "    length_term = kalman_length / 10000.0\n",
-        "\n",
-        "    kf_c   = np.empty(n, dtype=np.float64)\n",
-        "    velo_c = np.empty(n, dtype=np.float64)\n",
-        "\n",
-        "    # bar 0 (nz(kf_c[1], source) y nz(velo_c[1], 0))\n",
-        "    kf_c[0] = x[0]\n",
-        "    velo_c[0] = 0.0\n",
-        "\n",
-        "    for i in range(1, n):\n",
-        "        prev_kf = kf_c[i - 1]\n",
-        "        dk_c = x[i] - prev_kf\n",
-        "        smooth_c = prev_kf + dk_c * sqrt_term\n",
-        "        velo_c[i] = velo_c[i - 1] + length_term * dk_c\n",
-        "        kf_c[i] = smooth_c + velo_c[i]\n",
-        "\n",
-        "    # ---------- EMA con semilla SMA (comportamiento ta.ema de TV) ----------\n",
-        "    L = int(max(1, smooth))\n",
-        "    alpha = 2.0 / (L + 1.0)\n",
-        "    ema = np.full(n, np.nan, dtype=np.float64)\n",
-        "\n",
-        "    if n < L:\n",
-        "        # con pocas barras, igualamos al promedio simple disponible\n",
-        "        ema[-1] = np.nanmean(kf_c)\n",
-        "    else:\n",
-        "        # seed = SMA de las primeras L barras\n",
-        "        seed = np.mean(kf_c[:L])\n",
-        "        ema[L - 1] = seed\n",
-        "        for i in range(L, n):\n",
-        "            ema[i] = alpha * kf_c[i] + (1.0 - alpha) * ema[i - 1]\n",
-        "\n",
-        "    return (pd.Series(ema, index=idx) if is_series else ema)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ezwn8qPwfVtI",
-      "metadata": {
-        "id": "ezwn8qPwfVtI"
-      },
-      "outputs": [],
-      "source": [
-        "def add_ema_feature_block(\n",
-        "    stock_data: pd.DataFrame,\n",
-        "    features: pd.DataFrame,\n",
-        "    ema_lengths: Tuple[int, ...] = (15, 21, 50, 100, 200)\n",
-        ") -> List[str]:\n",
-        "    \"\"\"Generate EMA-based features for the provided lengths.\n",
-        "\n",
-        "    Parameters\n",
-        "    ----------\n",
-        "    stock_data : pd.DataFrame\n",
-        "        Source OHLCV data that must contain a 'Close' column.\n",
-        "    features : pd.DataFrame\n",
-        "        Feature matrix to which the EMA features will be added.\n",
-        "    ema_lengths : Tuple[int, ...], optional\n",
-        "        Window sizes for the EMAs, by default (15, 21, 50, 100, 200).\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    List[str]\n",
-        "        List of the EMA column names added to the feature matrix.\n",
-        "    \"\"\"\n",
-        "    close_prices = stock_data['Close']\n",
-        "    ema_columns: List[str] = []\n",
-        "\n",
-        "    for length in ema_lengths:\n",
-        "        ema_col = f'EMA_{length}'\n",
-        "        ema_series = ta.EMA(close_prices, timeperiod=length)\n",
-        "\n",
-        "        features[ema_col] = ema_series\n",
-        "        features[f'{ema_col}_diff'] = ema_series.diff()\n",
-        "        features[f'Close_minus_{ema_col}'] = close_prices - ema_series\n",
-        "\n",
-        "        ema_columns.append(ema_col)\n",
-        "\n",
-        "    for col_a, col_b in combinations(ema_columns, 2):\n",
-        "        boolean_col = f'{col_a}_above_{col_b}'\n",
-        "        features[boolean_col] = (features[col_a] > features[col_b]).astype(int)\n",
-        "\n",
-        "    return ema_columns\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "HahbLzEkjoeB",
-      "metadata": {
-        "id": "HahbLzEkjoeB"
-      },
-      "outputs": [],
-      "source": [
-        "def slope(src: pd.Series,\n",
-        "          length_kal: int,\n",
-        "          smooth_kal: int,\n",
-        "          slopeLen: int,\n",
-        "          offset: int) -> pd.DataFrame:\n",
-        "\n",
-        "    n = len(src)\n",
-        "    kf_state = np.full(n, np.nan)\n",
-        "    kf_velo  = np.zeros(n)\n",
-        "    sqrt_factor = np.sqrt(length_kal / 10000.0 * 2.0)\n",
-        "    vel_factor  = length_kal / 10000.0\n",
-        "\n",
-        "    for i in range(n):\n",
-        "        if i == 0:\n",
-        "            prev_state = src.iloc[0]\n",
-        "            prev_velo  = 0.0\n",
-        "        else:\n",
-        "            prev_state = kf_state[i-1] if not np.isnan(kf_state[i-1]) else src.iloc[i]\n",
-        "            prev_velo  = kf_velo[i-1]\n",
-        "\n",
-        "        dk = src.iloc[i] - prev_state\n",
-        "        smooth = prev_state + dk * sqrt_factor\n",
-        "        kf_velo[i]  = prev_velo + vel_factor * dk\n",
-        "        kf_state[i] = smooth + kf_velo[i]\n",
-        "\n",
-        "    # 2) EMA smoothing --------------------------------------------------\n",
-        "    kal = pd.Series(kf_state, index=src.index).ewm(span=smooth_kal, adjust=False).mean()\n",
-        "\n",
-        "    # 3) Slope/divergence -----------------------------------------------\n",
-        "    validLen = max(slopeLen, 1)\n",
-        "    slope_div = kal.diff(validLen) / validLen\n",
-        "    slope_signal = (slope_div > slope_div.shift(1)).astype(int)\n",
-        "\n",
-        "    # 4) Angle in degrees -----------------------------------------------\n",
-        "    price_change = kal - kal.shift(validLen)\n",
-        "    slope_angle = np.degrees(np.arctan(price_change))\n",
-        "    slope_angle_signal = (slope_angle > slope_angle.shift(1)).astype(int)\n",
-        "\n",
-        "    # 5) Linear regression prediction ----------------------------------\n",
-        "    def _linreg(y):\n",
-        "        x = np.arange(len(y))\n",
-        "        m, b = np.polyfit(x, y, 1)\n",
-        "        return b + m * (len(y)-1)\n",
-        "\n",
-        "    slope_lin_reg = kal.rolling(window=slopeLen).apply(_linreg, raw=False)\n",
-        "    slope_lin_reg = slope_lin_reg.shift(-offset)  # apply Pine-style offset\n",
-        "    slope_lin_reg_signal = (slope_lin_reg > slope_lin_reg.shift(1)).astype(int)\n",
-        "\n",
-        "    # 6) Pack results ---------------------------------------------------\n",
-        "    return pd.DataFrame({\n",
-        "        'slope_div':            slope_div,\n",
-        "        'slope_signal':         slope_signal,\n",
-        "        'slope_angle':          slope_angle,\n",
-        "        'slope_angle_signal':   slope_angle_signal,\n",
-        "        'slope_lin_reg':        slope_lin_reg,\n",
-        "        'slope_lin_reg_signal': slope_lin_reg_signal\n",
-        "    })"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "OdtkSGMfbJno"
-      },
-      "outputs": [],
-      "source": [
-        "\n",
-        "def volume_indicators(\n",
-        "    stock_data: pd.DataFrame,\n",
-        "    cmf_period: int = 20,\n",
-        "    tmf_period: int = 21,\n",
-        "    mfi_period: int = 14,\n",
-        "    ko_fast: int = 34,\n",
-        "    ko_slow: int = 55,\n",
-        "    efi_period: int = 13,\n",
-        "    eom_period: int = 14,\n",
-        "    vfi_period: int = 130,\n",
-        "    vfi_coef: float = 0.2\n",
-        ") -> pd.DataFrame:\n",
-        "    \"\"\"Compute a selection of volume-based indicators.\n",
-        "\n",
-        "    Parameters\n",
-        "    ----------\n",
-        "    stock_data : pd.DataFrame\n",
-        "        DataFrame with at least 'Open', 'High', 'Low', 'Close' and 'Volume' columns.\n",
-        "    cmf_period : int, default 20\n",
-        "        Lookback period for Chaikin Money Flow.\n",
-        "    tmf_period : int, default 21\n",
-        "        Lookback period for Twiggs Money Flow exponential averages.\n",
-        "    mfi_period : int, default 14\n",
-        "        Lookback period for Money Flow Index (TA-Lib implementation).\n",
-        "    ko_fast : int, default 34\n",
-        "        Fast EMA length for the Klinger Oscillator volume force.\n",
-        "    ko_slow : int, default 55\n",
-        "        Slow EMA length for the Klinger Oscillator volume force.\n",
-        "    efi_period : int, default 13\n",
-        "        Exponential smoothing period for Elder Force Index.\n",
-        "    eom_period : int, default 14\n",
-        "        Rolling mean period for Ease of Movement.\n",
-        "    vfi_period : int, default 130\n",
-        "        Rolling window for Volume Flow Indicator calculations.\n",
-        "    vfi_coef : float, default 0.2\n",
-        "        Cutoff coefficient used in the Volume Flow Indicator.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    pd.DataFrame\n",
-        "        DataFrame containing the indicators and their first differences.\n",
-        "    \"\"\"\n",
-        "    required_columns = {\"Open\", \"High\", \"Low\", \"Close\", \"Volume\"}\n",
-        "    missing = required_columns.difference(stock_data.columns)\n",
-        "    if missing:\n",
-        "        raise ValueError(f\"stock_data must contain columns: {sorted(required_columns)}. Missing: {sorted(missing)}\")\n",
-        "\n",
-        "    features = pd.DataFrame(index=stock_data.index)\n",
-        "\n",
-        "    high = stock_data['High'].astype(float)\n",
-        "    low = stock_data['Low'].astype(float)\n",
-        "    close = stock_data['Close'].astype(float)\n",
-        "    volume = stock_data['Volume'].astype(float)\n",
-        "    typical_price = (high + low + close) / 3.0\n",
-        "\n",
-        "    def _add_with_diff(name: str, series: pd.Series) -> None:\n",
-        "        features[name] = series\n",
-        "        features[f\"{name}_diff\"] = series.diff()\n",
-        "\n",
-        "    # Chaikin Money Flow (CMF)\n",
-        "    hl_range = (high - low).replace(0, np.nan)\n",
-        "    mf_multiplier = ((close - low) - (high - close))\n",
-        "    mf_volume = (mf_multiplier / hl_range).fillna(0.0) * volume\n",
-        "    cmf = mf_volume.rolling(window=cmf_period, min_periods=1).sum() / volume.rolling(window=cmf_period, min_periods=1).sum()\n",
-        "    _add_with_diff('CMF', cmf)\n",
-        "\n",
-        "    # Twiggs Money Flow (TMF)\n",
-        "    tmf_raw = (mf_multiplier / hl_range).fillna(0.0) * volume\n",
-        "    tmf = tmf_raw.ewm(span=tmf_period, adjust=False, min_periods=1).mean() / volume.ewm(span=tmf_period, adjust=False, min_periods=1).mean()\n",
-        "    _add_with_diff('TMF', tmf)\n",
-        "\n",
-        "    # Money Flow Index (MFI)\n",
-        "    mfi = ta.MFI(high, low, close, volume, timeperiod=mfi_period)\n",
-        "    _add_with_diff(f'MFI_{mfi_period}_volume', mfi)\n",
-        "\n",
-        "    # Klinger Oscillator (KO)\n",
-        "    tp_diff = typical_price.diff()\n",
-        "    trend = tp_diff.apply(lambda x: 1 if x > 0 else (-1 if x < 0 else np.nan)).ffill().fillna(1.0)\n",
-        "    vf = trend * volume * (2 * tp_diff.abs() / hl_range).fillna(0.0)\n",
-        "    ko = vf.ewm(span=ko_fast, adjust=False, min_periods=1).mean() - vf.ewm(span=ko_slow, adjust=False, min_periods=1).mean()\n",
-        "    _add_with_diff('KO', ko)\n",
-        "\n",
-        "    # Elder Force Index (EFI)\n",
-        "    efi_raw = close.diff() * volume\n",
-        "    efi = efi_raw.ewm(span=efi_period, adjust=False, min_periods=1).mean()\n",
-        "    _add_with_diff('EFI', efi)\n",
-        "\n",
-        "    # Ease of Movement (EOM)\n",
-        "    prior_mid = ((high.shift(1) + low.shift(1)) / 2.0)\n",
-        "    mid_move = ((high + low) / 2.0) - prior_mid\n",
-        "    eom = (mid_move * (high - low)) / volume.replace(0, np.nan)\n",
-        "    eom = eom.rolling(window=eom_period, min_periods=1).mean()\n",
-        "    _add_with_diff('EOM', eom)\n",
-        "\n",
-        "    # Volume Price Trend (VPT)\n",
-        "    vpt = ((close - close.shift(1)) / close.shift(1).replace(0, np.nan) * volume).fillna(0.0).cumsum()\n",
-        "    _add_with_diff('VPT', vpt)\n",
-        "\n",
-        "    # Negative Volume Index (NVI)\n",
-        "    nvi = volume.copy().astype(float)\n",
-        "    if not nvi.empty:\n",
-        "        nvi.iloc[0] = 1000.0\n",
-        "        for i in range(1, len(nvi)):\n",
-        "            prev = nvi.iloc[i-1]\n",
-        "            if volume.iloc[i] < volume.iloc[i-1]:\n",
-        "                change = (close.iloc[i] - close.iloc[i-1]) / close.iloc[i-1] if close.iloc[i-1] != 0 else 0.0\n",
-        "                nvi.iloc[i] = prev + prev * change\n",
-        "            else:\n",
-        "                nvi.iloc[i] = prev\n",
-        "    _add_with_diff('NVI', nvi)\n",
-        "\n",
-        "    # Positive Volume Index (PVI)\n",
-        "    pvi = volume.copy().astype(float)\n",
-        "    if not pvi.empty:\n",
-        "        pvi.iloc[0] = 1000.0\n",
-        "        for i in range(1, len(pvi)):\n",
-        "            prev = pvi.iloc[i-1]\n",
-        "            if volume.iloc[i] > volume.iloc[i-1]:\n",
-        "                change = (close.iloc[i] - close.iloc[i-1]) / close.iloc[i-1] if close.iloc[i-1] != 0 else 0.0\n",
-        "                pvi.iloc[i] = prev + prev * change\n",
-        "            else:\n",
-        "                pvi.iloc[i] = prev\n",
-        "    _add_with_diff('PVI', pvi)\n",
-        "\n",
-        "    # Volume Flow Indicator (VFI)\n",
-        "    log_tp = np.log(typical_price.replace(0, np.nan) / typical_price.shift(1).replace(0, np.nan)).replace([np.inf, -np.inf], np.nan).fillna(0.0)\n",
-        "    cutoff = log_tp.rolling(window=vfi_period, min_periods=1).std(ddof=0) * vfi_coef\n",
-        "    avg_volume = volume.rolling(window=vfi_period, min_periods=1).mean()\n",
-        "    vf_select = np.where(log_tp > cutoff, volume, np.where(log_tp < -cutoff, -volume, 0.0))\n",
-        "    vfi = pd.Series(vf_select, index=stock_data.index).rolling(window=vfi_period, min_periods=1).sum() / avg_volume.replace(0, np.nan)\n",
-        "    _add_with_diff('VFI', vfi)\n",
-        "\n",
-        "    # Volume-Weighted Average Price (VWAP)\n",
-        "    cum_volume = volume.cumsum()\n",
-        "    vwap = (typical_price * volume).cumsum() / cum_volume.replace(0, np.nan)\n",
-        "    _add_with_diff('VWAP', vwap)\n",
-        "\n",
-        "    # Market Facilitation Index (Bill Williams)\n",
-        "    market_fi = (high - low) / volume.replace(0, np.nan)\n",
-        "    _add_with_diff('Market_Facilitation_Index', market_fi)\n",
-        "\n",
-        "    # Accumulation/Distribution Line (A/D)\n",
-        "    clv = ((close - low) - (high - close)) / hl_range\n",
-        "    ad_line = (clv.fillna(0.0) * volume).cumsum()\n",
-        "    _add_with_diff('AD_Line', ad_line)\n",
-        "\n",
-        "    # Williams Accumulation/Distribution (WAD)\n",
-        "    prev_close = close.shift(1).fillna(close.iloc[0])\n",
-        "    true_high = pd.concat([high, prev_close], axis=1).max(axis=1)\n",
-        "    true_low = pd.concat([low, prev_close], axis=1).min(axis=1)\n",
-        "    wad_raw = np.where(\n",
-        "        close > prev_close,\n",
-        "        close - true_low,\n",
-        "        np.where(close < prev_close, close - true_high, 0.0)\n",
-        "    )\n",
-        "    wad = pd.Series(wad_raw, index=stock_data.index).cumsum()\n",
-        "    _add_with_diff('WAD', wad)\n",
-        "\n",
-        "    return features\n",
-        "\n"
-      ],
-      "id": "OdtkSGMfbJno"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "basicIndicators",
-      "metadata": {
-        "id": "basicIndicators"
-      },
-      "outputs": [],
-      "source": [
-        "def basic_indicators(\n",
-        "    stock_data: pd.DataFrame,\n",
-        "    macd_fast: int = 12,\n",
-        "    macd_slow: int = 26,\n",
-        "    macd_signal: int = 9,\n",
-        "    rsi_period: int = 14,\n",
-        "    bb_period: int = 20,\n",
-        "    bb_std: float = 2.0,\n",
-        "    atr_period: int = 14,\n",
-        "    momentum_period: int = 10,\n",
-        "    roc_period: int = 10,\n",
-        "    stoch_k_period: int = 14,\n",
-        "    stoch_d_period: int = 3,\n",
-        "    stoch_slow_period: int = 3,\n",
-        "    cci_period: int = 20,\n",
-        "    mfi_period: int = 14,\n",
-        "    adx_period: int = 14,\n",
-        "    williams_period: int = 14,\n",
-        ") -> pd.DataFrame:\n",
-        "    \"\"\"Compute a set of core price-based indicators and their differences.\"\"\"\n",
-        "    required_columns = {\"Open\", \"High\", \"Low\", \"Close\", \"Volume\"}\n",
-        "    missing = required_columns.difference(stock_data.columns)\n",
-        "    if missing:\n",
-        "        raise ValueError(\n",
-        "            \"stock_data must contain columns: {cols}. Missing: {missing}\".format(\n",
-        "                cols=sorted(required_columns), missing=sorted(missing)\n",
-        "            )\n",
-        "        )\n",
-        "\n",
-        "    features = pd.DataFrame(index=stock_data.index)\n",
-        "\n",
-        "    high = stock_data[\"High\"].astype(float)\n",
-        "    low = stock_data[\"Low\"].astype(float)\n",
-        "    close = stock_data[\"Close\"].astype(float)\n",
-        "    volume = stock_data[\"Volume\"].astype(float)\n",
-        "    typical_price = (high + low + close) / 3.0\n",
-        "\n",
-        "    def _add_with_diff(name: str, series: pd.Series) -> None:\n",
-        "        series = pd.Series(series, index=stock_data.index)\n",
-        "        features[name] = series\n",
-        "        features[f\"{name}_diff\"] = series.diff()\n",
-        "\n",
-        "    macd, macd_signal_series, macd_hist = ta.MACD(\n",
-        "        close,\n",
-        "        fastperiod=macd_fast,\n",
-        "        slowperiod=macd_slow,\n",
-        "        signalperiod=macd_signal,\n",
-        "    )\n",
-        "    _add_with_diff(f\"MACD_{macd_fast}_{macd_slow}_{macd_signal}\", macd)\n",
-        "    _add_with_diff(\n",
-        "        f\"MACD_signal_{macd_fast}_{macd_slow}_{macd_signal}\", macd_signal_series\n",
-        "    )\n",
-        "    _add_with_diff(f\"MACD_hist_{macd_fast}_{macd_slow}_{macd_signal}\", macd_hist)\n",
-        "\n",
-        "    rsi = ta.RSI(close, timeperiod=rsi_period)\n",
-        "    _add_with_diff(f\"RSI_basic_{rsi_period}\", rsi)\n",
-        "\n",
-        "    upper, middle, lower = ta.BBANDS(\n",
-        "        close,\n",
-        "        timeperiod=bb_period,\n",
-        "        nbdevup=bb_std,\n",
-        "        nbdevdn=bb_std,\n",
-        "        matype=0,\n",
-        "    )\n",
-        "    _add_with_diff(f\"BB_upper_{bb_period}\", upper)\n",
-        "    _add_with_diff(f\"BB_middle_{bb_period}\", middle)\n",
-        "    _add_with_diff(f\"BB_lower_{bb_period}\", lower)\n",
-        "\n",
-        "    atr = ta.ATR(high, low, close, timeperiod=atr_period)\n",
-        "    _add_with_diff(f\"ATR_{atr_period}\", atr)\n",
-        "\n",
-        "    obv = ta.OBV(close, volume)\n",
-        "    _add_with_diff(\"OBV_basic\", obv)\n",
-        "\n",
-        "    cum_volume = volume.cumsum()\n",
-        "    vwap = (typical_price * volume).cumsum() / cum_volume.replace(0, np.nan)\n",
-        "    _add_with_diff(\"VWAP_basic\", vwap)\n",
-        "\n",
-        "    momentum = ta.MOM(close, timeperiod=momentum_period)\n",
-        "    _add_with_diff(f\"Momentum_{momentum_period}\", momentum)\n",
-        "\n",
-        "    roc = ta.ROC(close, timeperiod=roc_period)\n",
-        "    _add_with_diff(f\"ROC_{roc_period}\", roc)\n",
-        "\n",
-        "    stoch_k, stoch_d = ta.STOCH(\n",
-        "        high,\n",
-        "        low,\n",
-        "        close,\n",
-        "        fastk_period=stoch_k_period,\n",
-        "        slowk_period=stoch_d_period,\n",
-        "        slowk_matype=0,\n",
-        "        slowd_period=stoch_slow_period,\n",
-        "        slowd_matype=0,\n",
-        "    )\n",
-        "    _add_with_diff(\n",
-        "        f\"Stoch_K_{stoch_k_period}_{stoch_d_period}_{stoch_slow_period}\", stoch_k\n",
-        "    )\n",
-        "    _add_with_diff(\n",
-        "        f\"Stoch_D_{stoch_k_period}_{stoch_d_period}_{stoch_slow_period}\", stoch_d\n",
-        "    )\n",
-        "\n",
-        "    cci = ta.CCI(high, low, close, timeperiod=cci_period)\n",
-        "    _add_with_diff(f\"CCI_{cci_period}\", cci)\n",
-        "\n",
-        "    mfi = ta.MFI(high, low, close, volume, timeperiod=mfi_period)\n",
-        "    _add_with_diff(f\"MFI_basic_{mfi_period}\", mfi)\n",
-        "\n",
-        "    adx = ta.ADX(high, low, close, timeperiod=adx_period)\n",
-        "    _add_with_diff(f\"ADX_{adx_period}\", adx)\n",
-        "\n",
-        "    williams_r = ta.WILLR(high, low, close, timeperiod=williams_period)\n",
-        "    _add_with_diff(f\"WilliamsR_{williams_period}\", williams_r)\n",
-        "\n",
-        "    return features\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ZnVB7nObuG_e",
-      "metadata": {
-        "id": "ZnVB7nObuG_e"
-      },
-      "outputs": [],
-      "source": [
-        "def create_features(stock_data: pd.DataFrame) -> pd.DataFrame:\n",
-        "\n",
-        "    periods        = [3, 7, 14]\n",
-        "    ema_lengths    = (15, 21, 50, 100, 200)\n",
-        "    kalman_periods = [300, 600, 900]\n",
-        "    slope_length   = [3, 6, 9]\n",
-        "\n",
-        "    features = pd.DataFrame(index=stock_data.index)\n",
-        "\n",
-        "    basic_features = basic_indicators(stock_data)\n",
-        "    features = features.join(basic_features)\n",
-        "\n",
-        "    volume_features = volume_indicators(stock_data)\n",
-        "    features = features.join(volume_features)\n",
-        "\n",
-        "    add_ema_feature_block(stock_data, features, ema_lengths)\n",
-        "\n",
-        "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
-        "        \"\"\"Return ordered unique column pairs without self-pairings.\"\"\"\n",
-        "        unique_columns = list(dict.fromkeys(columns))\n",
-        "        return list(combinations(unique_columns, 2))\n",
-        "\n",
-        "    # ───────────────────────── Indicadores por período ─────────────────────────\n",
-        "    t0 = time.time()\n",
-        "    indicator_columns = {'RSI': [], 'MFI': [], 'OBV': []}\n",
-        "\n",
-        "    # >>> Cambio: OBV sin períodos (una sola serie)\n",
-        "    obv_col = 'OBV'\n",
-        "    features[obv_col] = ta.OBV(stock_data['Close'], stock_data['Volume'])\n",
-        "    indicator_columns['OBV'].append(obv_col)\n",
-        "\n",
-        "    for period in tqdm(periods, desc=\"Indicators (RSI/MFI/OBV)\"):\n",
-        "        rsi_col = f'RSI_{period}'\n",
-        "        features[rsi_col] = ta.RSI(stock_data['Close'], timeperiod=period)\n",
-        "        indicator_columns['RSI'].append(rsi_col)\n",
-        "\n",
-        "        mfi_col = f'MFI_{period}'\n",
-        "        features[mfi_col] = ta.MFI(\n",
-        "            stock_data['High'], stock_data['Low'], stock_data['Close'],\n",
-        "            stock_data['Volume'], timeperiod=period\n",
-        "        )\n",
-        "        indicator_columns['MFI'].append(mfi_col)\n",
-        "\n",
-        "    # diffs y combinaciones dentro de cada familia\n",
-        "    for indicator, cols in indicator_columns.items():\n",
-        "        for col in tqdm(cols, desc=f\"{indicator}: diffs\", leave=False):\n",
-        "            features[f'{col}_diff'] = features[col].diff()\n",
-        "        pairs = _unique_pairwise(cols)  # para OBV (1 col) no habrá pares\n",
-        "        for col1, col2 in tqdm(pairs, desc=f\"{indicator}: pairwise\", leave=False):\n",
-        "            features[f'{col1} - {col2}'] = features[col1] - features[col2]\n",
-        "    tqdm.write(f\"[Timing] Indicators block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    # ───────────────────────── Kalman y derivados ───────────────────────\n",
-        "    t0 = time.time()\n",
-        "    kal_cols = []\n",
-        "    for period in tqdm(kalman_periods, desc=\"Kalman & Derivatives\"):\n",
-        "        kal = pd.Series(\n",
-        "            kalman_line(stock_data['Close'], kalman_length=period, smooth=3),\n",
-        "            index=stock_data.index\n",
-        "        )\n",
-        "        kname = f'Kal_{period}'\n",
-        "        kal_cols.append(kname)\n",
-        "\n",
-        "        features[kname]                           = kal\n",
-        "        features[f'Close_Kal_{period}']           = stock_data['Close'] - kal\n",
-        "        features[f'Kal_change_{period}']          = kal.diff(1)\n",
-        "        features[f'Kal_prev_minus_now_{period}']  = kal.shift(1) - kal\n",
-        "        features[f'Kal_prev2_minus_now_{period}'] = kal.shift(2) - kal\n",
-        "        features[f'Kal_change2_{period}']         = kal.diff(2)\n",
-        "\n",
-        "    kal_pairs = _unique_pairwise(kal_cols)\n",
-        "    for c1, c2 in tqdm(kal_pairs, desc=\"Kalman pairwise\"):\n",
-        "        features[f'{c1}_minus_{c2}'] = features[c1] - features[c2]\n",
-        "    tqdm.write(f\"[Timing] Kalman block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    # ───────────────────────── Slopes ───────────────────────────────────\n",
-        "    t0 = time.time()\n",
-        "    slope_indicator_columns = {\n",
-        "        'slope_div': [],\n",
-        "        'slope_signal': [],\n",
-        "        'slope_angle': [],\n",
-        "        'slope_angle_signal': [],\n",
-        "        'slope_lin_reg': [],\n",
-        "        'slope_lin_reg_signal': []\n",
-        "    }\n",
-        "\n",
-        "    slope_jobs = list(product(kalman_periods, slope_length))\n",
-        "    for period, sLen in tqdm(slope_jobs, desc=\"Slopes (kal_len × slope_len)\"):\n",
-        "        df_s = slope(stock_data['Close'], length_kal=period, smooth_kal=3,\n",
-        "                     slopeLen=sLen, offset=-1)\n",
-        "\n",
-        "        column_mapping = {\n",
-        "            'slope_div':            f'slope_div_{period}_{sLen}',\n",
-        "            'slope_signal':         f'slope_signal_{period}_{sLen}',\n",
-        "            'slope_angle':          f'slope_angle_{period}_{sLen}',\n",
-        "            'slope_angle_signal':   f'slope_angle_signal_{period}_{sLen}',\n",
-        "            'slope_lin_reg':        f'slope_lin_reg_{period}_{sLen}',\n",
-        "            'slope_lin_reg_signal': f'slope_lin_reg_signal_{period}_{sLen}'\n",
-        "        }\n",
-        "\n",
-        "        for indicator, col_name in column_mapping.items():\n",
-        "            series = df_s[indicator]\n",
-        "            features[col_name] = series\n",
-        "            features[f'{col_name}_diff'] = series.diff()\n",
-        "            slope_indicator_columns[indicator].append(col_name)\n",
-        "\n",
-        "    for indicator, cols in slope_indicator_columns.items():\n",
-        "        pairs = _unique_pairwise(cols)\n",
-        "        for c1, c2 in tqdm(pairs, desc=f\"{indicator}: pairwise\", leave=False):\n",
-        "            features[f'{c1} - {c2}'] = features[c1] - features[c2]\n",
-        "    tqdm.write(f\"[Timing] Slopes block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    return features\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "DoqqPJxPxnBF",
-      "metadata": {
-        "id": "DoqqPJxPxnBF"
-      },
-      "source": [
-        "## 5_min"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d7l7vt7QxvyC",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 324
-        },
-        "id": "d7l7vt7QxvyC",
-        "outputId": "675583b8-def4-4cf5-dfb4-8933ef498d7a"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Min_Date :  2019-01-02 01:00:00\n",
-            "Min_Date :  2025-07-25 23:55:00\n",
-            "Number_Rows =  465718\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "summary": "{\n  \"name\": \"df_5min\",\n  \"rows\": 5,\n  \"fields\": [\n    {\n      \"column\": \"Date\",\n      \"properties\": {\n        \"dtype\": \"date\",\n        \"min\": \"2025-07-25 23:35:00\",\n        \"max\": \"2025-07-25 23:55:00\",\n        \"num_unique_values\": 5,\n        \"samples\": [\n          \"2025-07-25 23:40:00\",\n          \"2025-07-25 23:55:00\",\n          \"2025-07-25 23:45:00\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Open\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1397894542414626,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.81,\n          3336.52,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"High\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.132263220280441,\n        \"min\": 3336.86,\n        \"max\": 3339.14,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.92,\n          3336.88,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Low\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.8069696400732905,\n        \"min\": 3336.12,\n        \"max\": 3338.04,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3337.56,\n          3336.44,\n          3336.64\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Close\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1374313166077035,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.69,\n          3336.8,\n          3336.73\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Volume\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 50,\n        \"min\": 82,\n        \"max\": 197,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          194,\n          82,\n          195\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Spread\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 5,\n        \"max\": 40,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          40,\n          5\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
-              "type": "dataframe"
-            },
-            "text/html": [
-              "\n",
-              "  <div id=\"df-f91857c6-e71e-49bc-ad66-384ac450c270\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Open</th>\n",
-              "      <th>High</th>\n",
-              "      <th>Low</th>\n",
-              "      <th>Close</th>\n",
-              "      <th>Volume</th>\n",
-              "      <th>Spread</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Date</th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:35:00</th>\n",
-              "      <td>3338.59</td>\n",
-              "      <td>3339.14</td>\n",
-              "      <td>3338.04</td>\n",
-              "      <td>3338.81</td>\n",
-              "      <td>197</td>\n",
-              "      <td>5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:40:00</th>\n",
-              "      <td>3338.81</td>\n",
-              "      <td>3338.92</td>\n",
-              "      <td>3337.56</td>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>194</td>\n",
-              "      <td>5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:45:00</th>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>3336.64</td>\n",
-              "      <td>3336.73</td>\n",
-              "      <td>195</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:50:00</th>\n",
-              "      <td>3336.73</td>\n",
-              "      <td>3336.86</td>\n",
-              "      <td>3336.12</td>\n",
-              "      <td>3336.52</td>\n",
-              "      <td>192</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:55:00</th>\n",
-              "      <td>3336.52</td>\n",
-              "      <td>3336.88</td>\n",
-              "      <td>3336.44</td>\n",
-              "      <td>3336.80</td>\n",
-              "      <td>82</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-f91857c6-e71e-49bc-ad66-384ac450c270')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-f91857c6-e71e-49bc-ad66-384ac450c270 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-f91857c6-e71e-49bc-ad66-384ac450c270');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "    <div id=\"df-936ec14c-235e-46de-be52-d72f909f6e77\">\n",
-              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-936ec14c-235e-46de-be52-d72f909f6e77')\"\n",
-              "                title=\"Suggest charts\"\n",
-              "                style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "      </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "      <script>\n",
-              "        async function quickchart(key) {\n",
-              "          const quickchartButtonEl =\n",
-              "            document.querySelector('#' + key + ' button');\n",
-              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "          try {\n",
-              "            const charts = await google.colab.kernel.invokeFunction(\n",
-              "                'suggestCharts', [key], {});\n",
-              "          } catch (error) {\n",
-              "            console.error('Error during call to suggestCharts:', error);\n",
-              "          }\n",
-              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "        }\n",
-              "        (() => {\n",
-              "          let quickchartButtonEl =\n",
-              "            document.querySelector('#df-936ec14c-235e-46de-be52-d72f909f6e77 button');\n",
-              "          quickchartButtonEl.style.display =\n",
-              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "        })();\n",
-              "      </script>\n",
-              "    </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "text/plain": [
-              "                        Open     High      Low    Close  Volume  Spread\n",
-              "Date                                                                   \n",
-              "2025-07-25 23:35:00  3338.59  3339.14  3338.04  3338.81     197       5\n",
-              "2025-07-25 23:40:00  3338.81  3338.92  3337.56  3338.69     194       5\n",
-              "2025-07-25 23:45:00  3338.69  3338.69  3336.64  3336.73     195      40\n",
-              "2025-07-25 23:50:00  3336.73  3336.86  3336.12  3336.52     192      40\n",
-              "2025-07-25 23:55:00  3336.52  3336.88  3336.44  3336.80      82      40"
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Read the CSV file\n",
-        "df_5min = pd.read_csv(root_data + 'Data/'+symbol+'_M5.csv', index_col=0)\n",
-        "df_5min.index = pd.to_datetime(df_5min.index)\n",
-        "#df_5min = df_5min.iloc[-1000000:,]\n",
-        "\n",
-        "print('Min_Date : ', df_5min.index.min())\n",
-        "print('Min_Date : ', df_5min.index.max())\n",
-        "print('Number_Rows = ',len(df_5min.index))\n",
-        "print('\\n')\n",
-        "\n",
-        "df_5min.tail()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "HBicVZcDx2CF",
-      "metadata": {
-        "id": "HBicVZcDx2CF"
-      },
-      "source": [
-        "**Features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "XxU4wllsEUcN",
-      "metadata": {
-        "id": "XxU4wllsEUcN"
-      },
-      "outputs": [],
-      "source": [
-        "start_time = time.time()\n",
-        "\n",
-        "features = create_features(df_5min)\n",
-        "features = features.dropna()\n",
-        "\n",
-        "end_time = time.time()\n",
-        "execution_time = end_time - start_time\n",
-        "\n",
-        "print(\"Number of features are:\", features.shape[1])\n",
-        "print(features.shape)\n",
-        "features.to_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
-        "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
-        "features.tail(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7Vw_2C-ZEO57",
-      "metadata": {
-        "id": "7Vw_2C-ZEO57"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(features.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "j4AwNJic6icv",
-      "metadata": {
-        "id": "j4AwNJic6icv"
-      },
-      "outputs": [],
-      "source": [
-        "features = pd.read_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
-        "features[\"Date\"] = pd.to_datetime(features[\"Date\"])\n",
-        "print(features.shape)\n",
-        "features.head(5)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "QX4cSq3Ftqhm",
-      "metadata": {
-        "id": "QX4cSq3Ftqhm"
-      },
-      "source": [
-        "**Scale_features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1qEb1Cz1vzj6",
-      "metadata": {
-        "id": "1qEb1Cz1vzj6"
-      },
-      "outputs": [],
-      "source": [
-        "cols_to_scale = features.columns[1:]\n",
-        "cols_to_scale"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eJcGUESttqhm",
-      "metadata": {
-        "id": "eJcGUESttqhm"
-      },
-      "outputs": [],
-      "source": [
-        "### Scale Features with Rolling Window\n",
-        "start_time = time.time()\n",
-        "\n",
-        "window = 200\n",
-        "rolling = features[cols_to_scale].rolling(window)\n",
-        "features[cols_to_scale] = (features[cols_to_scale] - rolling.mean()) / rolling.std()\n",
-        "\n",
-        "print(\"DataFrame with rolling-scaled features:\")\n",
-        "print(features.shape)\n",
-        "features.head()\n",
-        "end_time = time.time()\n",
-        "execution_time = end_time - start_time\n",
-        "print(f\"Execution time: {execution_time:.2f} seconds\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "BFVUCAe3GWFy",
-      "metadata": {
-        "id": "BFVUCAe3GWFy"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(features.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "aXMGezVftqhn",
-      "metadata": {
-        "id": "aXMGezVftqhn"
-      },
-      "outputs": [],
-      "source": [
-        "features.to_csv(root_data+'Results/'+symbol+'_M5_Scale_Features.csv')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "jh9-mi26wsya",
-      "metadata": {
-        "id": "jh9-mi26wsya"
-      },
-      "source": [
-        "## 10_min"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bgh3Xz5ux75A",
-      "metadata": {
-        "id": "bgh3Xz5ux75A"
-      },
-      "outputs": [],
-      "source": [
-        "# Read the CSV file\n",
-        "df_10min = pd.read_csv(root_data + 'Data/'+symbol+'_M10.csv', index_col=0)\n",
-        "df_10min.index = pd.to_datetime(df_10min.index)\n",
-        "#df_10min = df_10min.iloc[-100000:,]\n",
-        "\n",
-        "print('Min_Date : ', df_10min.index.min())\n",
-        "print('Min_Date : ', df_10min.index.max())\n",
-        "print('Number_Rows = ',len(df_10min.index))\n",
-        "print('\\n')\n",
-        "\n",
-        "df_10min.tail()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "WZRt7qxmx75A",
-      "metadata": {
-        "id": "WZRt7qxmx75A"
-      },
-      "source": [
-        "**Features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Enk8RNZ3x75B",
-      "metadata": {
-        "id": "Enk8RNZ3x75B"
-      },
-      "outputs": [],
-      "source": [
-        "### Create the Features Set\n",
-        "features_10min = create_features(df_10min)\n",
-        "features_10min = features_10min.dropna()\n",
-        "\n",
-        "# Add \"10min_\" prefix to all column names except 'Date'\n",
-        "features_10min = features_10min.add_prefix('10min_')\n",
-        "features_10min.rename(columns={'10min_Date': 'Date'}, inplace=True)\n",
-        "\n",
-        "print(\"Number of features are:\", features_10min.shape[1])\n",
-        "print(features_10min.shape)\n",
-        "features_10min.to_csv(root_data+'Results/'+symbol+'_M10_Raw_Features.csv')\n",
-        "features_10min.tail(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ZREQYp1Px75B",
-      "metadata": {
-        "id": "ZREQYp1Px75B"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\",'\\n')\n",
-        "print(features_10min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "F7wu9XEqx75B",
-      "metadata": {
-        "id": "F7wu9XEqx75B"
-      },
-      "outputs": [],
-      "source": [
-        "features_10min = pd.read_csv(root_data+'Results/'+symbol+'_M10_Raw_Features.csv')\n",
-        "features_10min[\"Date\"] = pd.to_datetime(features_10min[\"Date\"])\n",
-        "print(features_10min.shape)\n",
-        "features_10min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "OM1OXL0tx75B",
-      "metadata": {
-        "id": "OM1OXL0tx75B"
-      },
-      "source": [
-        "**Scale_features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "D_ktgzyhx75C",
-      "metadata": {
-        "id": "D_ktgzyhx75C"
-      },
-      "outputs": [],
-      "source": [
-        "cols_to_scale = features_10min.columns[1:]\n",
-        "cols_to_scale"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "qeSWEQdTx75D",
-      "metadata": {
-        "id": "qeSWEQdTx75D"
-      },
-      "outputs": [],
-      "source": [
-        "### Scale Features with Rolling Window\n",
-        "window = 200\n",
-        "rolling = features_10min[cols_to_scale].rolling(window)\n",
-        "features_10min[cols_to_scale] = (features_10min[cols_to_scale] - rolling.mean()) / rolling.std()\n",
-        "\n",
-        "print(\"DataFrame with rolling-scaled features:\")\n",
-        "print(features_10min.shape)\n",
-        "features_10min.tail()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "g5XpLxmSeP53",
-      "metadata": {
-        "id": "g5XpLxmSeP53"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\",'\\n')\n",
-        "print(features_10min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "RAYGNhPex75E",
-      "metadata": {
-        "id": "RAYGNhPex75E"
-      },
-      "outputs": [],
-      "source": [
-        "features_10min.to_csv(root_data+'Results/'+symbol+'_M10_Scale_Features.csv')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "dexDJat0XWBi",
-      "metadata": {
-        "id": "dexDJat0XWBi"
-      },
-      "source": [
-        "## 15_min"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "KiPN3qSWXWBj",
-      "metadata": {
-        "id": "KiPN3qSWXWBj"
-      },
-      "outputs": [],
-      "source": [
-        "# Read the CSV file\n",
-        "df_15min = pd.read_csv(root_data + 'Data/'+symbol+'_M15.csv', index_col=0)\n",
-        "df_15min.index = pd.to_datetime(df_15min.index)\n",
-        "#df_15min = df_15min.iloc[-500000:,]\n",
-        "#df_15min = df_15min.iloc[-5000:,]\n",
-        "\n",
-        "print('Min_Date : ', df_15min.index.min())\n",
-        "print('Min_Date : ', df_15min.index.max())\n",
-        "print('Number_Rows = ',len(df_15min.index))\n",
-        "print('\\n')\n",
-        "\n",
-        "df_15min.tail()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "V4zWjMGtXWBk",
-      "metadata": {
-        "id": "V4zWjMGtXWBk"
-      },
-      "source": [
-        "**Features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "DmkzrcRjXWBm",
-      "metadata": {
-        "id": "DmkzrcRjXWBm"
-      },
-      "outputs": [],
-      "source": [
-        "features_15min = create_features(df_15min)\n",
-        "\n",
-        "print(\"Number of features are:\", features_15min.shape[1])\n",
-        "print(features_15min.shape)\n",
-        "features_15min.to_csv(root_data+'Results/'+symbol+'_M15_Raw_Features.csv')\n",
-        "features_15min.tail(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "AVfc4FqyJ5d0",
-      "metadata": {
-        "id": "AVfc4FqyJ5d0"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(features_15min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "yGHSgJnYXWBn",
-      "metadata": {
-        "id": "yGHSgJnYXWBn"
-      },
-      "outputs": [],
-      "source": [
-        "features_15min = pd.read_csv(root_data+'Results/'+symbol+'_M15_Raw_Features.csv')\n",
-        "features_15min[\"Date\"] = pd.to_datetime(features_15min[\"Date\"])\n",
-        "print(features_15min.shape)\n",
-        "features_15min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "VRhYUP2RXWBn",
-      "metadata": {
-        "id": "VRhYUP2RXWBn"
-      },
-      "source": [
-        "**Scale_features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "kqXbXgJWXWBn",
-      "metadata": {
-        "id": "kqXbXgJWXWBn"
-      },
-      "outputs": [],
-      "source": [
-        "cols_to_scale = features_15min.columns[1:]\n",
-        "cols_to_scale"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "j6kGfSpyXWBo",
-      "metadata": {
-        "id": "j6kGfSpyXWBo"
-      },
-      "outputs": [],
-      "source": [
-        "### Scale Features with Rolling Window\n",
-        "window = 200\n",
-        "rolling = features_15min[cols_to_scale].rolling(window)\n",
-        "features_15min[cols_to_scale] = (features_15min[cols_to_scale] - rolling.mean()) / rolling.std()\n",
-        "\n",
-        "print(\"DataFrame with rolling-scaled features:\")\n",
-        "print(features_15min.shape)\n",
-        "#features.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ZmwG_RFHJyji",
-      "metadata": {
-        "id": "ZmwG_RFHJyji"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(features_15min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "IXiZG3OpXWBo",
-      "metadata": {
-        "id": "IXiZG3OpXWBo"
-      },
-      "outputs": [],
-      "source": [
-        "features_15min = features_15min.add_prefix('15min_')\n",
-        "features_15min.to_csv(root_data+'Results/'+symbol+'_M15_Scale_Features.csv')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "W1Pk4Hkfjhvt",
-      "metadata": {
-        "id": "W1Pk4Hkfjhvt"
-      },
-      "source": [
-        "**Plots**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "67453c9e",
-      "metadata": {
-        "id": "67453c9e"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "last_500_features = features_15min.tail(200)\n",
-        "last_500_df = df_15min.tail(200)\n",
-        "\n",
-        "indicators_to_plot = ['Close','Kal_300','Kal_600',]\n",
-        "\n",
-        "# Separate Close from other indicators\n",
-        "close_to_plot = 'Close' if 'Close' in indicators_to_plot else None\n",
-        "other_indicators_to_plot = [col for col in indicators_to_plot if col != 'Close' and col in last_500_features.columns]\n",
-        "\n",
-        "num_plots = len(other_indicators_to_plot) + (1 if close_to_plot else 0)\n",
-        "\n",
-        "# Plotting\n",
-        "fig, axes = plt.subplots(nrows=num_plots, ncols=1, figsize=(15, 2.5 * num_plots), sharex=True)\n",
-        "\n",
-        "# Ensure axes is an array even if only one plot\n",
-        "if not isinstance(axes, np.ndarray):\n",
-        "    axes = np.array([axes])\n",
-        "\n",
-        "current_plot_index = 0\n",
-        "\n",
-        "# Plot Close price if requested\n",
-        "if close_to_plot:\n",
-        "    axes[current_plot_index].plot(last_500_df.index, last_500_df['Close'])\n",
-        "    axes[current_plot_index].set_title('Close Price')\n",
-        "    axes[current_plot_index].grid(True)\n",
-        "    current_plot_index += 1\n",
-        "\n",
-        "# Plot each selected indicator (excluding 'Close')\n",
-        "for col in other_indicators_to_plot:\n",
-        "    axes[current_plot_index].plot(last_500_features.index, last_500_features[col])\n",
-        "    axes[current_plot_index].set_title(col)\n",
-        "    axes[current_plot_index].grid(True)\n",
-        "    current_plot_index += 1\n",
-        "\n",
-        "\n",
-        "#plt.tight_layout()\n",
-        "#plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "A5c__w6s_dtY",
-      "metadata": {
-        "id": "A5c__w6s_dtY"
-      },
-      "source": [
-        "# Feature Importance"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4j7J8tk_f3o-",
-      "metadata": {
-        "id": "4j7J8tk_f3o-"
-      },
-      "source": [
-        "## Labels"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6XOsumPycYz3",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 386
-        },
-        "id": "6XOsumPycYz3",
-        "outputId": "1ea7780a-8f29-4d3d-fc7e-019c53182ea5"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Min_Date    :  2019-01-02 01:00:00\n",
-            "Min_Date    :  2025-07-25 23:55:00 \n",
-            "\n",
-            "Number_Rows :  (465718, 29) \n",
-            "\n",
-            "Columns     :  Index(['Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Spread', 'ATR',\n",
-            "       'kal_1', 'kal_2', 'kal_3', 'kal_4', 'Open_Trade', 'Close_Trade',\n",
-            "       'Entry_Date', 'Type', 'Trade_Number', 'st_Exit_Date', 'trade type',\n",
-            "       'st_Duration', 'st_row_PnL_close', 'st_row_PnL_high', 'st_row_PnL_Low',\n",
-            "       'st_row_PnL_low', 'st_Max', 'st_Min', 'st_PnL', 'st_atr_PnL',\n",
-            "       'st_atr_max_PnL'],\n",
-            "      dtype='object')\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>count</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Open_Trade</th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>1.0</th>\n",
-              "      <td>33915</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>-1.0</th>\n",
-              "      <td>33858</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div><br><label><b>dtype:</b> int64</label>"
-            ],
-            "text/plain": [
-              "Open_Trade\n",
-              " 1.0    33915\n",
-              "-1.0    33858\n",
-              "Name: count, dtype: int64"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "lab = pd.read_csv(root_data + 'Results/'+symbol+'_'+strategy+'_'+time_frame+'_Strategy_Gen_Labels.csv', index_col=0)\n",
-        "lab['Date'] = pd.to_datetime(lab['Date'])\n",
-        "\n",
-        "print('Min_Date    : ',lab['Date'].min())\n",
-        "print('Min_Date    : ',lab['Date'].max(),'\\n')\n",
-        "print('Number_Rows : ',lab.shape,'\\n')\n",
-        "print('Columns     : ',lab.columns)\n",
-        "\n",
-        "lab['Open_Trade'].value_counts()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "apV2tezPsbux",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "apV2tezPsbux",
-        "outputId": "7f607a0e-ad79-4597-e1f4-33f48387f9b2"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Total_Trades = 67,773\n",
-            "\n",
-            "Mean st_atr_max_PnL = 238.39\n",
-            "\n",
-            "Above_Mean = 11,463,914.00\n",
-            "Below_Mean = 4,691,967.00\n",
-            "\n",
-            "<= 0.5 = 33.00\n",
-            "> 0.5 & <= 1 = 801,960.00\n",
-            "> 1 & <= 1.5 = 1,411,119.00\n",
-            "> 1.5 & <= 2 = 1,400,438.00\n",
-            "> 2 = 11,277,394.00\n"
-          ]
-        }
-      ],
-      "source": [
-        "#analyse_column = 'st_atr_max_PnL'\n",
-        "analyse_column = 'st_Max'\n",
-        "\n",
-        "st_max_0  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
-        "st_max_1  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
-        "st_max_2  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].sum()\n",
-        "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].sum()\n",
-        "\n",
-        "\n",
-        "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 0)),analyse_column].sum()\n",
-        "\n",
-        "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 0.7) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].sum()\n",
-        "\n",
-        "st_max_5 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 1) &\n",
-        "                   (lab['st_atr_max_PnL'] <= 1.5)),analyse_column].sum()\n",
-        "\n",
-        "st_max_6 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 1.5) &\n",
-        "                   (lab['st_atr_max_PnL'] <= 2)),analyse_column].sum()\n",
-        "\n",
-        "st_max_7 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 2)),analyse_column].sum()\n",
-        "\n",
-        "\n",
-        "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
-        "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
-        "print(f'Above_Mean = {st_max_2:,.2f}')\n",
-        "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
-        "\n",
-        "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
-        "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
-        "print(f'> 1 & <= 1.5 = {st_max_5:,.2f}')\n",
-        "print(f'> 1.5 & <= 2 = {st_max_6:,.2f}')\n",
-        "print(f'> 2 = {st_max_7:,.2f}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "p2fjs4Si792v",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "p2fjs4Si792v",
-        "outputId": "3c59923a-5da8-47d2-9e1a-7e1e9a0c0962"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Total_Trades = 67,773\n",
-            "\n",
-            "Mean st_atr_max_PnL = 1.89\n",
-            "\n",
-            "Above_Mean = 20,857.00\n",
-            "Below_Mean = 46,913.00\n",
-            "\n",
-            "<= 0.5 = 20,431.00\n",
-            "> 0.5 & <= 1 = 13,116.00\n",
-            "> 1 = 34,223.00\n"
-          ]
-        }
-      ],
-      "source": [
-        "analyse_column = 'st_atr_max_PnL'\n",
-        "\n",
-        "st_max_0 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
-        "st_max_1 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
-        "st_max_2 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].count()\n",
-        "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].count()\n",
-        "\n",
-        "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                    (lab['st_atr_max_PnL'] <= 0.5)),analyse_column].count()\n",
-        "\n",
-        "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                     (lab['st_atr_max_PnL'] >= 0.5) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].count()\n",
-        "\n",
-        "st_max_5 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] >= 1), analyse_column].count()\n",
-        "\n",
-        "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
-        "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
-        "print(f'Above_Mean = {st_max_2:,.2f}')\n",
-        "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
-        "\n",
-        "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
-        "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
-        "print(f'> 1 = {st_max_5:,.2f}')\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "85DATjQqZd66",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "85DATjQqZd66",
-        "outputId": "67c11f5a-3b3a-4b07-ecbc-f572c96d5c5f"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "Value counts de label 4/5/6:\n",
-            "label\n",
-            "0    33547\n",
-            "1    34223\n",
-            "Name: count, dtype: int64\n"
-          ]
-        }
-      ],
-      "source": [
-        "# --- Parámetros / campos\n",
-        "result_field = 'st_atr_max_PnL'\n",
-        "\n",
-        "#valid = (\n",
-        "#    (lab['Type'] == direction) &\n",
-        "#    (lab['Open_Trade'].isin([1, -1])) &\n",
-        "#    (lab[result_field].notna()))\n",
-        "\n",
-        "valid = (\n",
-        "    (lab['Open_Trade'].isin([1, -1])) &\n",
-        "    (lab[result_field].notna()))\n",
-        "\n",
-        "\n",
-        "# --- Etiquetado en la columna \"label\" con valores 4/5/6\n",
-        "lab['label'] = np.nan\n",
-        "lab.loc[valid & (lab[result_field] <= 1), 'label'] = 0\n",
-        "lab.loc[valid & (lab[result_field] >= 1), 'label'] = 1\n",
-        "\n",
-        "\n",
-        "# --- Mantener solo filas válidas y con label\n",
-        "lab = lab.loc[valid & lab['label'].notna()].copy()\n",
-        "lab['label'] = lab['label'].astype('int8')\n",
-        "\n",
-        "# --- Ver distribución de labels 4/5/6\n",
-        "print('\\nValue counts de label 4/5/6:')\n",
-        "print(lab['label'].value_counts(dropna=False).sort_index())\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "_BCdqt3Y0Fjm",
-      "metadata": {
-        "id": "_BCdqt3Y0Fjm"
-      },
-      "source": [
-        "## Features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "u1I6_IHtGgbE",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "u1I6_IHtGgbE",
-        "outputId": "34870a70-f3ba-466d-b262-10a3f5939f29"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(268296, 366)\n"
-          ]
-        }
-      ],
-      "source": [
-        "raw_feat_15min = pd.read_csv(root_data+'Results/'+symbol+'_M15_Raw_Features.csv')\n",
-        "raw_feat_15min[\"Date\"] = pd.to_datetime(raw_feat_15min[\"Date\"])\n",
-        "print(raw_feat_15min.shape)\n",
-        "#raw_feat_15min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8jK6LavOGgbF",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 464
-        },
-        "id": "8jK6LavOGgbF",
-        "outputId": "e2efdd27-f6c2-488b-89b9-a1dd0bddda4b"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(268296, 366)\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe"
-            },
-            "text/html": [
-              "\n",
-              "  <div id=\"df-286e3991-0362-491b-8235-b21743710d56\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Date</th>\n",
-              "      <th>15min_OBV</th>\n",
-              "      <th>15min_RSI_3</th>\n",
-              "      <th>15min_MFI_3</th>\n",
-              "      <th>15min_RSI_7</th>\n",
-              "      <th>15min_MFI_7</th>\n",
-              "      <th>15min_RSI_14</th>\n",
-              "      <th>15min_MFI_14</th>\n",
-              "      <th>15min_RSI_3_diff</th>\n",
-              "      <th>15min_RSI_7_diff</th>\n",
-              "      <th>...</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6</th>\n",
-              "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9</th>\n",
-              "      <th>15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6</th>\n",
-              "      <th>15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9</th>\n",
-              "      <th>15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>268291</th>\n",
-              "      <td>2025-07-25 23:10:00</td>\n",
-              "      <td>-0.678811</td>\n",
-              "      <td>-0.876084</td>\n",
-              "      <td>-1.302567</td>\n",
-              "      <td>0.119717</td>\n",
-              "      <td>-0.719882</td>\n",
-              "      <td>0.897443</td>\n",
-              "      <td>0.911516</td>\n",
-              "      <td>-0.368162</td>\n",
-              "      <td>-0.506248</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.081175</td>\n",
-              "      <td>0.044165</td>\n",
-              "      <td>-0.063931</td>\n",
-              "      <td>0.07562</td>\n",
-              "      <td>-0.02420</td>\n",
-              "      <td>-0.103575</td>\n",
-              "      <td>-0.026669</td>\n",
-              "      <td>-0.090598</td>\n",
-              "      <td>0.013099</td>\n",
-              "      <td>0.099235</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>268292</th>\n",
-              "      <td>2025-07-25 23:20:00</td>\n",
-              "      <td>-0.713760</td>\n",
-              "      <td>-1.108173</td>\n",
-              "      <td>-1.292210</td>\n",
-              "      <td>-0.149088</td>\n",
-              "      <td>-1.438063</td>\n",
-              "      <td>0.732902</td>\n",
-              "      <td>0.520889</td>\n",
-              "      <td>-0.289632</td>\n",
-              "      <td>-0.461977</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.081175</td>\n",
-              "      <td>0.044165</td>\n",
-              "      <td>-0.063931</td>\n",
-              "      <td>0.07562</td>\n",
-              "      <td>-0.02420</td>\n",
-              "      <td>-0.103575</td>\n",
-              "      <td>-0.026669</td>\n",
-              "      <td>-0.090598</td>\n",
-              "      <td>0.013099</td>\n",
-              "      <td>0.099235</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>268293</th>\n",
-              "      <td>2025-07-25 23:30:00</td>\n",
-              "      <td>-0.649067</td>\n",
-              "      <td>1.064528</td>\n",
-              "      <td>-0.311180</td>\n",
-              "      <td>1.102293</td>\n",
-              "      <td>-1.572824</td>\n",
-              "      <td>1.394754</td>\n",
-              "      <td>0.325417</td>\n",
-              "      <td>2.685337</td>\n",
-              "      <td>2.126853</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.081175</td>\n",
-              "      <td>0.044165</td>\n",
-              "      <td>-0.063931</td>\n",
-              "      <td>0.07562</td>\n",
-              "      <td>-0.02420</td>\n",
-              "      <td>-0.103575</td>\n",
-              "      <td>-0.026669</td>\n",
-              "      <td>-0.090598</td>\n",
-              "      <td>0.013099</td>\n",
-              "      <td>0.099235</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>268294</th>\n",
-              "      <td>2025-07-25 23:40:00</td>\n",
-              "      <td>-0.707530</td>\n",
-              "      <td>-0.566703</td>\n",
-              "      <td>-0.264287</td>\n",
-              "      <td>-0.315545</td>\n",
-              "      <td>-1.524675</td>\n",
-              "      <td>0.396390</td>\n",
-              "      <td>0.554163</td>\n",
-              "      <td>-2.004983</td>\n",
-              "      <td>-2.380777</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.081175</td>\n",
-              "      <td>0.044165</td>\n",
-              "      <td>-0.063931</td>\n",
-              "      <td>0.07562</td>\n",
-              "      <td>-0.02420</td>\n",
-              "      <td>-0.103575</td>\n",
-              "      <td>-0.026669</td>\n",
-              "      <td>-0.090598</td>\n",
-              "      <td>0.013099</td>\n",
-              "      <td>0.099235</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>268295</th>\n",
-              "      <td>2025-07-25 23:50:00</td>\n",
-              "      <td>-0.652857</td>\n",
-              "      <td>-0.487742</td>\n",
-              "      <td>-0.286408</td>\n",
-              "      <td>-0.265147</td>\n",
-              "      <td>-1.447693</td>\n",
-              "      <td>0.422128</td>\n",
-              "      <td>0.223350</td>\n",
-              "      <td>0.097241</td>\n",
-              "      <td>0.085239</td>\n",
-              "      <td>...</td>\n",
-              "      <td>0.081175</td>\n",
-              "      <td>0.030089</td>\n",
-              "      <td>-0.089578</td>\n",
-              "      <td>0.07562</td>\n",
-              "      <td>-0.03686</td>\n",
-              "      <td>-0.118712</td>\n",
-              "      <td>-0.026669</td>\n",
-              "      <td>-0.090598</td>\n",
-              "      <td>0.026669</td>\n",
-              "      <td>0.115957</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>5 rows × 366 columns</p>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-286e3991-0362-491b-8235-b21743710d56')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-286e3991-0362-491b-8235-b21743710d56 button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-286e3991-0362-491b-8235-b21743710d56');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "    <div id=\"df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff\">\n",
-              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff')\"\n",
-              "                title=\"Suggest charts\"\n",
-              "                style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "      </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "      <script>\n",
-              "        async function quickchart(key) {\n",
-              "          const quickchartButtonEl =\n",
-              "            document.querySelector('#' + key + ' button');\n",
-              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "          try {\n",
-              "            const charts = await google.colab.kernel.invokeFunction(\n",
-              "                'suggestCharts', [key], {});\n",
-              "          } catch (error) {\n",
-              "            console.error('Error during call to suggestCharts:', error);\n",
-              "          }\n",
-              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "        }\n",
-              "        (() => {\n",
-              "          let quickchartButtonEl =\n",
-              "            document.querySelector('#df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff button');\n",
-              "          quickchartButtonEl.style.display =\n",
-              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "        })();\n",
-              "      </script>\n",
-              "    </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "text/plain": [
-              "                      Date  15min_OBV  15min_RSI_3  15min_MFI_3  15min_RSI_7  \\\n",
-              "268291 2025-07-25 23:10:00  -0.678811    -0.876084    -1.302567     0.119717   \n",
-              "268292 2025-07-25 23:20:00  -0.713760    -1.108173    -1.292210    -0.149088   \n",
-              "268293 2025-07-25 23:30:00  -0.649067     1.064528    -0.311180     1.102293   \n",
-              "268294 2025-07-25 23:40:00  -0.707530    -0.566703    -0.264287    -0.315545   \n",
-              "268295 2025-07-25 23:50:00  -0.652857    -0.487742    -0.286408    -0.265147   \n",
-              "\n",
-              "        15min_MFI_7  15min_RSI_14  15min_MFI_14  15min_RSI_3_diff  \\\n",
-              "268291    -0.719882      0.897443      0.911516         -0.368162   \n",
-              "268292    -1.438063      0.732902      0.520889         -0.289632   \n",
-              "268293    -1.572824      1.394754      0.325417          2.685337   \n",
-              "268294    -1.524675      0.396390      0.554163         -2.004983   \n",
-              "268295    -1.447693      0.422128      0.223350          0.097241   \n",
-              "\n",
-              "        15min_RSI_7_diff  ...  \\\n",
-              "268291         -0.506248  ...   \n",
-              "268292         -0.461977  ...   \n",
-              "268293          2.126853  ...   \n",
-              "268294         -2.380777  ...   \n",
-              "268295          0.085239  ...   \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9  \\\n",
-              "268291                                           0.081175               \n",
-              "268292                                           0.081175               \n",
-              "268293                                           0.081175               \n",
-              "268294                                           0.081175               \n",
-              "268295                                           0.081175               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3  \\\n",
-              "268291                                           0.044165               \n",
-              "268292                                           0.044165               \n",
-              "268293                                           0.044165               \n",
-              "268294                                           0.044165               \n",
-              "268295                                           0.030089               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6  \\\n",
-              "268291                                          -0.063931               \n",
-              "268292                                          -0.063931               \n",
-              "268293                                          -0.063931               \n",
-              "268294                                          -0.063931               \n",
-              "268295                                          -0.089578               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9  \\\n",
-              "268291                                            0.07562               \n",
-              "268292                                            0.07562               \n",
-              "268293                                            0.07562               \n",
-              "268294                                            0.07562               \n",
-              "268295                                            0.07562               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3  \\\n",
-              "268291                                           -0.02420               \n",
-              "268292                                           -0.02420               \n",
-              "268293                                           -0.02420               \n",
-              "268294                                           -0.02420               \n",
-              "268295                                           -0.03686               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6  \\\n",
-              "268291                                          -0.103575               \n",
-              "268292                                          -0.103575               \n",
-              "268293                                          -0.103575               \n",
-              "268294                                          -0.103575               \n",
-              "268295                                          -0.118712               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9  \\\n",
-              "268291                                          -0.026669               \n",
-              "268292                                          -0.026669               \n",
-              "268293                                          -0.026669               \n",
-              "268294                                          -0.026669               \n",
-              "268295                                          -0.026669               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6  \\\n",
-              "268291                                          -0.090598               \n",
-              "268292                                          -0.090598               \n",
-              "268293                                          -0.090598               \n",
-              "268294                                          -0.090598               \n",
-              "268295                                          -0.090598               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9  \\\n",
-              "268291                                           0.013099               \n",
-              "268292                                           0.013099               \n",
-              "268293                                           0.013099               \n",
-              "268294                                           0.013099               \n",
-              "268295                                           0.026669               \n",
-              "\n",
-              "        15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9  \n",
-              "268291                                           0.099235              \n",
-              "268292                                           0.099235              \n",
-              "268293                                           0.099235              \n",
-              "268294                                           0.099235              \n",
-              "268295                                           0.115957              \n",
-              "\n",
-              "[5 rows x 366 columns]"
-            ]
-          },
-          "execution_count": 22,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "scale_feat_15min = pd.read_csv(root_data+'Results/'+symbol+'_M15_Scale_Features.csv')\n",
-        "scale_feat_15min = scale_feat_15min.drop('Unnamed: 0', axis=1)\n",
-        "scale_feat_15min.rename(columns={'15min_Date': 'Date'}, inplace=True)\n",
-        "scale_feat_15min[\"Date\"] = pd.to_datetime(scale_feat_15min[\"Date\"])\n",
-        "print(scale_feat_15min.shape)\n",
-        "scale_feat_15min.tail(5)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gX04ZTmfz-pK",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gX04ZTmfz-pK",
-        "outputId": "d5f990fd-0ded-4589-e070-20b49bc5c7ba"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(465703, 366)\n"
-          ]
-        }
-      ],
-      "source": [
-        "raw_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
-        "raw_feat_5min[\"Date\"] = pd.to_datetime(raw_feat_5min[\"Date\"])\n",
-        "print(raw_feat_5min.shape)\n",
-        "#raw_feat_5min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "D5gxf0ke0KUx",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "D5gxf0ke0KUx",
-        "outputId": "929a5d72-b5dc-4c51-b709-02d56fd6a1d4"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(465703, 366)\n"
-          ]
-        }
-      ],
-      "source": [
-        "scale_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Scale_Features.csv')\n",
-        "scale_feat_5min = scale_feat_5min.drop('Unnamed: 0', axis=1)\n",
-        "scale_feat_5min[\"Date\"] = pd.to_datetime(scale_feat_5min[\"Date\"])\n",
-        "print(scale_feat_5min.shape)\n",
-        "#scale_feat_5min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "hwsOt0mbFWeo",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "hwsOt0mbFWeo",
-        "outputId": "3c3260c0-ae61-4eb2-fc97-103f30fed2a0"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "NaN counts per column (sorted): \n",
-            "\n",
-            "slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    199\n",
-            "slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9    199\n",
-            "OBV                                                        199\n",
-            "RSI_3                                                      199\n",
-            "MFI_3                                                      199\n",
-            "                                                          ... \n",
-            "MFI_3 - MFI_7                                              199\n",
-            "MFI_3 - MFI_14                                             199\n",
-            "MFI_7 - MFI_14                                             199\n",
-            "OBV_diff                                                   199\n",
-            "Date                                                         0\n",
-            "Length: 366, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(\"NaN counts per column (sorted):\",'\\n')\n",
-        "print(scale_feat_5min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cHlD0eRb0scj",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "cHlD0eRb0scj",
-        "outputId": "0005b140-a44c-4835-e176-c33df3cfb033"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(268281, 366)\n"
-          ]
-        }
-      ],
-      "source": [
-        "raw_feat_10min = pd.read_csv(root_data+'Results/'+symbol+'_M10_Raw_Features.csv')\n",
-        "raw_feat_10min[\"Date\"] = pd.to_datetime(raw_feat_10min[\"Date\"])\n",
-        "\n",
-        "# Add \"10min_\" prefix to all column names except 'Date'\n",
-        "cols_to_prefix = [col for col in raw_feat_10min.columns if col != 'Date']\n",
-        "raw_feat_10min.rename(columns={col: col for col in cols_to_prefix}, inplace=True)\n",
-        "\n",
-        "print(raw_feat_10min.shape)\n",
-        "#raw_feat_10min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "O7xrmOA90sck",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "O7xrmOA90sck",
-        "outputId": "12383796-8d5c-4941-bdd4-d9cdea8acdd1"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(268281, 366)\n"
-          ]
-        }
-      ],
-      "source": [
-        "scale_feat_10min = pd.read_csv(root_data+'Results/'+symbol+'_M10_Scale_Features.csv')\n",
-        "scale_feat_10min = scale_feat_10min.drop('Unnamed: 0', axis=1)\n",
-        "scale_feat_10min[\"Date\"] = pd.to_datetime(scale_feat_10min[\"Date\"])\n",
-        "\n",
-        "# Add \"10min_\" prefix to all column names except 'Date'\n",
-        "cols_to_prefix = [col for col in scale_feat_10min.columns if col != 'Date']\n",
-        "scale_feat_10min.rename(columns={col:col for col in cols_to_prefix}, inplace=True)\n",
-        "\n",
-        "print(scale_feat_10min.shape)\n",
-        "#scale_feat_10min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3rH4dF7HFmJy",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "3rH4dF7HFmJy",
-        "outputId": "3fb60e92-7e81-4b06-ab3e-c825b6e03f00"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "NaN counts per column (sorted): \n",
-            "\n",
-            "10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    199\n",
-            "10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9    199\n",
-            "10min_OBV                                                        199\n",
-            "10min_RSI_3                                                      199\n",
-            "10min_MFI_3                                                      199\n",
-            "                                                                ... \n",
-            "10min_MFI_3 - MFI_7                                              199\n",
-            "10min_MFI_3 - MFI_14                                             199\n",
-            "10min_MFI_7 - MFI_14                                             199\n",
-            "10min_OBV_diff                                                   199\n",
-            "Date                                                               0\n",
-            "Length: 366, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(\"NaN counts per column (sorted):\",'\\n')\n",
-        "print(scale_feat_10min.isnull().sum().sort_values(ascending=False), '\\n')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Hv5bsrpc03z7",
-      "metadata": {
-        "id": "Hv5bsrpc03z7"
-      },
-      "source": [
-        "## Merge"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Mc1y2NbRM_f1",
-      "metadata": {
-        "id": "Mc1y2NbRM_f1"
-      },
-      "outputs": [],
-      "source": [
-        "data_type = 'Scale'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "I0gkNVT60Ka5",
-      "metadata": {
-        "id": "I0gkNVT60Ka5"
-      },
-      "outputs": [],
-      "source": [
-        "# Add \"15min_\" prefix to all column names except 'Date'\n",
-        "cols_to_prefix_15min = [col for col in scale_feat_15min.columns if col != 'Date']\n",
-        "scale_feat_15min.rename(columns={col: '15min_' + col for col in cols_to_prefix_15min}, inplace=True)\n",
-        "\n",
-        "# First merge scale_feat_5min with scale_feat_10min and apply forward fill\n",
-        "merged_features = scale_feat_5min.merge(scale_feat_10min, on='Date', how='left').ffill()\n",
-        "merged_features = merged_features.merge(scale_feat_15min, on='Date', how='left').ffill()\n",
-        "\n",
-        "# Remove 'Open_Trade' from lab before merging to avoid duplicate columns and ensure correct ordering\n",
-        "df = pd.merge(lab[['Date', 'label', 'Open_Trade']], merged_features, on='Date', how='left')\n",
-        "\n",
-        "cols = df.columns.tolist()\n",
-        "cols.remove('label')\n",
-        "cols.insert(1, 'label')\n",
-        "df = df[cols]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fQPfQroWYLRM",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "fQPfQroWYLRM",
-        "outputId": "a16c0c78-937e-43ca-faa6-5146f2c0ef27"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Columns with '15min_' prefix found:\n",
-            "['15min_15min_OBV', '15min_15min_RSI_3', '15min_15min_MFI_3', '15min_15min_RSI_7', '15min_15min_MFI_7', '15min_15min_RSI_14', '15min_15min_MFI_14', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_Kal_300', '15min_15min_Close_Kal_300', '15min_15min_Kal_change_300', '15min_15min_Kal_prev_minus_now_300', '15min_15min_Kal_prev2_minus_now_300', '15min_15min_Kal_change2_300', '15min_15min_Kal_600', '15min_15min_Close_Kal_600', '15min_15min_Kal_change_600', '15min_15min_Kal_prev_minus_now_600', '15min_15min_Kal_prev2_minus_now_600', '15min_15min_Kal_change2_600', '15min_15min_Kal_900', '15min_15min_Close_Kal_900', '15min_15min_Kal_change_900', '15min_15min_Kal_prev_minus_now_900', '15min_15min_Kal_prev2_minus_now_900', '15min_15min_Kal_change2_900', '15min_15min_Kal_300_minus_Kal_600', '15min_15min_Kal_300_minus_Kal_900', '15min_15min_Kal_600_minus_Kal_900', '15min_15min_slope_div_300_3', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9']\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Check for columns with '1min_' prefix\n",
-        "one_min_cols = [col for col in df.columns if '15min_' in col]\n",
-        "\n",
-        "if one_min_cols:\n",
-        "    print(\"Columns with '15min_' prefix found:\")\n",
-        "    print(one_min_cols)\n",
-        "else:\n",
-        "    print(\"No columns with '15min_' prefix found.\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "jXcXWty506Ur",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "jXcXWty506Ur",
-        "outputId": "10f79c82-4b66-4e5b-eb07-cf2e6beda361"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "(67770, 1098) \n",
-            "\n",
-            "Label_Counts :  label\n",
-            "1    34223\n",
-            "0    33547\n",
-            "Name: count, dtype: int64 \n",
-            "\n",
-            "['Date', 'label', 'Open_Trade', 'OBV', 'RSI_3', 'MFI_3', 'RSI_7', 'MFI_7', 'RSI_14', 'MFI_14', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'MFI_3_diff', 'MFI_7_diff', 'MFI_14_diff', 'MFI_3 - MFI_7', 'MFI_3 - MFI_14', 'MFI_7 - MFI_14', 'OBV_diff', 'Kal_300', 'Close_Kal_300', 'Kal_change_300', 'Kal_prev_minus_now_300', 'Kal_prev2_minus_now_300', 'Kal_change2_300', 'Kal_600', 'Close_Kal_600', 'Kal_change_600', 'Kal_prev_minus_now_600', 'Kal_prev2_minus_now_600', 'Kal_change2_600', 'Kal_900', 'Close_Kal_900', 'Kal_change_900', 'Kal_prev_minus_now_900', 'Kal_prev2_minus_now_900', 'Kal_change2_900', 'Kal_300_minus_Kal_600', 'Kal_300_minus_Kal_900', 'Kal_600_minus_Kal_900', 'slope_div_300_3', 'slope_div_300_3_diff', 'slope_signal_300_3', 'slope_signal_300_3_diff', 'slope_angle_300_3', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6', 'slope_div_300_6_diff', 'slope_signal_300_6', 'slope_signal_300_6_diff', 'slope_angle_300_6', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9', 'slope_div_300_9_diff', 'slope_signal_300_9', 'slope_signal_300_9_diff', 'slope_angle_300_9', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3', 'slope_div_600_3_diff', 'slope_signal_600_3', 'slope_signal_600_3_diff', 'slope_angle_600_3', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6', 'slope_div_600_6_diff', 'slope_signal_600_6', 'slope_signal_600_6_diff', 'slope_angle_600_6', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9', 'slope_div_600_9_diff', 'slope_signal_600_9', 'slope_signal_600_9_diff', 'slope_angle_600_9', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3', 'slope_div_900_3_diff', 'slope_signal_900_3', 'slope_signal_900_3_diff', 'slope_angle_900_3', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6', 'slope_div_900_6_diff', 'slope_signal_900_6', 'slope_signal_900_6_diff', 'slope_angle_900_6', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9', 'slope_div_900_9_diff', 'slope_signal_900_9', 'slope_signal_900_9_diff', 'slope_angle_900_9', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '10min_OBV', '10min_RSI_3', '10min_MFI_3', '10min_RSI_7', '10min_MFI_7', '10min_RSI_14', '10min_MFI_14', '10min_RSI_3_diff', '10min_RSI_7_diff', '10min_RSI_14_diff', '10min_RSI_3 - RSI_7', '10min_RSI_3 - RSI_14', '10min_RSI_7 - RSI_14', '10min_MFI_3_diff', '10min_MFI_7_diff', '10min_MFI_14_diff', '10min_MFI_3 - MFI_7', '10min_MFI_3 - MFI_14', '10min_MFI_7 - MFI_14', '10min_OBV_diff', '10min_Kal_300', '10min_Close_Kal_300', '10min_Kal_change_300', '10min_Kal_prev_minus_now_300', '10min_Kal_prev2_minus_now_300', '10min_Kal_change2_300', '10min_Kal_600', '10min_Close_Kal_600', '10min_Kal_change_600', '10min_Kal_prev_minus_now_600', '10min_Kal_prev2_minus_now_600', '10min_Kal_change2_600', '10min_Kal_900', '10min_Close_Kal_900', '10min_Kal_change_900', '10min_Kal_prev_minus_now_900', '10min_Kal_prev2_minus_now_900', '10min_Kal_change2_900', '10min_Kal_300_minus_Kal_600', '10min_Kal_300_minus_Kal_900', '10min_Kal_600_minus_Kal_900', '10min_slope_div_300_3', '10min_slope_div_300_3_diff', '10min_slope_signal_300_3', '10min_slope_signal_300_3_diff', '10min_slope_angle_300_3', '10min_slope_angle_300_3_diff', '10min_slope_angle_signal_300_3', '10min_slope_angle_signal_300_3_diff', '10min_slope_lin_reg_300_3', '10min_slope_lin_reg_300_3_diff', '10min_slope_lin_reg_signal_300_3', '10min_slope_lin_reg_signal_300_3_diff', '10min_slope_div_300_6', '10min_slope_div_300_6_diff', '10min_slope_signal_300_6', '10min_slope_signal_300_6_diff', '10min_slope_angle_300_6', '10min_slope_angle_300_6_diff', '10min_slope_angle_signal_300_6', '10min_slope_angle_signal_300_6_diff', '10min_slope_lin_reg_300_6', '10min_slope_lin_reg_300_6_diff', '10min_slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_6_diff', '10min_slope_div_300_9', '10min_slope_div_300_9_diff', '10min_slope_signal_300_9', '10min_slope_signal_300_9_diff', '10min_slope_angle_300_9', '10min_slope_angle_300_9_diff', '10min_slope_angle_signal_300_9', '10min_slope_angle_signal_300_9_diff', '10min_slope_lin_reg_300_9', '10min_slope_lin_reg_300_9_diff', '10min_slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_9_diff', '10min_slope_div_600_3', '10min_slope_div_600_3_diff', '10min_slope_signal_600_3', '10min_slope_signal_600_3_diff', '10min_slope_angle_600_3', '10min_slope_angle_600_3_diff', '10min_slope_angle_signal_600_3', '10min_slope_angle_signal_600_3_diff', '10min_slope_lin_reg_600_3', '10min_slope_lin_reg_600_3_diff', '10min_slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_600_3_diff', '10min_slope_div_600_6', '10min_slope_div_600_6_diff', '10min_slope_signal_600_6', '10min_slope_signal_600_6_diff', '10min_slope_angle_600_6', '10min_slope_angle_600_6_diff', '10min_slope_angle_signal_600_6', '10min_slope_angle_signal_600_6_diff', '10min_slope_lin_reg_600_6', '10min_slope_lin_reg_600_6_diff', '10min_slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_6_diff', '10min_slope_div_600_9', '10min_slope_div_600_9_diff', '10min_slope_signal_600_9', '10min_slope_signal_600_9_diff', '10min_slope_angle_600_9', '10min_slope_angle_600_9_diff', '10min_slope_angle_signal_600_9', '10min_slope_angle_signal_600_9_diff', '10min_slope_lin_reg_600_9', '10min_slope_lin_reg_600_9_diff', '10min_slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_9_diff', '10min_slope_div_900_3', '10min_slope_div_900_3_diff', '10min_slope_signal_900_3', '10min_slope_signal_900_3_diff', '10min_slope_angle_900_3', '10min_slope_angle_900_3_diff', '10min_slope_angle_signal_900_3', '10min_slope_angle_signal_900_3_diff', '10min_slope_lin_reg_900_3', '10min_slope_lin_reg_900_3_diff', '10min_slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_900_3_diff', '10min_slope_div_900_6', '10min_slope_div_900_6_diff', '10min_slope_signal_900_6', '10min_slope_signal_900_6_diff', '10min_slope_angle_900_6', '10min_slope_angle_900_6_diff', '10min_slope_angle_signal_900_6', '10min_slope_angle_signal_900_6_diff', '10min_slope_lin_reg_900_6', '10min_slope_lin_reg_900_6_diff', '10min_slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_6_diff', '10min_slope_div_900_9', '10min_slope_div_900_9_diff', '10min_slope_signal_900_9', '10min_slope_signal_900_9_diff', '10min_slope_angle_900_9', '10min_slope_angle_900_9_diff', '10min_slope_angle_signal_900_9', '10min_slope_angle_signal_900_9_diff', '10min_slope_lin_reg_900_9', '10min_slope_lin_reg_900_9_diff', '10min_slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_9_diff', '10min_slope_div_300_3 - slope_div_300_6', '10min_slope_div_300_3 - slope_div_300_9', '10min_slope_div_300_3 - slope_div_600_3', '10min_slope_div_300_3 - slope_div_600_6', '10min_slope_div_300_3 - slope_div_600_9', '10min_slope_div_300_3 - slope_div_900_3', '10min_slope_div_300_3 - slope_div_900_6', '10min_slope_div_300_3 - slope_div_900_9', '10min_slope_div_300_6 - slope_div_300_9', '10min_slope_div_300_6 - slope_div_600_3', '10min_slope_div_300_6 - slope_div_600_6', '10min_slope_div_300_6 - slope_div_600_9', '10min_slope_div_300_6 - slope_div_900_3', '10min_slope_div_300_6 - slope_div_900_6', '10min_slope_div_300_6 - slope_div_900_9', '10min_slope_div_300_9 - slope_div_600_3', '10min_slope_div_300_9 - slope_div_600_6', '10min_slope_div_300_9 - slope_div_600_9', '10min_slope_div_300_9 - slope_div_900_3', '10min_slope_div_300_9 - slope_div_900_6', '10min_slope_div_300_9 - slope_div_900_9', '10min_slope_div_600_3 - slope_div_600_6', '10min_slope_div_600_3 - slope_div_600_9', '10min_slope_div_600_3 - slope_div_900_3', '10min_slope_div_600_3 - slope_div_900_6', '10min_slope_div_600_3 - slope_div_900_9', '10min_slope_div_600_6 - slope_div_600_9', '10min_slope_div_600_6 - slope_div_900_3', '10min_slope_div_600_6 - slope_div_900_6', '10min_slope_div_600_6 - slope_div_900_9', '10min_slope_div_600_9 - slope_div_900_3', '10min_slope_div_600_9 - slope_div_900_6', '10min_slope_div_600_9 - slope_div_900_9', '10min_slope_div_900_3 - slope_div_900_6', '10min_slope_div_900_3 - slope_div_900_9', '10min_slope_div_900_6 - slope_div_900_9', '10min_slope_signal_300_3 - slope_signal_300_6', '10min_slope_signal_300_3 - slope_signal_300_9', '10min_slope_signal_300_3 - slope_signal_600_3', '10min_slope_signal_300_3 - slope_signal_600_6', '10min_slope_signal_300_3 - slope_signal_600_9', '10min_slope_signal_300_3 - slope_signal_900_3', '10min_slope_signal_300_3 - slope_signal_900_6', '10min_slope_signal_300_3 - slope_signal_900_9', '10min_slope_signal_300_6 - slope_signal_300_9', '10min_slope_signal_300_6 - slope_signal_600_3', '10min_slope_signal_300_6 - slope_signal_600_6', '10min_slope_signal_300_6 - slope_signal_600_9', '10min_slope_signal_300_6 - slope_signal_900_3', '10min_slope_signal_300_6 - slope_signal_900_6', '10min_slope_signal_300_6 - slope_signal_900_9', '10min_slope_signal_300_9 - slope_signal_600_3', '10min_slope_signal_300_9 - slope_signal_600_6', '10min_slope_signal_300_9 - slope_signal_600_9', '10min_slope_signal_300_9 - slope_signal_900_3', '10min_slope_signal_300_9 - slope_signal_900_6', '10min_slope_signal_300_9 - slope_signal_900_9', '10min_slope_signal_600_3 - slope_signal_600_6', '10min_slope_signal_600_3 - slope_signal_600_9', '10min_slope_signal_600_3 - slope_signal_900_3', '10min_slope_signal_600_3 - slope_signal_900_6', '10min_slope_signal_600_3 - slope_signal_900_9', '10min_slope_signal_600_6 - slope_signal_600_9', '10min_slope_signal_600_6 - slope_signal_900_3', '10min_slope_signal_600_6 - slope_signal_900_6', '10min_slope_signal_600_6 - slope_signal_900_9', '10min_slope_signal_600_9 - slope_signal_900_3', '10min_slope_signal_600_9 - slope_signal_900_6', '10min_slope_signal_600_9 - slope_signal_900_9', '10min_slope_signal_900_3 - slope_signal_900_6', '10min_slope_signal_900_3 - slope_signal_900_9', '10min_slope_signal_900_6 - slope_signal_900_9', '10min_slope_angle_300_3 - slope_angle_300_6', '10min_slope_angle_300_3 - slope_angle_300_9', '10min_slope_angle_300_3 - slope_angle_600_3', '10min_slope_angle_300_3 - slope_angle_600_6', '10min_slope_angle_300_3 - slope_angle_600_9', '10min_slope_angle_300_3 - slope_angle_900_3', '10min_slope_angle_300_3 - slope_angle_900_6', '10min_slope_angle_300_3 - slope_angle_900_9', '10min_slope_angle_300_6 - slope_angle_300_9', '10min_slope_angle_300_6 - slope_angle_600_3', '10min_slope_angle_300_6 - slope_angle_600_6', '10min_slope_angle_300_6 - slope_angle_600_9', '10min_slope_angle_300_6 - slope_angle_900_3', '10min_slope_angle_300_6 - slope_angle_900_6', '10min_slope_angle_300_6 - slope_angle_900_9', '10min_slope_angle_300_9 - slope_angle_600_3', '10min_slope_angle_300_9 - slope_angle_600_6', '10min_slope_angle_300_9 - slope_angle_600_9', '10min_slope_angle_300_9 - slope_angle_900_3', '10min_slope_angle_300_9 - slope_angle_900_6', '10min_slope_angle_300_9 - slope_angle_900_9', '10min_slope_angle_600_3 - slope_angle_600_6', '10min_slope_angle_600_3 - slope_angle_600_9', '10min_slope_angle_600_3 - slope_angle_900_3', '10min_slope_angle_600_3 - slope_angle_900_6', '10min_slope_angle_600_3 - slope_angle_900_9', '10min_slope_angle_600_6 - slope_angle_600_9', '10min_slope_angle_600_6 - slope_angle_900_3', '10min_slope_angle_600_6 - slope_angle_900_6', '10min_slope_angle_600_6 - slope_angle_900_9', '10min_slope_angle_600_9 - slope_angle_900_3', '10min_slope_angle_600_9 - slope_angle_900_6', '10min_slope_angle_600_9 - slope_angle_900_9', '10min_slope_angle_900_3 - slope_angle_900_6', '10min_slope_angle_900_3 - slope_angle_900_9', '10min_slope_angle_900_6 - slope_angle_900_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '15min_15min_OBV', '15min_15min_RSI_3', '15min_15min_MFI_3', '15min_15min_RSI_7', '15min_15min_MFI_7', '15min_15min_RSI_14', '15min_15min_MFI_14', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_Kal_300', '15min_15min_Close_Kal_300', '15min_15min_Kal_change_300', '15min_15min_Kal_prev_minus_now_300', '15min_15min_Kal_prev2_minus_now_300', '15min_15min_Kal_change2_300', '15min_15min_Kal_600', '15min_15min_Close_Kal_600', '15min_15min_Kal_change_600', '15min_15min_Kal_prev_minus_now_600', '15min_15min_Kal_prev2_minus_now_600', '15min_15min_Kal_change2_600', '15min_15min_Kal_900', '15min_15min_Close_Kal_900', '15min_15min_Kal_change_900', '15min_15min_Kal_prev_minus_now_900', '15min_15min_Kal_prev2_minus_now_900', '15min_15min_Kal_change2_900', '15min_15min_Kal_300_minus_Kal_600', '15min_15min_Kal_300_minus_Kal_900', '15min_15min_Kal_600_minus_Kal_900', '15min_15min_slope_div_300_3', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
-            "\n",
-            "NaN counts per column (sorted):\n",
-            "slope_angle_900_3 - slope_angle_900_6            29\n",
-            "slope_angle_600_9 - slope_angle_900_9            29\n",
-            "slope_angle_600_9 - slope_angle_900_6            29\n",
-            "slope_angle_600_9 - slope_angle_900_3            29\n",
-            "slope_angle_600_6 - slope_angle_900_9            29\n",
-            "                                                 ..\n",
-            "10min_slope_angle_300_3 - slope_angle_300_9       0\n",
-            "10min_slope_angle_300_3 - slope_angle_600_3       0\n",
-            "10min_slope_angle_300_3 - slope_angle_600_6       0\n",
-            "10min_slope_angle_300_3 - slope_angle_600_9       0\n",
-            "10min_slope_signal_600_6 - slope_signal_900_9     0\n",
-            "Length: 1098, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(df.shape,'\\n')\n",
-        "print('Label_Counts : ',df.label.value_counts(),'\\n')\n",
-        "print(list(df.columns), '\\n')\n",
-        "\n",
-        "# Add NaN count per column, sorted\n",
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(df.isnull().sum().sort_values(ascending=False), '\\n')\n",
-        "\n",
-        "#df.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Suezit_quoZ1",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Suezit_quoZ1",
-        "outputId": "0f50a746-96f2-4a2d-d5b0-6042fc52407e"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "DataFrame with difference features:\n",
-            "(67770, 851) \n",
-            "\n",
-            "Label_Counts :  label\n",
-            "1    34223\n",
-            "0    33547\n",
-            "Name: count, dtype: int64 \n",
-            "\n",
-            "['Date', 'label', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'MFI_3_diff', 'MFI_7_diff', 'MFI_14_diff', 'MFI_3 - MFI_7', 'MFI_3 - MFI_14', 'MFI_7 - MFI_14', 'OBV_diff', 'slope_div_300_3_diff', 'slope_signal_300_3_diff', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6_diff', 'slope_signal_300_6_diff', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9_diff', 'slope_signal_300_9_diff', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3_diff', 'slope_signal_600_3_diff', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6_diff', 'slope_signal_600_6_diff', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9_diff', 'slope_signal_600_9_diff', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3_diff', 'slope_signal_900_3_diff', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6_diff', 'slope_signal_900_6_diff', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9_diff', 'slope_signal_900_9_diff', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '10min_RSI_3_diff', '10min_RSI_7_diff', '10min_RSI_14_diff', '10min_RSI_3 - RSI_7', '10min_RSI_3 - RSI_14', '10min_RSI_7 - RSI_14', '10min_MFI_3_diff', '10min_MFI_7_diff', '10min_MFI_14_diff', '10min_MFI_3 - MFI_7', '10min_MFI_3 - MFI_14', '10min_MFI_7 - MFI_14', '10min_OBV_diff', '10min_slope_div_300_3_diff', '10min_slope_signal_300_3_diff', '10min_slope_angle_300_3_diff', '10min_slope_angle_signal_300_3_diff', '10min_slope_lin_reg_300_3_diff', '10min_slope_lin_reg_signal_300_3_diff', '10min_slope_div_300_6_diff', '10min_slope_signal_300_6_diff', '10min_slope_angle_300_6_diff', '10min_slope_angle_signal_300_6_diff', '10min_slope_lin_reg_300_6_diff', '10min_slope_lin_reg_signal_300_6_diff', '10min_slope_div_300_9_diff', '10min_slope_signal_300_9_diff', '10min_slope_angle_300_9_diff', '10min_slope_angle_signal_300_9_diff', '10min_slope_lin_reg_300_9_diff', '10min_slope_lin_reg_signal_300_9_diff', '10min_slope_div_600_3_diff', '10min_slope_signal_600_3_diff', '10min_slope_angle_600_3_diff', '10min_slope_angle_signal_600_3_diff', '10min_slope_lin_reg_600_3_diff', '10min_slope_lin_reg_signal_600_3_diff', '10min_slope_div_600_6_diff', '10min_slope_signal_600_6_diff', '10min_slope_angle_600_6_diff', '10min_slope_angle_signal_600_6_diff', '10min_slope_lin_reg_600_6_diff', '10min_slope_lin_reg_signal_600_6_diff', '10min_slope_div_600_9_diff', '10min_slope_signal_600_9_diff', '10min_slope_angle_600_9_diff', '10min_slope_angle_signal_600_9_diff', '10min_slope_lin_reg_600_9_diff', '10min_slope_lin_reg_signal_600_9_diff', '10min_slope_div_900_3_diff', '10min_slope_signal_900_3_diff', '10min_slope_angle_900_3_diff', '10min_slope_angle_signal_900_3_diff', '10min_slope_lin_reg_900_3_diff', '10min_slope_lin_reg_signal_900_3_diff', '10min_slope_div_900_6_diff', '10min_slope_signal_900_6_diff', '10min_slope_angle_900_6_diff', '10min_slope_angle_signal_900_6_diff', '10min_slope_lin_reg_900_6_diff', '10min_slope_lin_reg_signal_900_6_diff', '10min_slope_div_900_9_diff', '10min_slope_signal_900_9_diff', '10min_slope_angle_900_9_diff', '10min_slope_angle_signal_900_9_diff', '10min_slope_lin_reg_900_9_diff', '10min_slope_lin_reg_signal_900_9_diff', '10min_slope_div_300_3 - slope_div_300_6', '10min_slope_div_300_3 - slope_div_300_9', '10min_slope_div_300_3 - slope_div_600_3', '10min_slope_div_300_3 - slope_div_600_6', '10min_slope_div_300_3 - slope_div_600_9', '10min_slope_div_300_3 - slope_div_900_3', '10min_slope_div_300_3 - slope_div_900_6', '10min_slope_div_300_3 - slope_div_900_9', '10min_slope_div_300_6 - slope_div_300_9', '10min_slope_div_300_6 - slope_div_600_3', '10min_slope_div_300_6 - slope_div_600_6', '10min_slope_div_300_6 - slope_div_600_9', '10min_slope_div_300_6 - slope_div_900_3', '10min_slope_div_300_6 - slope_div_900_6', '10min_slope_div_300_6 - slope_div_900_9', '10min_slope_div_300_9 - slope_div_600_3', '10min_slope_div_300_9 - slope_div_600_6', '10min_slope_div_300_9 - slope_div_600_9', '10min_slope_div_300_9 - slope_div_900_3', '10min_slope_div_300_9 - slope_div_900_6', '10min_slope_div_300_9 - slope_div_900_9', '10min_slope_div_600_3 - slope_div_600_6', '10min_slope_div_600_3 - slope_div_600_9', '10min_slope_div_600_3 - slope_div_900_3', '10min_slope_div_600_3 - slope_div_900_6', '10min_slope_div_600_3 - slope_div_900_9', '10min_slope_div_600_6 - slope_div_600_9', '10min_slope_div_600_6 - slope_div_900_3', '10min_slope_div_600_6 - slope_div_900_6', '10min_slope_div_600_6 - slope_div_900_9', '10min_slope_div_600_9 - slope_div_900_3', '10min_slope_div_600_9 - slope_div_900_6', '10min_slope_div_600_9 - slope_div_900_9', '10min_slope_div_900_3 - slope_div_900_6', '10min_slope_div_900_3 - slope_div_900_9', '10min_slope_div_900_6 - slope_div_900_9', '10min_slope_signal_300_3 - slope_signal_300_6', '10min_slope_signal_300_3 - slope_signal_300_9', '10min_slope_signal_300_3 - slope_signal_600_3', '10min_slope_signal_300_3 - slope_signal_600_6', '10min_slope_signal_300_3 - slope_signal_600_9', '10min_slope_signal_300_3 - slope_signal_900_3', '10min_slope_signal_300_3 - slope_signal_900_6', '10min_slope_signal_300_3 - slope_signal_900_9', '10min_slope_signal_300_6 - slope_signal_300_9', '10min_slope_signal_300_6 - slope_signal_600_3', '10min_slope_signal_300_6 - slope_signal_600_6', '10min_slope_signal_300_6 - slope_signal_600_9', '10min_slope_signal_300_6 - slope_signal_900_3', '10min_slope_signal_300_6 - slope_signal_900_6', '10min_slope_signal_300_6 - slope_signal_900_9', '10min_slope_signal_300_9 - slope_signal_600_3', '10min_slope_signal_300_9 - slope_signal_600_6', '10min_slope_signal_300_9 - slope_signal_600_9', '10min_slope_signal_300_9 - slope_signal_900_3', '10min_slope_signal_300_9 - slope_signal_900_6', '10min_slope_signal_300_9 - slope_signal_900_9', '10min_slope_signal_600_3 - slope_signal_600_6', '10min_slope_signal_600_3 - slope_signal_600_9', '10min_slope_signal_600_3 - slope_signal_900_3', '10min_slope_signal_600_3 - slope_signal_900_6', '10min_slope_signal_600_3 - slope_signal_900_9', '10min_slope_signal_600_6 - slope_signal_600_9', '10min_slope_signal_600_6 - slope_signal_900_3', '10min_slope_signal_600_6 - slope_signal_900_6', '10min_slope_signal_600_6 - slope_signal_900_9', '10min_slope_signal_600_9 - slope_signal_900_3', '10min_slope_signal_600_9 - slope_signal_900_6', '10min_slope_signal_600_9 - slope_signal_900_9', '10min_slope_signal_900_3 - slope_signal_900_6', '10min_slope_signal_900_3 - slope_signal_900_9', '10min_slope_signal_900_6 - slope_signal_900_9', '10min_slope_angle_300_3 - slope_angle_300_6', '10min_slope_angle_300_3 - slope_angle_300_9', '10min_slope_angle_300_3 - slope_angle_600_3', '10min_slope_angle_300_3 - slope_angle_600_6', '10min_slope_angle_300_3 - slope_angle_600_9', '10min_slope_angle_300_3 - slope_angle_900_3', '10min_slope_angle_300_3 - slope_angle_900_6', '10min_slope_angle_300_3 - slope_angle_900_9', '10min_slope_angle_300_6 - slope_angle_300_9', '10min_slope_angle_300_6 - slope_angle_600_3', '10min_slope_angle_300_6 - slope_angle_600_6', '10min_slope_angle_300_6 - slope_angle_600_9', '10min_slope_angle_300_6 - slope_angle_900_3', '10min_slope_angle_300_6 - slope_angle_900_6', '10min_slope_angle_300_6 - slope_angle_900_9', '10min_slope_angle_300_9 - slope_angle_600_3', '10min_slope_angle_300_9 - slope_angle_600_6', '10min_slope_angle_300_9 - slope_angle_600_9', '10min_slope_angle_300_9 - slope_angle_900_3', '10min_slope_angle_300_9 - slope_angle_900_6', '10min_slope_angle_300_9 - slope_angle_900_9', '10min_slope_angle_600_3 - slope_angle_600_6', '10min_slope_angle_600_3 - slope_angle_600_9', '10min_slope_angle_600_3 - slope_angle_900_3', '10min_slope_angle_600_3 - slope_angle_900_6', '10min_slope_angle_600_3 - slope_angle_900_9', '10min_slope_angle_600_6 - slope_angle_600_9', '10min_slope_angle_600_6 - slope_angle_900_3', '10min_slope_angle_600_6 - slope_angle_900_6', '10min_slope_angle_600_6 - slope_angle_900_9', '10min_slope_angle_600_9 - slope_angle_900_3', '10min_slope_angle_600_9 - slope_angle_900_6', '10min_slope_angle_600_9 - slope_angle_900_9', '10min_slope_angle_900_3 - slope_angle_900_6', '10min_slope_angle_900_3 - slope_angle_900_9', '10min_slope_angle_900_6 - slope_angle_900_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
-            "\n",
-            "NaN counts per column (sorted):\n",
-            "slope_angle_signal_300_9 - slope_angle_signal_900_6          29\n",
-            "slope_angle_signal_300_9 - slope_angle_signal_900_3          29\n",
-            "slope_angle_signal_300_9 - slope_angle_signal_600_9          29\n",
-            "slope_angle_signal_300_9 - slope_angle_signal_600_6          29\n",
-            "slope_angle_signal_300_9 - slope_angle_signal_600_3          29\n",
-            "                                                             ..\n",
-            "10min_slope_angle_signal_300_6 - slope_angle_signal_900_3     0\n",
-            "10min_slope_angle_signal_300_6 - slope_angle_signal_900_6     0\n",
-            "10min_slope_angle_signal_300_6 - slope_angle_signal_900_9     0\n",
-            "10min_slope_angle_signal_300_9 - slope_angle_signal_600_3     0\n",
-            "10min_slope_angle_signal_300_3 - slope_angle_signal_900_9     0\n",
-            "Length: 851, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Select features containing 'diff' or '-' in their names\n",
-        "diff_features = df.filter(regex='diff|-')\n",
-        "\n",
-        "# Create a new dataframe with the Date column, label and the selected features\n",
-        "df_diff = pd.concat([df[['Date', 'label']], diff_features], axis=1)\n",
-        "\n",
-        "print(\"DataFrame with difference features:\")\n",
-        "print(df_diff.shape,'\\n')\n",
-        "print('Label_Counts : ',df_diff.label.value_counts(),'\\n')\n",
-        "print(list(df_diff.columns), '\\n')\n",
-        "\n",
-        "# Add NaN count per column, sorted\n",
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(df_diff.isnull().sum().sort_values(ascending=False), '\\n')\n",
-        "\n",
-        "#df_diff.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4TPpba7UChUY",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4TPpba7UChUY",
-        "outputId": "2f81a31c-2de8-4fbd-f1c6-a847eac106a7"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Flipped 33857 rows with Open_Trade = -1.\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Align feature directions so that shorts mirror longs\n",
-        "if 'Open_Trade' not in df.columns:\n",
-        "    raise KeyError(\"'Open_Trade' column is required in df to flip feature signs.\")\n",
-        "\n",
-        "# Attach the trade direction to the diff dataframe (kept for reference).\n",
-        "df_diff = df_diff.merge(df[['Date', 'Open_Trade']], on='Date', how='left')\n",
-        "\n",
-        "# Identify feature columns to flip (exclude identifiers/targets).\n",
-        "feature_cols = [col for col in df_diff.columns if col not in ['Date', 'label', 'Open_Trade']]\n",
-        "short_mask = df_diff['Open_Trade'] == -1\n",
-        "\n",
-        "if short_mask.any():\n",
-        "    df_diff.loc[short_mask, feature_cols] = df_diff.loc[short_mask, feature_cols] * -1\n",
-        "    print(f\"Flipped {short_mask.sum()} rows with Open_Trade = -1.\")\n",
-        "else:\n",
-        "    print(\"No rows with Open_Trade = -1 were found.\")\n",
-        "\n",
-        "# Reorder columns so Open_Trade stays next to the label for downstream steps.\n",
-        "ordered_cols = ['Date', 'label', 'Open_Trade'] + [col for col in feature_cols]\n",
-        "df_diff = df_diff[ordered_cols]\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "pQa8_4GpvRRf",
-      "metadata": {
-        "id": "pQa8_4GpvRRf"
-      },
-      "outputs": [],
-      "source": [
-        "df = df_diff.copy()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "lBtQecOO08zB",
-      "metadata": {
-        "id": "lBtQecOO08zB"
-      },
-      "source": [
-        "## ML"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8rlkmypd9DJj",
-      "metadata": {
-        "id": "8rlkmypd9DJj"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 1. ENTRENAR Y OBTENER IMPORTANCIAS =====================\n",
-        "def compute_xgb_importance(\n",
-        "    X: pd.DataFrame,\n",
-        "    y: pd.Series,\n",
-        "    task: str = \"classification\",\n",
-        "    random_state: int = 42,\n",
-        "    **xgb_params: Any\n",
-        ") -> Tuple[pd.DataFrame, Any]:\n",
-        "    \"\"\"\n",
-        "    Entrena un modelo XGBoost y devuelve:\n",
-        "      - imp_df: DataFrame con 'feature', 'importance' y 'cum_importance'.\n",
-        "      - model : modelo ya entrenado.\n",
-        "\n",
-        "    Soporta:\n",
-        "      • Clasificación binaria o multiclase (detecta nº de clases).\n",
-        "      • Regresión (si task != 'classification').\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X : pd.DataFrame\n",
-        "        Matriz de características (sin la columna objetivo).\n",
-        "    y : pd.Series\n",
-        "        Etiquetas objetivo. Puede ser binaria (0/1) o multiclase (0..K-1).\n",
-        "    task : str, opcional\n",
-        "        \"classification\" (default) o \"regression\".\n",
-        "    random_state : int, opcional\n",
-        "        Semilla para reproducibilidad.\n",
-        "    **xgb_params : dict\n",
-        "        Parámetros adicionales para el estimador de XGBoost.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (imp_df, model)\n",
-        "        imp_df : DataFrame con importancias y su acumulado.\n",
-        "        model  : instancia entrenada de XGBClassifier / XGBRegressor.\n",
-        "    \"\"\"\n",
-        "    default_params: Dict[str, Any] = dict(\n",
-        "        n_estimators=500,\n",
-        "        max_depth=6,\n",
-        "        learning_rate=0.05,\n",
-        "        subsample=0.8,\n",
-        "        colsample_bytree=0.8,\n",
-        "        random_state=random_state,\n",
-        "        n_jobs=-1,\n",
-        "        tree_method=\"hist\",\n",
-        "    )\n",
-        "    default_params.update(xgb_params)\n",
-        "\n",
-        "    if task == \"classification\":\n",
-        "        # Detectar nº de clases\n",
-        "        classes = np.unique(y)\n",
-        "        n_classes = len(classes)\n",
-        "\n",
-        "        # XGBClassifier ajusta objetivo automáticamente, pero lo explicitamos:\n",
-        "        if n_classes > 2:\n",
-        "            default_params.setdefault(\"objective\", \"multi:softprob\")\n",
-        "            default_params.setdefault(\"num_class\", n_classes)\n",
-        "            eval_metric = \"mlogloss\"\n",
-        "        else:\n",
-        "            default_params.setdefault(\"objective\", \"binary:logistic\")\n",
-        "            eval_metric = \"logloss\"\n",
-        "\n",
-        "        model = XGBClassifier(eval_metric=eval_metric, **default_params)\n",
-        "\n",
-        "    else:\n",
-        "        model = XGBRegressor(**default_params)\n",
-        "\n",
-        "    model.fit(X, y)\n",
-        "\n",
-        "    imp_df = (\n",
-        "        pd.DataFrame({\n",
-        "            \"feature\": X.columns,\n",
-        "            \"importance\": model.feature_importances_\n",
-        "        })\n",
-        "        .sort_values(\"importance\", ascending=False)\n",
-        "        .reset_index(drop=True)\n",
-        "    )\n",
-        "    total_imp = imp_df[\"importance\"].sum()\n",
-        "    if total_imp == 0:\n",
-        "        # Evitar división por cero si el modelo devuelve todo cero (raro, pero posible)\n",
-        "        imp_df[\"cum_importance\"] = 0.0\n",
-        "    else:\n",
-        "        imp_df[\"cum_importance\"] = imp_df[\"importance\"].cumsum() / total_imp\n",
-        "\n",
-        "    return imp_df, model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3r9Di4Xx9DOU",
-      "metadata": {
-        "id": "3r9Di4Xx9DOU"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 2. SELECCIÓN DE FEATURES =====================\n",
-        "def select_features_with_importance(\n",
-        "    X: pd.DataFrame,\n",
-        "    imp_df: pd.DataFrame,\n",
-        "    top_n: Optional[int] = None,\n",
-        "    threshold: Optional[str | float] = None,\n",
-        "    cum_threshold: Optional[float] = 0.8\n",
-        ") -> Tuple[pd.DataFrame, List[str]]:\n",
-        "    \"\"\"\n",
-        "    Selección flexible de variables a partir de importancias de XGBoost.\n",
-        "\n",
-        "    Reglas:\n",
-        "      - Si top_n no es None           => usa el top_n.\n",
-        "      - Else si cum_threshold no None => usa importancia acumulada (p.ej. 0.8 = 80%).\n",
-        "      - Else usa threshold ('median', 'mean' o valor numérico).\n",
-        "\n",
-        "    Devuelve (X_reducido, lista_de_features).\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X : pd.DataFrame\n",
-        "        Matriz de características original.\n",
-        "    imp_df : pd.DataFrame\n",
-        "        DataFrame devuelto por compute_xgb_importance.\n",
-        "    top_n : int | None\n",
-        "        Número fijo de variables a conservar.\n",
-        "    threshold : str | float | None\n",
-        "        Umbral de importancia. Si str, usar 'median' o 'mean'.\n",
-        "    cum_threshold : float | None\n",
-        "        Porcentaje acumulado de importancia (0-1). Si None, se ignora.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (X_sel, keep)\n",
-        "        X_sel : subset de X con columnas seleccionadas.\n",
-        "        keep  : lista de nombres de columnas seleccionadas.\n",
-        "    \"\"\"\n",
-        "    if top_n is not None:\n",
-        "        keep = imp_df.head(top_n)[\"feature\"].tolist()\n",
-        "\n",
-        "    elif cum_threshold is not None:\n",
-        "        keep_mask = imp_df[\"cum_importance\"] <= float(cum_threshold)\n",
-        "        keep = imp_df.loc[keep_mask, \"feature\"].tolist()\n",
-        "        # asegurar que haya al menos una más para no quedarnos exactamente en el corte\n",
-        "        if len(keep) < len(imp_df):\n",
-        "            keep.append(imp_df.iloc[len(keep)][\"feature\"])\n",
-        "\n",
-        "    else:\n",
-        "        if threshold is None:\n",
-        "            threshold = \"median\"\n",
-        "        if isinstance(threshold, str):\n",
-        "            thr_val = imp_df[\"importance\"].agg(threshold)\n",
-        "        else:\n",
-        "            thr_val = float(threshold)\n",
-        "        keep = imp_df.loc[imp_df[\"importance\"] >= thr_val, \"feature\"].tolist()\n",
-        "\n",
-        "    return X[keep], keep"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "tCDZCTz2_v9z",
-      "metadata": {
-        "id": "tCDZCTz2_v9z"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 3. BÚSQUEDA DEL MEJOR UMBRAL ACUMULADO =====================\n",
-        "def find_best_cum_threshold(\n",
-        "    X_train: pd.DataFrame,\n",
-        "    y_train: pd.Series,\n",
-        "    X_valid: pd.DataFrame,\n",
-        "    y_valid: pd.Series,\n",
-        "    task: str = \"classification\",\n",
-        "    thresholds: Tuple[float, ...] = (0.6, 0.7, 0.8, 0.9),\n",
-        "    random_state: int = 42,\n",
-        "    metric: str = \"auto\",\n",
-        "    **xgb_params: Any\n",
-        ") -> Tuple[float, pd.DataFrame, pd.DataFrame]:\n",
-        "    \"\"\"\n",
-        "    Entrena un XGB en train, calcula importancias y prueba varios umbrales\n",
-        "    acumulados para ver cuál da la mejor métrica en valid.\n",
-        "\n",
-        "    Para CLASIFICACIÓN:\n",
-        "        - Detecta nº de clases.\n",
-        "        - Métrica por defecto (metric=\"auto\"):\n",
-        "            • Binaria: ROC-AUC (probabilidades de la clase positiva).\n",
-        "            • Multiclase: ROC-AUC macro OVR (usa predict_proba).\n",
-        "          Alternativas: metric=\"f1_macro\", \"accuracy\", \"logloss\" (se MINIMIZA).\n",
-        "    Para REGRESIÓN:\n",
-        "        - Usa R^2.\n",
-        "\n",
-        "    Devuelve:\n",
-        "        best_thr, res_df_ordenado_por_score_desc, imp_df\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X_train, y_train, X_valid, y_valid : pd.DataFrame / pd.Series\n",
-        "        Particiones de entrenamiento y validación.\n",
-        "    task : str\n",
-        "        \"classification\" (default) o \"regression\".\n",
-        "    thresholds : tuple[float, ...]\n",
-        "        Valores de umbral de importancia acumulada a evaluar (0-1).\n",
-        "    random_state : int\n",
-        "        Semilla para reproducibilidad.\n",
-        "    metric : str\n",
-        "        \"auto\" (default), \"roc_auc\", \"f1_macro\", \"accuracy\", \"logloss\" (clasif) o \"r2\" (regresión).\n",
-        "    **xgb_params : dict\n",
-        "        Parámetros extra para el estimador de XGBoost (pasan a compute y a los modelos internos).\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (best_thr, res_df, imp_df)\n",
-        "        best_thr : float\n",
-        "            Umbral con mejor score (o menor logloss si metric='logloss').\n",
-        "        res_df : pd.DataFrame\n",
-        "            Tabla con resultados por umbral (n_features, score).\n",
-        "        imp_df : pd.DataFrame\n",
-        "            Importancias calculadas en X_train / y_train.\n",
-        "    \"\"\"\n",
-        "    imp_df, _ = compute_xgb_importance(\n",
-        "        X_train, y_train, task=task, random_state=random_state, **xgb_params\n",
-        "    )\n",
-        "\n",
-        "    results = []\n",
-        "\n",
-        "    # Detectar nº de clases si es clasificación\n",
-        "    if task == \"classification\":\n",
-        "        classes = np.unique(y_train)\n",
-        "        n_classes = len(classes)\n",
-        "        if metric == \"auto\":\n",
-        "            metric_to_use = \"roc_auc\" if n_classes == 2 else \"roc_auc\"\n",
-        "        else:\n",
-        "            metric_to_use = metric\n",
-        "    else:\n",
-        "        metric_to_use = \"r2\" if metric == \"auto\" else metric\n",
-        "\n",
-        "    for thr in thresholds:\n",
-        "        X_tr_sel, cols = select_features_with_importance(\n",
-        "            X_train, imp_df, cum_threshold=thr, top_n=None, threshold=None\n",
-        "        )\n",
-        "        X_va_sel = X_valid[cols]\n",
-        "\n",
-        "        if task == \"classification\":\n",
-        "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
-        "            params.update(xgb_params)\n",
-        "\n",
-        "            if n_classes > 2:\n",
-        "                params.setdefault(\"objective\", \"multi:softprob\")\n",
-        "                params.setdefault(\"num_class\", n_classes)\n",
-        "                eval_metric = \"mlogloss\"\n",
-        "            else:\n",
-        "                params.setdefault(\"objective\", \"binary:logistic\")\n",
-        "                eval_metric = \"logloss\"\n",
-        "\n",
-        "            model_sel = XGBClassifier(eval_metric=eval_metric, **params)\n",
-        "            model_sel.fit(X_tr_sel, y_train)\n",
-        "\n",
-        "            # Probabilidades y predicciones\n",
-        "            proba = model_sel.predict_proba(X_va_sel)\n",
-        "            pred  = np.argmax(proba, axis=1) if n_classes > 2 else (proba[:, 1] >= 0.5).astype(int)\n",
-        "\n",
-        "            # Calcular métrica\n",
-        "            if metric_to_use == \"roc_auc\":\n",
-        "                if n_classes == 2:\n",
-        "                    score = roc_auc_score(y_valid, proba[:, 1])\n",
-        "                else:\n",
-        "                    # AUC macro One-vs-Rest\n",
-        "                    score = roc_auc_score(y_valid, proba, multi_class=\"ovr\", average=\"macro\")\n",
-        "            elif metric_to_use == \"f1_macro\":\n",
-        "                score = f1_score(y_valid, pred, average=\"macro\")\n",
-        "            elif metric_to_use == \"accuracy\":\n",
-        "                score = accuracy_score(y_valid, pred)\n",
-        "            elif metric_to_use == \"logloss\":\n",
-        "                # En este caso, menor es mejor. Guardamos negativo para mantener criterio \"mayor mejor\".\n",
-        "                score = -log_loss(y_valid, proba, labels=np.unique(y_train))\n",
-        "            else:\n",
-        "                raise ValueError(f\"Métrica no soportada: {metric_to_use}\")\n",
-        "\n",
-        "        else:\n",
-        "            # REGRESIÓN\n",
-        "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
-        "            params.update(xgb_params)\n",
-        "            model_sel = XGBRegressor(**params)\n",
-        "            model_sel.fit(X_tr_sel, y_train)\n",
-        "            pred = model_sel.predict(X_va_sel)\n",
-        "\n",
-        "            if metric_to_use == \"r2\":\n",
-        "                score = r2_score(y_valid, pred)\n",
-        "            else:\n",
-        "                raise ValueError(f\"Métrica de regresión no soportada: {metric_to_use}\")\n",
-        "\n",
-        "        results.append({\"cum_threshold\": thr, \"n_features\": len(cols), \"score\": score})\n",
-        "\n",
-        "    # Ordenar (si usamos logloss negado, mayor sigue siendo mejor)\n",
-        "    res_df = pd.DataFrame(results).sort_values(\"score\", ascending=False).reset_index(drop=True)\n",
-        "    best_thr = float(res_df.iloc[0][\"cum_threshold\"])\n",
-        "    return best_thr, res_df, imp_df"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "R0Dm8ZPGcBr7",
-      "metadata": {
-        "id": "R0Dm8ZPGcBr7"
-      },
-      "outputs": [],
-      "source": [
-        "def remove_highly_correlated_features(df, threshold=0.9):\n",
-        "\n",
-        "    # Solo numéricos para evitar errores y acelerar\n",
-        "    corr_matrix = df.corr(numeric_only=True).abs()\n",
-        "    upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape, dtype=bool), k=1))\n",
-        "\n",
-        "    to_drop = []\n",
-        "    for col in tqdm(upper.columns, desc=f\"Pruning corr > {threshold}\", unit=\"col\", leave=False):\n",
-        "        if (upper[col] > threshold).any():\n",
-        "            to_drop.append(col)\n",
-        "\n",
-        "    return df.drop(columns=to_drop, errors=\"ignore\"), to_drop\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "WodcQEBJ_wAW",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 850,
-          "referenced_widgets": [
-            "9609059e3a254435ad1ac68a6a404d33",
-            "4290faf2225a4d32bde385b6521e9ab2",
-            "74a6582880894069ad603643f92d7690",
-            "da5e8d42499b429d9b286ba00635148a",
-            "aaaaf872df124159b5d3af65c70d3e83",
-            "24978cca329a49de8aa7134bfb61be2b",
-            "fc87caee4db1426fadc04572c74617b5",
-            "31586bc636e84cf8a9a8e287c337ded4",
-            "f033e19b4ce74802907e77d074d358dd",
-            "cde12ad7e71c47a7a3429ced6e034fcd",
-            "3abde22d56a04951806f97ceb50efa92"
-          ]
-        },
-        "id": "WodcQEBJ_wAW",
-        "outputId": "95371cc4-7f94-4d1e-cd81-846cddd81d9e"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9609059e3a254435ad1ac68a6a404d33",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Pruning corr > 0.9:   0%|          | 0/850 [00:00<?, ?col/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Logistic regression CV accuracy: 0.611824623560673\n",
-            "=== Importancias XGBoost ===\n",
-            "                                            feature  importance  \\\n",
-            "0                                  10min_RSI_3_diff    0.028439   \n",
-            "1                               10min_RSI_3 - RSI_7    0.024041   \n",
-            "2                      10min_slope_angle_300_3_diff    0.014504   \n",
-            "3                              10min_RSI_7 - RSI_14    0.007869   \n",
-            "4                                    RSI_7 - RSI_14    0.007382   \n",
-            "5                        10min_slope_div_300_3_diff    0.007044   \n",
-            "6                                        RSI_3_diff    0.006131   \n",
-            "7                                    10min_OBV_diff    0.005756   \n",
-            "8                     10min_slope_signal_900_9_diff    0.005219   \n",
-            "9                      10min_slope_angle_900_6_diff    0.005199   \n",
-            "10                                 10min_MFI_7_diff    0.005177   \n",
-            "11  10min_slope_lin_reg_300_3 - slope_lin_reg_600_3    0.005173   \n",
-            "12                             slope_div_300_6_diff    0.004984   \n",
-            "13      10min_slope_angle_600_3 - slope_angle_900_3    0.004778   \n",
-            "14                                 10min_MFI_3_diff    0.004606   \n",
-            "15      10min_slope_angle_300_3 - slope_angle_300_9    0.004583   \n",
-            "16                           slope_angle_300_6_diff    0.004534   \n",
-            "17                             slope_div_300_3_diff    0.004482   \n",
-            "18                     10min_slope_angle_900_9_diff    0.004434   \n",
-            "19      10min_slope_angle_300_6 - slope_angle_300_9    0.004397   \n",
-            "\n",
-            "    cum_importance  \n",
-            "0         0.028439  \n",
-            "1         0.052480  \n",
-            "2         0.066984  \n",
-            "3         0.074852  \n",
-            "4         0.082234  \n",
-            "5         0.089279  \n",
-            "6         0.095409  \n",
-            "7         0.101166  \n",
-            "8         0.106385  \n",
-            "9         0.111584  \n",
-            "10        0.116761  \n",
-            "11        0.121933  \n",
-            "12        0.126917  \n",
-            "13        0.131695  \n",
-            "14        0.136301  \n",
-            "15        0.140885  \n",
-            "16        0.145419  \n",
-            "17        0.149901  \n",
-            "18        0.154335  \n",
-            "19        0.158732  \n",
-            "Total features: 252\n",
-            "Features seleccionadas: 192\n",
-            "XGBoost CV accuracy: 0.6071302037201063\n"
-          ]
-        }
-      ],
-      "source": [
-        "# ===================== 3. PIPELINE PRINCIPAL =====================\n",
-        "df = df.dropna()\n",
-        "y = df['label']\n",
-        "X = df.iloc[:, 2:]\n",
-        "\n",
-        "# --- 3.3 Split temporal (ejemplo simple 80/20) ---\n",
-        "split_idx = int(len(X) * 0.8)\n",
-        "X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]\n",
-        "y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]\n",
-        "\n",
-        "# --- 3.4 Remove correlated features ---\n",
-        "X_train_filtered, dropped_features = remove_highly_correlated_features(X_train, threshold=0.9)\n",
-        "X_test_filtered = X_test.drop(columns=dropped_features)\n",
-        "\n",
-        "# Baseline logistic regression with time-series CV\n",
-        "scaler = StandardScaler()\n",
-        "X_scaled = scaler.fit_transform(X_train_filtered)\n",
-        "tscv = TimeSeriesSplit(n_splits=5)\n",
-        "baseline = cross_val_score(LogisticRegression(max_iter=1000), X_scaled, y_train, cv=tscv).mean()\n",
-        "print('Logistic regression CV accuracy:', baseline)\n",
-        "\n",
-        "# --- 3.5 Importancias con XGBoost ---\n",
-        "imp_df, xgb_model = compute_xgb_importance(X_train_filtered, y_train, task='classification')\n",
-        "\n",
-        "print('=== Importancias XGBoost ===')\n",
-        "print(imp_df.head(20))\n",
-        "print(f'Total features: {len(imp_df)}')\n",
-        "\n",
-        "# --- 3.6 Selección (elige una opción) ---\n",
-        "X_train_sel, keep_cols = select_features_with_importance(X_train_filtered, imp_df, cum_threshold=0.8)\n",
-        "X_test_sel = X_test_filtered[keep_cols]\n",
-        "\n",
-        "print(f'Features seleccionadas: {len(keep_cols)}')\n",
-        "importance_map = imp_df.set_index(\"feature\")[\"importance\"]\n",
-        "selected_importances = pd.DataFrame({\n",
-        "    \"feature\": keep_cols,\n",
-        "    \"importance\": importance_map.reindex(keep_cols).values\n",
-        "})\n",
-        "selected_importances.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_ImportantCols.csv', index=False)\n",
-        "\n",
-        "# Save dataset with selected features\n",
-        "df_selected = df[['Date', 'label'] + keep_cols]\n",
-        "df_selected.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_Features.csv', index=False)\n",
-        "\n",
-        "# Time-series cross-validation with XGBoost\n",
-        "xgb_cv = XGBClassifier(eval_metric='logloss', n_estimators=500, max_depth=6, learning_rate=0.05, subsample=0.8, colsample_bytree=0.8, random_state=42, n_jobs=-1, tree_method='hist')\n",
-        "xgb_scores = cross_val_score(xgb_cv, X_train_sel, y_train, cv=tscv, scoring='accuracy')\n",
-        "print('XGBoost CV accuracy:', xgb_scores.mean())\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2RFfhHT2AwAJ",
-      "metadata": {
-        "id": "2RFfhHT2AwAJ"
-      },
-      "source": [
-        "# Encode_Features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "jRl6BZWUZ-WI",
-      "metadata": {
-        "id": "jRl6BZWUZ-WI"
-      },
-      "outputs": [],
-      "source": [
-        "### Encode Features\n",
-        "\n",
-        "cols_to_scale = df.columns[1:]\n",
-        "model = Sequential()\n",
-        "model.add(Dense(64, activation='relu', input_shape=(len(cols_to_scale),)))\n",
-        "model.add(Dense(32, activation='relu'))\n",
-        "model.add(Dense(8, activation='relu'))\n",
-        "model.add(Dense(32, activation='relu'))\n",
-        "model.add(Dense(64, activation='relu'))\n",
-        "model.add(Dense(len(cols_to_scale), activation='linear'))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3hmEdGGclTxU",
-      "metadata": {
-        "id": "3hmEdGGclTxU"
-      },
-      "outputs": [],
-      "source": [
-        "# Compile the model\n",
-        "model.compile(optimizer='adam', loss='mean_squared_error')\n",
-        "\n",
-        "# Train the autoencoder using the scaled features\n",
-        "cols_to_scale = df.columns[1:]\n",
-        "autoencoder = model.fit(df[cols_to_scale], df[cols_to_scale], epochs=100, batch_size=32)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gfyyEElYwPQ_",
-      "metadata": {
-        "id": "gfyyEElYwPQ_"
-      },
-      "outputs": [],
-      "source": [
-        "# Plot the graph of Loss versus Epoch\n",
-        "plt.plot(autoencoder.history[\"loss\"])\n",
-        "plt.plot(figsize=(15, 7))\n",
-        "plt.title('Loss vs. Epoch', fontsize=16)\n",
-        "plt.xlabel('Epoch', fontsize=14)\n",
-        "plt.ylabel('Loss', fontsize=14)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "DmJ8a4TuwPRA",
-      "metadata": {
-        "id": "DmJ8a4TuwPRA"
-      },
-      "outputs": [],
-      "source": [
-        "# Select the columns to be scaled (from index 6 onwards)\n",
-        "cols_to_scale = df.columns[1:]\n",
-        "\n",
-        "reconstruction_error = np.square(df[cols_to_scale] - model.predict(df[cols_to_scale]))\n",
-        "feature_reconstruction_error = np.mean(reconstruction_error, axis=0)\n",
-        "feature_reconstruction_error_df = pd.DataFrame(feature_reconstruction_error, index=cols_to_scale).T\n",
-        "\n",
-        "overall_reconstruction_error = feature_reconstruction_error_df.mean().mean()\n",
-        "print('\\n','\\n', f\"\\033[1mOverall Reconstruction Error: {overall_reconstruction_error:.4f}\\033[0m\", '\\n','\\n')\n",
-        "\n",
-        "# Print the individual features error in a horizontal format\n",
-        "display(feature_reconstruction_error_df)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Nr2MdqXlwPRA",
-      "metadata": {
-        "id": "Nr2MdqXlwPRA"
-      },
-      "source": [
-        "You can see that certain features have very low error, but some might have an error as high as 0.2. However, overall the error rate is 0.04 and thus, we can move forward.\n",
-        "\n",
-        "Let us now move towards finding the reduced features. This is done in the following steps.\n",
-        "\n",
-        "**Extract the encoder part of the autoencoder**:\n",
-        "You will extract the encoder part of the autoencoder, which compresses the data into a reduced-dimensional representation. This part includes the first three layers of the model.\n",
-        "\n",
-        "Use the encoder to obtain the reduced-dimensional representation:\n",
-        "We use the encoder to transform the input test data `(X_test)` into a reduced-dimensional representation `(X_encoded_test)`. This represents an encoded version of the input data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "pvDj7316wPRA",
-      "metadata": {
-        "id": "pvDj7316wPRA",
-        "scrolled": true
-      },
-      "outputs": [],
-      "source": [
-        "# Re-create the encoder from the layers of the successfully trained model\n",
-        "encoder = Sequential(model.layers[:3])\n",
-        "X_encoded_test = encoder.predict(X[cols_to_scale]) # Use the scaled features for prediction"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bmIW_EmxwPRB",
-      "metadata": {
-        "id": "bmIW_EmxwPRB"
-      },
-      "outputs": [],
-      "source": [
-        "\n",
-        "# ── NUEVO: añade la columna Date al DataFrame codificado ──\n",
-        "dates = df['Date'].reset_index(drop=True)                 # 1) copia la fecha\n",
-        "features_enc = pd.DataFrame(                              # 2) crea el DF codificado\n",
-        "    X_encoded_test,\n",
-        "    columns=[f'Encoded_{i}' for i in range(X_encoded_test.shape[1])]\n",
-        ")\n",
-        "features_enc.insert(0, 'Date', dates)\n",
-        "features_enc.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "B-uYkk3_e3wF",
-      "metadata": {
-        "id": "B-uYkk3_e3wF"
-      },
-      "outputs": [],
-      "source": [
-        "features_enc.shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d3614702",
-      "metadata": {
-        "id": "d3614702"
-      },
-      "outputs": [],
-      "source": [
-        "### Save the encoder model\n",
-        "\n",
-        "encoder_save_path = root_data+'Models/'+symbol+'_'+direction+'_'+data_type+'_ahm_encoder_model.keras'\n",
-        "os.makedirs(os.path.dirname(encoder_save_path), exist_ok=True)\n",
-        "encoder.save(encoder_save_path)\n",
-        "print(f\"Encoder model saved successfully at: {encoder_save_path}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "lHzi4304z00U",
-      "metadata": {
-        "id": "lHzi4304z00U"
-      },
-      "outputs": [],
-      "source": [
-        "features_enc.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_Enc_Features.csv')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "kEzuAKPE3KBb",
-      "metadata": {
-        "id": "kEzuAKPE3KBb"
-      },
-      "source": [
-        "# Varios"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [
-        "Ysa-7eLvEMpE",
-        "m8CIB8vltFfH",
-        "y6QRdBKwrX98",
-        "zhTndYVi1TEV",
-        "jh9-mi26wsya",
-        "Hv5bsrpc03z7",
-        "2RFfhHT2AwAJ"
-      ],
-      "gpuType": "T4",
-      "machine_shape": "hm",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.5"
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "24978cca329a49de8aa7134bfb61be2b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_module_version": "1.2.0",
-          "model_name": "LayoutModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "31586bc636e84cf8a9a8e287c337ded4": {
-          "model_module": "@jupyter-widgets/base",
-          "model_module_version": "1.2.0",
-          "model_name": "LayoutModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "3abde22d56a04951806f97ceb50efa92": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "4290faf2225a4d32bde385b6521e9ab2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "HTMLModel",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_24978cca329a49de8aa7134bfb61be2b",
-            "placeholder": "​",
-            "style": "IPY_MODEL_fc87caee4db1426fadc04572c74617b5",
-            "value": "Pruning corr &gt; 0.9:   0%"
-          }
-        },
-        "74a6582880894069ad603643f92d7690": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "FloatProgressModel",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_31586bc636e84cf8a9a8e287c337ded4",
-            "max": 850,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_f033e19b4ce74802907e77d074d358dd",
-            "value": 850
-          }
-        },
-        "9609059e3a254435ad1ac68a6a404d33": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "HBoxModel",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_4290faf2225a4d32bde385b6521e9ab2",
-              "IPY_MODEL_74a6582880894069ad603643f92d7690",
-              "IPY_MODEL_da5e8d42499b429d9b286ba00635148a"
-            ],
-            "layout": "IPY_MODEL_aaaaf872df124159b5d3af65c70d3e83"
-          }
-        },
-        "aaaaf872df124159b5d3af65c70d3e83": {
-          "model_module": "@jupyter-widgets/base",
-          "model_module_version": "1.2.0",
-          "model_name": "LayoutModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": "hidden",
-            "width": null
-          }
-        },
-        "cde12ad7e71c47a7a3429ced6e034fcd": {
-          "model_module": "@jupyter-widgets/base",
-          "model_module_version": "1.2.0",
-          "model_name": "LayoutModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "da5e8d42499b429d9b286ba00635148a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "HTMLModel",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_cde12ad7e71c47a7a3429ced6e034fcd",
-            "placeholder": "​",
-            "style": "IPY_MODEL_3abde22d56a04951806f97ceb50efa92",
-            "value": " 0/850 [00:00&lt;?, ?col/s]"
-          }
-        },
-        "f033e19b4ce74802907e77d074d358dd": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "ProgressStyleModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "fc87caee4db1426fadc04572c74617b5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_module_version": "1.5.0",
-          "model_name": "DescriptionStyleModel",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bf83164c",
+   "metadata": {
+    "id": "bf83164c"
+   },
+   "source": [
+    "# Pendientes\n",
+    "\n",
+    "Nada"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "Ysa-7eLvEMpE",
+   "metadata": {
+    "id": "Ysa-7eLvEMpE"
+   },
+   "source": [
+    "# Gpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9GJAW8qAEM8f",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9GJAW8qAEM8f",
+    "outputId": "5430e5b2-c26a-468f-8c59-a09545f7e189"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Sep 22 17:36:34 2025       \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
+      "|-----------------------------------------+------------------------+----------------------+\n",
+      "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+      "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+      "|                                         |                        |               MIG M. |\n",
+      "|=========================================+========================+======================|\n",
+      "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
+      "| N/A   43C    P8             11W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
+      "|                                         |                        |                  N/A |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "                                                                                         \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| Processes:                                                                              |\n",
+      "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
+      "|        ID   ID                                                               Usage      |\n",
+      "|=========================================================================================|\n",
+      "|  No running processes found                                                             |\n",
+      "+-----------------------------------------------------------------------------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "FcIdAmrNERw-",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "FcIdAmrNERw-",
+    "outputId": "4f0b0aae-99aa-4f36-ee7d-f2b4d43d7461"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "tf.config.list_physical_devices('GPU')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m8CIB8vltFfH",
+   "metadata": {
+    "id": "m8CIB8vltFfH"
+   },
+   "source": [
+    "# Set_Up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "EB5RqjoAtFwl",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "EB5RqjoAtFwl",
+    "outputId": "34781d46-a966-4ed8-b8e8-a853290f305a"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/content/drive/MyDrive/Course Folder/Forex/XAUUSD/\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "root_data = f'/content/drive/MyDrive/Course Folder/Forex/XAUUSD/'\n",
+    "print(root_data)\n",
+    "\n",
+    "direction = 'Short'\n",
+    "direction_number = -1\n",
+    "\n",
+    "symbol = 'XAUUSD'\n",
+    "strategy = 'Kalman'\n",
+    "time_frame = 'M5'\n",
+    "\n",
+    "trade_evolution = 'st_Max'\n",
+    "result_field = 'st_PnL'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "y6QRdBKwrX98",
+   "metadata": {
+    "id": "y6QRdBKwrX98"
+   },
+   "source": [
+    "# Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "R9bTNmBwK_Up",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "R9bTNmBwK_Up",
+    "outputId": "4257f600-81e5-42ac-e4a0-84a5cae26c09"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting ta-lib\n",
+      "  Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (24 kB)\n",
+      "Requirement already satisfied: build in /usr/local/lib/python3.12/dist-packages (from ta-lib) (1.3.0)\n",
+      "Requirement already satisfied: cython in /usr/local/lib/python3.12/dist-packages (from ta-lib) (3.0.12)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.12/dist-packages (from ta-lib) (2.0.2)\n",
+      "Requirement already satisfied: packaging>=19.1 in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (25.0)\n",
+      "Requirement already satisfied: pyproject_hooks in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (1.2.0)\n",
+      "Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl (4.1 MB)\n",
+      "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/4.1 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m220.9 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m114.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: ta-lib\n",
+      "Successfully installed ta-lib-0.6.7\n",
+      "0.6.7\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install ta-lib\n",
+    "import talib as ta\n",
+    "print(ta.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bda1a01c",
+   "metadata": {
+    "id": "bda1a01c"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import joblib\n",
+    "import math\n",
+    "import time\n",
+    "\n",
+    "from itertools import combinations, product\n",
+    "\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import Dense\n",
+    "\n",
+    "from sklearn.cluster import KMeans\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.feature_selection import RFECV\n",
+    "from sklearn.model_selection import StratifiedKFold\n",
+    "from sklearn.feature_selection import SelectFromModel\n",
+    "from sklearn.metrics import roc_auc_score, r2_score\n",
+    "from sklearn.model_selection import TimeSeriesSplit\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "\n",
+    "from scipy.cluster.hierarchy import linkage, fcluster\n",
+    "from scipy.spatial.distance import squareform\n",
+    "\n",
+    "from xgboost import XGBClassifier, XGBRegressor\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "from __future__ import annotations\n",
+    "from typing import Tuple, List, Optional, Dict, Any, Union\n",
+    "\n",
+    "from xgboost import XGBClassifier, XGBRegressor\n",
+    "from sklearn.metrics import (roc_auc_score, f1_score, accuracy_score, log_loss, r2_score)\n",
+    "\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7JweuZy755ym",
+   "metadata": {
+    "id": "7JweuZy755ym"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "plt.style.use(\"seaborn-v0_8-darkgrid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "KFfn45ty82qv",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "KFfn45ty82qv",
+    "outputId": "b61f1ebd-525f-484d-8ebe-3b78a61caf7c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mounted at /content/drive\n"
+     ]
+    }
+   ],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aa65d54",
+   "metadata": {
+    "id": "9aa65d54"
+   },
+   "source": [
+    "# Calculate_Features\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "I23127P7lBq_",
+   "metadata": {
+    "id": "I23127P7lBq_"
+   },
+   "source": [
+    "## Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kp4yJdGAjoeA",
+   "metadata": {
+    "id": "kp4yJdGAjoeA"
+   },
+   "outputs": [],
+   "source": [
+    "def kalman_line(source, kalman_length: int, smooth: int):\n",
+    "    \"\"\"\n",
+    "    Pine -> Python (solo 'kalman_line'), replicando la EMA de TradingView con\n",
+    "    *semilla SMA* (como ta.ema) sobre el núcleo Kalman kf_c.\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    source : pd.Series o array-like de floats (precio crudo, sin diff/returns)\n",
+    "    kalman_length : int   (equivale a length_kal en Pine)\n",
+    "    smooth : int          (equivale a smooth_kal en Pine -> ta.ema(kf_c, smooth))\n",
+    "\n",
+    "    Retorna\n",
+    "    -------\n",
+    "    Mismo tipo que `source`: pd.Series o np.ndarray con la línea Kalman suavizada.\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    # normalizamos tipos\n",
+    "    is_series = hasattr(source, \"index\")\n",
+    "    idx = source.index if is_series else None\n",
+    "    x = np.asarray(source, dtype=np.float64)\n",
+    "    n = x.shape[0]\n",
+    "    if n == 0:\n",
+    "        return source\n",
+    "\n",
+    "    # ---------- núcleo Kalman idéntico al Pine ----------\n",
+    "    sqrt_term   = np.sqrt((kalman_length / 10000.0) * 2.0)\n",
+    "    length_term = kalman_length / 10000.0\n",
+    "\n",
+    "    kf_c   = np.empty(n, dtype=np.float64)\n",
+    "    velo_c = np.empty(n, dtype=np.float64)\n",
+    "\n",
+    "    # bar 0 (nz(kf_c[1], source) y nz(velo_c[1], 0))\n",
+    "    kf_c[0] = x[0]\n",
+    "    velo_c[0] = 0.0\n",
+    "\n",
+    "    for i in range(1, n):\n",
+    "        prev_kf = kf_c[i - 1]\n",
+    "        dk_c = x[i] - prev_kf\n",
+    "        smooth_c = prev_kf + dk_c * sqrt_term\n",
+    "        velo_c[i] = velo_c[i - 1] + length_term * dk_c\n",
+    "        kf_c[i] = smooth_c + velo_c[i]\n",
+    "\n",
+    "    # ---------- EMA con semilla SMA (comportamiento ta.ema de TV) ----------\n",
+    "    L = int(max(1, smooth))\n",
+    "    alpha = 2.0 / (L + 1.0)\n",
+    "    ema = np.full(n, np.nan, dtype=np.float64)\n",
+    "\n",
+    "    if n < L:\n",
+    "        # con pocas barras, igualamos al promedio simple disponible\n",
+    "        ema[-1] = np.nanmean(kf_c)\n",
+    "    else:\n",
+    "        # seed = SMA de las primeras L barras\n",
+    "        seed = np.mean(kf_c[:L])\n",
+    "        ema[L - 1] = seed\n",
+    "        for i in range(L, n):\n",
+    "            ema[i] = alpha * kf_c[i] + (1.0 - alpha) * ema[i - 1]\n",
+    "\n",
+    "    return (pd.Series(ema, index=idx) if is_series else ema)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ezwn8qPwfVtI",
+   "metadata": {
+    "id": "ezwn8qPwfVtI"
+   },
+   "outputs": [],
+   "source": [
+    "def add_ema_feature_block(\n",
+    "    stock_data: pd.DataFrame,\n",
+    "    ema_lengths: Tuple[int, ...] = (15, 21, 50, 100, 200)\n",
+    ") -> Tuple[pd.DataFrame, List[str]]:\n",
+    "    \"\"\"Generate EMA-based features as an independent DataFrame.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    stock_data : pd.DataFrame\n",
+    "        Source OHLCV data that must contain a 'Close' column.\n",
+    "    ema_lengths : Tuple[int, ...], optional\n",
+    "        Window sizes for the EMAs, by default (15, 21, 50, 100, 200).\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    Tuple[pd.DataFrame, List[str]]\n",
+    "        DataFrame containing the EMA features and the list of EMA column names.\n",
+    "    \"\"\"\n",
+    "    close_prices = stock_data['Close']\n",
+    "    features = pd.DataFrame(index=stock_data.index)\n",
+    "    ema_columns: List[str] = []\n",
+    "\n",
+    "    for length in ema_lengths:\n",
+    "        ema_col = f'EMA_{length}'\n",
+    "        ema_series = ta.EMA(close_prices, timeperiod=length)\n",
+    "\n",
+    "        features[ema_col] = ema_series\n",
+    "        features[f'{ema_col}_diff'] = ema_series.diff()\n",
+    "        features[f'Close_minus_{ema_col}'] = close_prices - ema_series\n",
+    "\n",
+    "        ema_columns.append(ema_col)\n",
+    "\n",
+    "    for col_a, col_b in combinations(ema_columns, 2):\n",
+    "        boolean_col = f'{col_a}_above_{col_b}'\n",
+    "        features[boolean_col] = (features[col_a] > features[col_b]).astype(int)\n",
+    "\n",
+    "    return features, ema_columns\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "HahbLzEkjoeB",
+   "metadata": {
+    "id": "HahbLzEkjoeB"
+   },
+   "outputs": [],
+   "source": [
+    "def slope(src: pd.Series,\n",
+    "          length_kal: int,\n",
+    "          smooth_kal: int,\n",
+    "          slopeLen: int,\n",
+    "          offset: int) -> pd.DataFrame:\n",
+    "\n",
+    "    n = len(src)\n",
+    "    kf_state = np.full(n, np.nan)\n",
+    "    kf_velo  = np.zeros(n)\n",
+    "    sqrt_factor = np.sqrt(length_kal / 10000.0 * 2.0)\n",
+    "    vel_factor  = length_kal / 10000.0\n",
+    "\n",
+    "    for i in range(n):\n",
+    "        if i == 0:\n",
+    "            prev_state = src.iloc[0]\n",
+    "            prev_velo  = 0.0\n",
+    "        else:\n",
+    "            prev_state = kf_state[i-1] if not np.isnan(kf_state[i-1]) else src.iloc[i]\n",
+    "            prev_velo  = kf_velo[i-1]\n",
+    "\n",
+    "        dk = src.iloc[i] - prev_state\n",
+    "        smooth = prev_state + dk * sqrt_factor\n",
+    "        kf_velo[i]  = prev_velo + vel_factor * dk\n",
+    "        kf_state[i] = smooth + kf_velo[i]\n",
+    "\n",
+    "    # 2) EMA smoothing --------------------------------------------------\n",
+    "    kal = pd.Series(kf_state, index=src.index).ewm(span=smooth_kal, adjust=False).mean()\n",
+    "\n",
+    "    # 3) Slope/divergence -----------------------------------------------\n",
+    "    validLen = max(slopeLen, 1)\n",
+    "    slope_div = kal.diff(validLen) / validLen\n",
+    "    slope_signal = (slope_div > slope_div.shift(1)).astype(int)\n",
+    "\n",
+    "    # 4) Angle in degrees -----------------------------------------------\n",
+    "    price_change = kal - kal.shift(validLen)\n",
+    "    slope_angle = np.degrees(np.arctan(price_change))\n",
+    "    slope_angle_signal = (slope_angle > slope_angle.shift(1)).astype(int)\n",
+    "\n",
+    "    # 5) Linear regression prediction ----------------------------------\n",
+    "    def _linreg(y):\n",
+    "        x = np.arange(len(y))\n",
+    "        m, b = np.polyfit(x, y, 1)\n",
+    "        return b + m * (len(y)-1)\n",
+    "\n",
+    "    slope_lin_reg = kal.rolling(window=slopeLen).apply(_linreg, raw=False)\n",
+    "    slope_lin_reg = slope_lin_reg.shift(-offset)  # apply Pine-style offset\n",
+    "    slope_lin_reg_signal = (slope_lin_reg > slope_lin_reg.shift(1)).astype(int)\n",
+    "\n",
+    "    # 6) Pack results ---------------------------------------------------\n",
+    "    return pd.DataFrame({\n",
+    "        'slope_div':            slope_div,\n",
+    "        'slope_signal':         slope_signal,\n",
+    "        'slope_angle':          slope_angle,\n",
+    "        'slope_angle_signal':   slope_angle_signal,\n",
+    "        'slope_lin_reg':        slope_lin_reg,\n",
+    "        'slope_lin_reg_signal': slope_lin_reg_signal\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d988ef9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_slope_feature_block(stock_data: pd.DataFrame,\n",
+    "                                 kalman_periods: List[int],\n",
+    "                                 slope_lengths: List[int]) -> pd.DataFrame:\n",
+    "    \"\"\"Assemble the complete slope feature block for the provided parameters.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    stock_data : pd.DataFrame\n",
+    "        Input OHLCV data.\n",
+    "    kalman_periods : List[int]\n",
+    "        Window lengths used for the Kalman filter baseline.\n",
+    "    slope_lengths : List[int]\n",
+    "        Lookback windows used when computing the slope statistics.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pd.DataFrame\n",
+    "        A DataFrame containing all slope-based indicators, their diffs and pairwise combinations.\n",
+    "    \"\"\"\n",
+    "    slope_features = pd.DataFrame(index=stock_data.index)\n",
+    "    slope_indicator_columns: Dict[str, List[str]] = {\n",
+    "        'slope_div': [],\n",
+    "        'slope_signal': [],\n",
+    "        'slope_angle': [],\n",
+    "        'slope_angle_signal': [],\n",
+    "        'slope_lin_reg': [],\n",
+    "        'slope_lin_reg_signal': []\n",
+    "    }\n",
+    "\n",
+    "    slope_jobs = list(product(kalman_periods, slope_lengths))\n",
+    "\n",
+    "    for period, s_len in tqdm(slope_jobs, desc=\"Slopes (kal_len × slope_len)\"):\n",
+    "        df_s = slope(stock_data['Close'], length_kal=period, smooth_kal=3,\n",
+    "                     slopeLen=s_len, offset=-1)\n",
+    "\n",
+    "        column_mapping = {\n",
+    "            'slope_div':            f'slope_div_{period}_{s_len}',\n",
+    "            'slope_signal':         f'slope_signal_{period}_{s_len}',\n",
+    "            'slope_angle':          f'slope_angle_{period}_{s_len}',\n",
+    "            'slope_angle_signal':   f'slope_angle_signal_{period}_{s_len}',\n",
+    "            'slope_lin_reg':        f'slope_lin_reg_{period}_{s_len}',\n",
+    "            'slope_lin_reg_signal': f'slope_lin_reg_signal_{period}_{s_len}'\n",
+    "        }\n",
+    "\n",
+    "        for indicator, col_name in column_mapping.items():\n",
+    "            series = df_s[indicator]\n",
+    "            slope_features[col_name] = series\n",
+    "            slope_features[f'{col_name}_diff'] = series.diff()\n",
+    "            slope_indicator_columns[indicator].append(col_name)\n",
+    "\n",
+    "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
+    "        unique_columns = list(dict.fromkeys(columns))\n",
+    "        return list(combinations(unique_columns, 2))\n",
+    "\n",
+    "    for indicator, cols in slope_indicator_columns.items():\n",
+    "        pairs = _unique_pairwise(cols)\n",
+    "        for c1, c2 in pairs:\n",
+    "            slope_features[f'{c1} - {c2}'] = slope_features[c1] - slope_features[c2]\n",
+    "\n",
+    "    return slope_features\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "OdtkSGMfbJno",
+   "metadata": {
+    "id": "OdtkSGMfbJno"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def volume_indicators(\n",
+    "    stock_data: pd.DataFrame,\n",
+    "    cmf_period: int = 20,\n",
+    "    tmf_period: int = 21,\n",
+    "    mfi_period: int = 14,\n",
+    "    ko_fast: int = 34,\n",
+    "    ko_slow: int = 55,\n",
+    "    efi_period: int = 13,\n",
+    "    eom_period: int = 14,\n",
+    "    vfi_period: int = 130,\n",
+    "    vfi_coef: float = 0.2\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"Compute a selection of volume-based indicators.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    stock_data : pd.DataFrame\n",
+    "        DataFrame with at least 'Open', 'High', 'Low', 'Close' and 'Volume' columns.\n",
+    "    cmf_period : int, default 20\n",
+    "        Lookback period for Chaikin Money Flow.\n",
+    "    tmf_period : int, default 21\n",
+    "        Lookback period for Twiggs Money Flow exponential averages.\n",
+    "    mfi_period : int, default 14\n",
+    "        Lookback period for Money Flow Index (TA-Lib implementation).\n",
+    "    ko_fast : int, default 34\n",
+    "        Fast EMA length for the Klinger Oscillator volume force.\n",
+    "    ko_slow : int, default 55\n",
+    "        Slow EMA length for the Klinger Oscillator volume force.\n",
+    "    efi_period : int, default 13\n",
+    "        Exponential smoothing period for Elder Force Index.\n",
+    "    eom_period : int, default 14\n",
+    "        Rolling mean period for Ease of Movement.\n",
+    "    vfi_period : int, default 130\n",
+    "        Rolling window for Volume Flow Indicator calculations.\n",
+    "    vfi_coef : float, default 0.2\n",
+    "        Cutoff coefficient used in the Volume Flow Indicator.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pd.DataFrame\n",
+    "        DataFrame containing the indicators and their first differences.\n",
+    "    \"\"\"\n",
+    "    required_columns = {\"Open\", \"High\", \"Low\", \"Close\", \"Volume\"}\n",
+    "    missing = required_columns.difference(stock_data.columns)\n",
+    "    if missing:\n",
+    "        raise ValueError(f\"stock_data must contain columns: {sorted(required_columns)}. Missing: {sorted(missing)}\")\n",
+    "\n",
+    "    features = pd.DataFrame(index=stock_data.index)\n",
+    "\n",
+    "    high = stock_data['High'].astype(float)\n",
+    "    low = stock_data['Low'].astype(float)\n",
+    "    close = stock_data['Close'].astype(float)\n",
+    "    volume = stock_data['Volume'].astype(float)\n",
+    "    typical_price = (high + low + close) / 3.0\n",
+    "\n",
+    "    def _add_with_diff(name: str, series: pd.Series) -> None:\n",
+    "        features[name] = series\n",
+    "        features[f\"{name}_diff\"] = series.diff()\n",
+    "\n",
+    "    # Chaikin Money Flow (CMF)\n",
+    "    hl_range = (high - low).replace(0, np.nan)\n",
+    "    mf_multiplier = ((close - low) - (high - close))\n",
+    "    mf_volume = (mf_multiplier / hl_range).fillna(0.0) * volume\n",
+    "    cmf = mf_volume.rolling(window=cmf_period, min_periods=1).sum() / volume.rolling(window=cmf_period, min_periods=1).sum()\n",
+    "    _add_with_diff('CMF', cmf)\n",
+    "\n",
+    "    # Twiggs Money Flow (TMF)\n",
+    "    tmf_raw = (mf_multiplier / hl_range).fillna(0.0) * volume\n",
+    "    tmf = tmf_raw.ewm(span=tmf_period, adjust=False, min_periods=1).mean() / volume.ewm(span=tmf_period, adjust=False, min_periods=1).mean()\n",
+    "    _add_with_diff('TMF', tmf)\n",
+    "\n",
+    "    # Money Flow Index (MFI)\n",
+    "    mfi = ta.MFI(high, low, close, volume, timeperiod=mfi_period)\n",
+    "    _add_with_diff(f'MFI_{mfi_period}_volume', mfi)\n",
+    "\n",
+    "    # Klinger Oscillator (KO)\n",
+    "    tp_diff = typical_price.diff()\n",
+    "    trend = tp_diff.apply(lambda x: 1 if x > 0 else (-1 if x < 0 else np.nan)).ffill().fillna(1.0)\n",
+    "    vf = trend * volume * (2 * tp_diff.abs() / hl_range).fillna(0.0)\n",
+    "    ko = vf.ewm(span=ko_fast, adjust=False, min_periods=1).mean() - vf.ewm(span=ko_slow, adjust=False, min_periods=1).mean()\n",
+    "    _add_with_diff('KO', ko)\n",
+    "\n",
+    "    # Elder Force Index (EFI)\n",
+    "    efi_raw = close.diff() * volume\n",
+    "    efi = efi_raw.ewm(span=efi_period, adjust=False, min_periods=1).mean()\n",
+    "    _add_with_diff('EFI', efi)\n",
+    "\n",
+    "    # Ease of Movement (EOM)\n",
+    "    prior_mid = ((high.shift(1) + low.shift(1)) / 2.0)\n",
+    "    mid_move = ((high + low) / 2.0) - prior_mid\n",
+    "    eom = (mid_move * (high - low)) / volume.replace(0, np.nan)\n",
+    "    eom = eom.rolling(window=eom_period, min_periods=1).mean()\n",
+    "    _add_with_diff('EOM', eom)\n",
+    "\n",
+    "    # Volume Price Trend (VPT)\n",
+    "    vpt = ((close - close.shift(1)) / close.shift(1).replace(0, np.nan) * volume).fillna(0.0).cumsum()\n",
+    "    _add_with_diff('VPT', vpt)\n",
+    "\n",
+    "    # Negative Volume Index (NVI)\n",
+    "    nvi = volume.copy().astype(float)\n",
+    "    if not nvi.empty:\n",
+    "        nvi.iloc[0] = 1000.0\n",
+    "        for i in range(1, len(nvi)):\n",
+    "            prev = nvi.iloc[i-1]\n",
+    "            if volume.iloc[i] < volume.iloc[i-1]:\n",
+    "                change = (close.iloc[i] - close.iloc[i-1]) / close.iloc[i-1] if close.iloc[i-1] != 0 else 0.0\n",
+    "                nvi.iloc[i] = prev + prev * change\n",
+    "            else:\n",
+    "                nvi.iloc[i] = prev\n",
+    "    _add_with_diff('NVI', nvi)\n",
+    "\n",
+    "    # Positive Volume Index (PVI)\n",
+    "    pvi = volume.copy().astype(float)\n",
+    "    if not pvi.empty:\n",
+    "        pvi.iloc[0] = 1000.0\n",
+    "        for i in range(1, len(pvi)):\n",
+    "            prev = pvi.iloc[i-1]\n",
+    "            if volume.iloc[i] > volume.iloc[i-1]:\n",
+    "                change = (close.iloc[i] - close.iloc[i-1]) / close.iloc[i-1] if close.iloc[i-1] != 0 else 0.0\n",
+    "                pvi.iloc[i] = prev + prev * change\n",
+    "            else:\n",
+    "                pvi.iloc[i] = prev\n",
+    "    _add_with_diff('PVI', pvi)\n",
+    "\n",
+    "    # Volume Flow Indicator (VFI)\n",
+    "    log_tp = np.log(typical_price.replace(0, np.nan) / typical_price.shift(1).replace(0, np.nan)).replace([np.inf, -np.inf], np.nan).fillna(0.0)\n",
+    "    cutoff = log_tp.rolling(window=vfi_period, min_periods=1).std(ddof=0) * vfi_coef\n",
+    "    avg_volume = volume.rolling(window=vfi_period, min_periods=1).mean()\n",
+    "    vf_select = np.where(log_tp > cutoff, volume, np.where(log_tp < -cutoff, -volume, 0.0))\n",
+    "    vfi = pd.Series(vf_select, index=stock_data.index).rolling(window=vfi_period, min_periods=1).sum() / avg_volume.replace(0, np.nan)\n",
+    "    _add_with_diff('VFI', vfi)\n",
+    "\n",
+    "    # Volume-Weighted Average Price (VWAP)\n",
+    "    cum_volume = volume.cumsum()\n",
+    "    vwap = (typical_price * volume).cumsum() / cum_volume.replace(0, np.nan)\n",
+    "    _add_with_diff('VWAP', vwap)\n",
+    "\n",
+    "    # Market Facilitation Index (Bill Williams)\n",
+    "    market_fi = (high - low) / volume.replace(0, np.nan)\n",
+    "    _add_with_diff('Market_Facilitation_Index', market_fi)\n",
+    "\n",
+    "    # Accumulation/Distribution Line (A/D)\n",
+    "    clv = ((close - low) - (high - close)) / hl_range\n",
+    "    ad_line = (clv.fillna(0.0) * volume).cumsum()\n",
+    "    _add_with_diff('AD_Line', ad_line)\n",
+    "\n",
+    "    # Williams Accumulation/Distribution (WAD)\n",
+    "    prev_close = close.shift(1).fillna(close.iloc[0])\n",
+    "    true_high = pd.concat([high, prev_close], axis=1).max(axis=1)\n",
+    "    true_low = pd.concat([low, prev_close], axis=1).min(axis=1)\n",
+    "    wad_raw = np.where(\n",
+    "        close > prev_close,\n",
+    "        close - true_low,\n",
+    "        np.where(close < prev_close, close - true_high, 0.0)\n",
+    "    )\n",
+    "    wad = pd.Series(wad_raw, index=stock_data.index).cumsum()\n",
+    "    _add_with_diff('WAD', wad)\n",
+    "\n",
+    "    return features\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "basicIndicators",
+   "metadata": {
+    "id": "basicIndicators"
+   },
+   "outputs": [],
+   "source": [
+    "def basic_indicators(\n",
+    "    stock_data: pd.DataFrame,\n",
+    "    macd_fast: int = 12,\n",
+    "    macd_slow: int = 26,\n",
+    "    macd_signal: int = 9,\n",
+    "    rsi_period: int = 14,\n",
+    "    bb_period: int = 20,\n",
+    "    bb_std: float = 2.0,\n",
+    "    atr_period: int = 14,\n",
+    "    momentum_period: int = 10,\n",
+    "    roc_period: int = 10,\n",
+    "    stoch_k_period: int = 14,\n",
+    "    stoch_d_period: int = 3,\n",
+    "    stoch_slow_period: int = 3,\n",
+    "    cci_period: int = 20,\n",
+    "    mfi_period: int = 14,\n",
+    "    adx_period: int = 14,\n",
+    "    williams_period: int = 14,\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"Compute a set of core price-based indicators and their differences.\"\"\"\n",
+    "    required_columns = {\"Open\", \"High\", \"Low\", \"Close\", \"Volume\"}\n",
+    "    missing = required_columns.difference(stock_data.columns)\n",
+    "    if missing:\n",
+    "        raise ValueError(\n",
+    "            \"stock_data must contain columns: {cols}. Missing: {missing}\".format(\n",
+    "                cols=sorted(required_columns), missing=sorted(missing)\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "    features = pd.DataFrame(index=stock_data.index)\n",
+    "\n",
+    "    high = stock_data[\"High\"].astype(float)\n",
+    "    low = stock_data[\"Low\"].astype(float)\n",
+    "    close = stock_data[\"Close\"].astype(float)\n",
+    "    volume = stock_data[\"Volume\"].astype(float)\n",
+    "    typical_price = (high + low + close) / 3.0\n",
+    "\n",
+    "    def _add_with_diff(name: str, series: pd.Series) -> None:\n",
+    "        series = pd.Series(series, index=stock_data.index)\n",
+    "        features[name] = series\n",
+    "        features[f\"{name}_diff\"] = series.diff()\n",
+    "\n",
+    "    macd, macd_signal_series, macd_hist = ta.MACD(\n",
+    "        close,\n",
+    "        fastperiod=macd_fast,\n",
+    "        slowperiod=macd_slow,\n",
+    "        signalperiod=macd_signal,\n",
+    "    )\n",
+    "    _add_with_diff(f\"MACD_{macd_fast}_{macd_slow}_{macd_signal}\", macd)\n",
+    "    _add_with_diff(\n",
+    "        f\"MACD_signal_{macd_fast}_{macd_slow}_{macd_signal}\", macd_signal_series\n",
+    "    )\n",
+    "    _add_with_diff(f\"MACD_hist_{macd_fast}_{macd_slow}_{macd_signal}\", macd_hist)\n",
+    "\n",
+    "    rsi = ta.RSI(close, timeperiod=rsi_period)\n",
+    "    _add_with_diff(f\"RSI_basic_{rsi_period}\", rsi)\n",
+    "\n",
+    "    upper, middle, lower = ta.BBANDS(\n",
+    "        close,\n",
+    "        timeperiod=bb_period,\n",
+    "        nbdevup=bb_std,\n",
+    "        nbdevdn=bb_std,\n",
+    "        matype=0,\n",
+    "    )\n",
+    "    _add_with_diff(f\"BB_upper_{bb_period}\", upper)\n",
+    "    _add_with_diff(f\"BB_middle_{bb_period}\", middle)\n",
+    "    _add_with_diff(f\"BB_lower_{bb_period}\", lower)\n",
+    "\n",
+    "    atr = ta.ATR(high, low, close, timeperiod=atr_period)\n",
+    "    _add_with_diff(f\"ATR_{atr_period}\", atr)\n",
+    "\n",
+    "    obv = ta.OBV(close, volume)\n",
+    "    _add_with_diff(\"OBV_basic\", obv)\n",
+    "\n",
+    "    cum_volume = volume.cumsum()\n",
+    "    vwap = (typical_price * volume).cumsum() / cum_volume.replace(0, np.nan)\n",
+    "    _add_with_diff(\"VWAP_basic\", vwap)\n",
+    "\n",
+    "    momentum = ta.MOM(close, timeperiod=momentum_period)\n",
+    "    _add_with_diff(f\"Momentum_{momentum_period}\", momentum)\n",
+    "\n",
+    "    roc = ta.ROC(close, timeperiod=roc_period)\n",
+    "    _add_with_diff(f\"ROC_{roc_period}\", roc)\n",
+    "\n",
+    "    stoch_k, stoch_d = ta.STOCH(\n",
+    "        high,\n",
+    "        low,\n",
+    "        close,\n",
+    "        fastk_period=stoch_k_period,\n",
+    "        slowk_period=stoch_d_period,\n",
+    "        slowk_matype=0,\n",
+    "        slowd_period=stoch_slow_period,\n",
+    "        slowd_matype=0,\n",
+    "    )\n",
+    "    _add_with_diff(\n",
+    "        f\"Stoch_K_{stoch_k_period}_{stoch_d_period}_{stoch_slow_period}\", stoch_k\n",
+    "    )\n",
+    "    _add_with_diff(\n",
+    "        f\"Stoch_D_{stoch_k_period}_{stoch_d_period}_{stoch_slow_period}\", stoch_d\n",
+    "    )\n",
+    "\n",
+    "    cci = ta.CCI(high, low, close, timeperiod=cci_period)\n",
+    "    _add_with_diff(f\"CCI_{cci_period}\", cci)\n",
+    "\n",
+    "    mfi = ta.MFI(high, low, close, volume, timeperiod=mfi_period)\n",
+    "    _add_with_diff(f\"MFI_basic_{mfi_period}\", mfi)\n",
+    "\n",
+    "    adx = ta.ADX(high, low, close, timeperiod=adx_period)\n",
+    "    _add_with_diff(f\"ADX_{adx_period}\", adx)\n",
+    "\n",
+    "    williams_r = ta.WILLR(high, low, close, timeperiod=williams_period)\n",
+    "    _add_with_diff(f\"WilliamsR_{williams_period}\", williams_r)\n",
+    "\n",
+    "    return features\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZnVB7nObuG_e",
+   "metadata": {
+    "id": "ZnVB7nObuG_e"
+   },
+   "outputs": [],
+   "source": [
+    "def create_features(\n",
+    "    stock_data: pd.DataFrame,\n",
+    "    return_components: bool = False\n",
+    ") -> Union[pd.DataFrame, Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]]:\n",
+    "\n",
+    "    periods        = [3, 7, 14]\n",
+    "    ema_lengths    = (15, 21, 50, 100, 200)\n",
+    "    kalman_periods = [300, 600, 900]\n",
+    "    slope_length   = [3, 6, 9]\n",
+    "\n",
+    "    features = pd.DataFrame(index=stock_data.index)\n",
+    "    component_frames: Dict[str, pd.DataFrame] = {}\n",
+    "\n",
+    "    basic_features = basic_indicators(stock_data)\n",
+    "    component_frames['Basic_Indicators'] = basic_features\n",
+    "    features = features.join(basic_features)\n",
+    "\n",
+    "    volume_features = volume_indicators(stock_data)\n",
+    "    component_frames['Volume_Indicators'] = volume_features\n",
+    "    features = features.join(volume_features)\n",
+    "\n",
+    "    ema_features, _ = add_ema_feature_block(stock_data, ema_lengths)\n",
+    "    component_frames['EMA_Features'] = ema_features\n",
+    "    features = features.join(ema_features)\n",
+    "\n",
+    "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
+    "        \"\"\"Return ordered unique column pairs without self-pairings.\"\"\"\n",
+    "        unique_columns = list(dict.fromkeys(columns))\n",
+    "        return list(combinations(unique_columns, 2))\n",
+    "\n",
+    "    # ───────────────────────── Indicadores por período ─────────────────────────\n",
+    "    t0 = time.time()\n",
+    "    indicator_columns = {'RSI': [], 'MFI': [], 'OBV': []}\n",
+    "\n",
+    "    # >>> Cambio: OBV sin períodos (una sola serie)\n",
+    "    obv_col = 'OBV'\n",
+    "    features[obv_col] = ta.OBV(stock_data['Close'], stock_data['Volume'])\n",
+    "    indicator_columns['OBV'].append(obv_col)\n",
+    "\n",
+    "    for period in tqdm(periods, desc=\"Indicators (RSI/MFI/OBV)\"):\n",
+    "        rsi_col = f'RSI_{period}'\n",
+    "        features[rsi_col] = ta.RSI(stock_data['Close'], timeperiod=period)\n",
+    "        indicator_columns['RSI'].append(rsi_col)\n",
+    "\n",
+    "        mfi_col = f'MFI_{period}'\n",
+    "        features[mfi_col] = ta.MFI(\n",
+    "            stock_data['High'], stock_data['Low'], stock_data['Close'],\n",
+    "            stock_data['Volume'], timeperiod=period\n",
+    "        )\n",
+    "        indicator_columns['MFI'].append(mfi_col)\n",
+    "\n",
+    "    # diffs y combinaciones dentro de cada familia\n",
+    "    for indicator, cols in indicator_columns.items():\n",
+    "        for col in tqdm(cols, desc=f\"{indicator}: diffs\", leave=False):\n",
+    "            features[f'{col}_diff'] = features[col].diff()\n",
+    "        pairs = _unique_pairwise(cols)  # para OBV (1 col) no habrá pares\n",
+    "        for col1, col2 in tqdm(pairs, desc=f\"{indicator}: pairwise\", leave=False):\n",
+    "            features[f'{col1} - {col2}'] = features[col1] - features[col2]\n",
+    "    tqdm.write(f\"[Timing] Indicators block: {time.time()-t0:.2f}s\")\n",
+    "\n",
+    "    # ───────────────────────── Kalman y derivados ───────────────────────\n",
+    "    t0 = time.time()\n",
+    "    kal_cols = []\n",
+    "    for period in tqdm(kalman_periods, desc=\"Kalman & Derivatives\"):\n",
+    "        kal = pd.Series(\n",
+    "            kalman_line(stock_data['Close'], kalman_length=period, smooth=3),\n",
+    "            index=stock_data.index\n",
+    "        )\n",
+    "        kname = f'Kal_{period}'\n",
+    "        kal_cols.append(kname)\n",
+    "\n",
+    "        features[kname]                           = kal\n",
+    "        features[f'Close_Kal_{period}']           = stock_data['Close'] - kal\n",
+    "        features[f'Kal_change_{period}']          = kal.diff(1)\n",
+    "        features[f'Kal_prev_minus_now_{period}']  = kal.shift(1) - kal\n",
+    "        features[f'Kal_prev2_minus_now_{period}'] = kal.shift(2) - kal\n",
+    "        features[f'Kal_change2_{period}']         = kal.diff(2)\n",
+    "\n",
+    "    kal_pairs = _unique_pairwise(kal_cols)\n",
+    "    for c1, c2 in tqdm(kal_pairs, desc=\"Kalman pairwise\"):\n",
+    "        features[f'{c1}_minus_{c2}'] = features[c1] - features[c2]\n",
+    "    tqdm.write(f\"[Timing] Kalman block: {time.time()-t0:.2f}s\")\n",
+    "\n",
+    "    # ───────────────────────── Slopes ───────────────────────────────────\n",
+    "    t0 = time.time()\n",
+    "    slope_features = build_slope_feature_block(stock_data, kalman_periods, slope_length)\n",
+    "    component_frames['Slope'] = slope_features\n",
+    "    features = features.join(slope_features)\n",
+    "    tqdm.write(f\"[Timing] Slopes block: {time.time()-t0:.2f}s\")\n",
+    "\n",
+    "    if return_components:\n",
+    "        component_frames['Create_Features'] = features.copy()\n",
+    "        return features, component_frames\n",
+    "\n",
+    "    return features\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e0c0f79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scale_feature_block(features: pd.DataFrame, window: int = 200) -> pd.DataFrame:\n",
+    "    \"\"\"Scale features using a rolling window standardization.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    features : pd.DataFrame\n",
+    "        Feature block to scale.\n",
+    "    window : int, optional\n",
+    "        Rolling window size, by default 200.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pd.DataFrame\n",
+    "        Scaled feature block preserving the original index.\n",
+    "    \"\"\"\n",
+    "    if features.empty:\n",
+    "        return features.copy()\n",
+    "\n",
+    "    scaled = features.copy()\n",
+    "    rolling = scaled.rolling(window)\n",
+    "    scaled = (scaled - rolling.mean()) / rolling.std()\n",
+    "    return scaled\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DoqqPJxPxnBF",
+   "metadata": {
+    "id": "DoqqPJxPxnBF"
+   },
+   "source": [
+    "## 5_min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7l7vt7QxvyC",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 324
+    },
+    "id": "d7l7vt7QxvyC",
+    "outputId": "675583b8-def4-4cf5-dfb4-8933ef498d7a"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min_Date :  2019-01-02 01:00:00\n",
+      "Min_Date :  2025-07-25 23:55:00\n",
+      "Number_Rows =  465718\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "summary": "{\n  \"name\": \"df_5min\",\n  \"rows\": 5,\n  \"fields\": [\n    {\n      \"column\": \"Date\",\n      \"properties\": {\n        \"dtype\": \"date\",\n        \"min\": \"2025-07-25 23:35:00\",\n        \"max\": \"2025-07-25 23:55:00\",\n        \"num_unique_values\": 5,\n        \"samples\": [\n          \"2025-07-25 23:40:00\",\n          \"2025-07-25 23:55:00\",\n          \"2025-07-25 23:45:00\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Open\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1397894542414626,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.81,\n          3336.52,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"High\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.132263220280441,\n        \"min\": 3336.86,\n        \"max\": 3339.14,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.92,\n          3336.88,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Low\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.8069696400732905,\n        \"min\": 3336.12,\n        \"max\": 3338.04,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3337.56,\n          3336.44,\n          3336.64\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Close\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1374313166077035,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.69,\n          3336.8,\n          3336.73\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Volume\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 50,\n        \"min\": 82,\n        \"max\": 197,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          194,\n          82,\n          195\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Spread\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 5,\n        \"max\": 40,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          40,\n          5\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
+       "type": "dataframe"
+      },
+      "text/html": [
+       "\n",
+       "  <div id=\"df-f91857c6-e71e-49bc-ad66-384ac450c270\" class=\"colab-df-container\">\n",
+       "    <div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Open</th>\n",
+       "      <th>High</th>\n",
+       "      <th>Low</th>\n",
+       "      <th>Close</th>\n",
+       "      <th>Volume</th>\n",
+       "      <th>Spread</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:35:00</th>\n",
+       "      <td>3338.59</td>\n",
+       "      <td>3339.14</td>\n",
+       "      <td>3338.04</td>\n",
+       "      <td>3338.81</td>\n",
+       "      <td>197</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:40:00</th>\n",
+       "      <td>3338.81</td>\n",
+       "      <td>3338.92</td>\n",
+       "      <td>3337.56</td>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>194</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:45:00</th>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>3336.64</td>\n",
+       "      <td>3336.73</td>\n",
+       "      <td>195</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:50:00</th>\n",
+       "      <td>3336.73</td>\n",
+       "      <td>3336.86</td>\n",
+       "      <td>3336.12</td>\n",
+       "      <td>3336.52</td>\n",
+       "      <td>192</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:55:00</th>\n",
+       "      <td>3336.52</td>\n",
+       "      <td>3336.88</td>\n",
+       "      <td>3336.44</td>\n",
+       "      <td>3336.80</td>\n",
+       "      <td>82</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "    <div class=\"colab-df-buttons\">\n",
+       "\n",
+       "  <div class=\"colab-df-container\">\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-f91857c6-e71e-49bc-ad66-384ac450c270')\"\n",
+       "            title=\"Convert this dataframe to an interactive table.\"\n",
+       "            style=\"display:none;\">\n",
+       "\n",
+       "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+       "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+       "  </svg>\n",
+       "    </button>\n",
+       "\n",
+       "  <style>\n",
+       "    .colab-df-container {\n",
+       "      display:flex;\n",
+       "      gap: 12px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert {\n",
+       "      background-color: #E8F0FE;\n",
+       "      border: none;\n",
+       "      border-radius: 50%;\n",
+       "      cursor: pointer;\n",
+       "      display: none;\n",
+       "      fill: #1967D2;\n",
+       "      height: 32px;\n",
+       "      padding: 0 0 0 0;\n",
+       "      width: 32px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert:hover {\n",
+       "      background-color: #E2EBFA;\n",
+       "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "      fill: #174EA6;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-buttons div {\n",
+       "      margin-bottom: 4px;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert {\n",
+       "      background-color: #3B4455;\n",
+       "      fill: #D2E3FC;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert:hover {\n",
+       "      background-color: #434B5C;\n",
+       "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+       "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+       "      fill: #FFFFFF;\n",
+       "    }\n",
+       "  </style>\n",
+       "\n",
+       "    <script>\n",
+       "      const buttonEl =\n",
+       "        document.querySelector('#df-f91857c6-e71e-49bc-ad66-384ac450c270 button.colab-df-convert');\n",
+       "      buttonEl.style.display =\n",
+       "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "\n",
+       "      async function convertToInteractive(key) {\n",
+       "        const element = document.querySelector('#df-f91857c6-e71e-49bc-ad66-384ac450c270');\n",
+       "        const dataTable =\n",
+       "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+       "                                                    [key], {});\n",
+       "        if (!dataTable) return;\n",
+       "\n",
+       "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+       "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+       "          + ' to learn more about interactive tables.';\n",
+       "        element.innerHTML = '';\n",
+       "        dataTable['output_type'] = 'display_data';\n",
+       "        await google.colab.output.renderOutput(dataTable, element);\n",
+       "        const docLink = document.createElement('div');\n",
+       "        docLink.innerHTML = docLinkHtml;\n",
+       "        element.appendChild(docLink);\n",
+       "      }\n",
+       "    </script>\n",
+       "  </div>\n",
+       "\n",
+       "\n",
+       "    <div id=\"df-936ec14c-235e-46de-be52-d72f909f6e77\">\n",
+       "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-936ec14c-235e-46de-be52-d72f909f6e77')\"\n",
+       "                title=\"Suggest charts\"\n",
+       "                style=\"display:none;\">\n",
+       "\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+       "     width=\"24px\">\n",
+       "    <g>\n",
+       "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+       "    </g>\n",
+       "</svg>\n",
+       "      </button>\n",
+       "\n",
+       "<style>\n",
+       "  .colab-df-quickchart {\n",
+       "      --bg-color: #E8F0FE;\n",
+       "      --fill-color: #1967D2;\n",
+       "      --hover-bg-color: #E2EBFA;\n",
+       "      --hover-fill-color: #174EA6;\n",
+       "      --disabled-fill-color: #AAA;\n",
+       "      --disabled-bg-color: #DDD;\n",
+       "  }\n",
+       "\n",
+       "  [theme=dark] .colab-df-quickchart {\n",
+       "      --bg-color: #3B4455;\n",
+       "      --fill-color: #D2E3FC;\n",
+       "      --hover-bg-color: #434B5C;\n",
+       "      --hover-fill-color: #FFFFFF;\n",
+       "      --disabled-bg-color: #3B4455;\n",
+       "      --disabled-fill-color: #666;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart {\n",
+       "    background-color: var(--bg-color);\n",
+       "    border: none;\n",
+       "    border-radius: 50%;\n",
+       "    cursor: pointer;\n",
+       "    display: none;\n",
+       "    fill: var(--fill-color);\n",
+       "    height: 32px;\n",
+       "    padding: 0;\n",
+       "    width: 32px;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart:hover {\n",
+       "    background-color: var(--hover-bg-color);\n",
+       "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "    fill: var(--button-hover-fill-color);\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart-complete:disabled,\n",
+       "  .colab-df-quickchart-complete:disabled:hover {\n",
+       "    background-color: var(--disabled-bg-color);\n",
+       "    fill: var(--disabled-fill-color);\n",
+       "    box-shadow: none;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-spinner {\n",
+       "    border: 2px solid var(--fill-color);\n",
+       "    border-color: transparent;\n",
+       "    border-bottom-color: var(--fill-color);\n",
+       "    animation:\n",
+       "      spin 1s steps(1) infinite;\n",
+       "  }\n",
+       "\n",
+       "  @keyframes spin {\n",
+       "    0% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "      border-left-color: var(--fill-color);\n",
+       "    }\n",
+       "    20% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    30% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    40% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    60% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    80% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "    90% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "  }\n",
+       "</style>\n",
+       "\n",
+       "      <script>\n",
+       "        async function quickchart(key) {\n",
+       "          const quickchartButtonEl =\n",
+       "            document.querySelector('#' + key + ' button');\n",
+       "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+       "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+       "          try {\n",
+       "            const charts = await google.colab.kernel.invokeFunction(\n",
+       "                'suggestCharts', [key], {});\n",
+       "          } catch (error) {\n",
+       "            console.error('Error during call to suggestCharts:', error);\n",
+       "          }\n",
+       "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+       "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+       "        }\n",
+       "        (() => {\n",
+       "          let quickchartButtonEl =\n",
+       "            document.querySelector('#df-936ec14c-235e-46de-be52-d72f909f6e77 button');\n",
+       "          quickchartButtonEl.style.display =\n",
+       "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "        })();\n",
+       "      </script>\n",
+       "    </div>\n",
+       "\n",
+       "    </div>\n",
+       "  </div>\n"
+      ],
+      "text/plain": [
+       "                        Open     High      Low    Close  Volume  Spread\n",
+       "Date                                                                   \n",
+       "2025-07-25 23:35:00  3338.59  3339.14  3338.04  3338.81     197       5\n",
+       "2025-07-25 23:40:00  3338.81  3338.92  3337.56  3338.69     194       5\n",
+       "2025-07-25 23:45:00  3338.69  3338.69  3336.64  3336.73     195      40\n",
+       "2025-07-25 23:50:00  3336.73  3336.86  3336.12  3336.52     192      40\n",
+       "2025-07-25 23:55:00  3336.52  3336.88  3336.44  3336.80      82      40"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Read the CSV file\n",
+    "df_5min = pd.read_csv(root_data + 'Data/'+symbol+'_M5.csv', index_col=0)\n",
+    "df_5min.index = pd.to_datetime(df_5min.index)\n",
+    "#df_5min = df_5min.iloc[-1000000:,]\n",
+    "\n",
+    "print('Min_Date : ', df_5min.index.min())\n",
+    "print('Min_Date : ', df_5min.index.max())\n",
+    "print('Number_Rows = ',len(df_5min.index))\n",
+    "print('\\n')\n",
+    "\n",
+    "df_5min.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "HBicVZcDx2CF",
+   "metadata": {
+    "id": "HBicVZcDx2CF"
+   },
+   "source": [
+    "**Features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "XxU4wllsEUcN",
+   "metadata": {
+    "id": "XxU4wllsEUcN"
+   },
+   "outputs": [],
+   "source": [
+    "start_time = time.time()\n",
+    "\n",
+    "features_5min_raw, components_5min = create_features(df_5min, return_components=True)\n",
+    "features_5min_raw = features_5min_raw.dropna()\n",
+    "valid_index_5min = features_5min_raw.index\n",
+    "\n",
+    "# Align every component to the valid index coming from the full feature set\n",
+    "m5_raw_blocks: Dict[str, pd.DataFrame] = {name: frame.loc[valid_index_5min].copy()\n",
+    "                                           for name, frame in components_5min.items()}\n",
+    "m5_raw_blocks['Create_Features'] = features_5min_raw\n",
+    "\n",
+    "m5_scaled_blocks: Dict[str, pd.DataFrame] = {}\n",
+    "m5_raw_paths: Dict[str, str] = {}\n",
+    "m5_scaled_paths: Dict[str, str] = {}\n",
+    "\n",
+    "for name, frame in m5_raw_blocks.items():\n",
+    "    filename_raw = f\"{symbol}_M5_{name}_Raw_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Raw_Features.csv\"\n",
+    "    raw_path = os.path.join(root_data, 'Results', filename_raw)\n",
+    "    frame.to_csv(raw_path)\n",
+    "    m5_raw_paths[name] = raw_path\n",
+    "\n",
+    "    scaled_frame = scale_feature_block(frame)\n",
+    "    m5_scaled_blocks[name] = scaled_frame\n",
+    "    filename_scale = f\"{symbol}_M5_{name}_Scale_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Scale_Features.csv\"\n",
+    "    scale_path = os.path.join(root_data, 'Results', filename_scale)\n",
+    "    scaled_frame.to_csv(scale_path)\n",
+    "    m5_scaled_paths[name] = scale_path\n",
+    "\n",
+    "execution_time = time.time() - start_time\n",
+    "\n",
+    "print(f\"Number of features are: {features_5min_raw.shape[1]}\")\n",
+    "print(features_5min_raw.shape)\n",
+    "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
+    "print(f\"Saved {len(m5_raw_blocks) * 2} DataFrames for the M5 timeframe.\")\n",
+    "features_5min_raw.tail(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7Vw_2C-ZEO57",
+   "metadata": {
+    "id": "7Vw_2C-ZEO57"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(m5_raw_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "j4AwNJic6icv",
+   "metadata": {
+    "id": "j4AwNJic6icv"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved raw feature files:\")\n",
+    "for name, path in m5_raw_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "QX4cSq3Ftqhm",
+   "metadata": {
+    "id": "QX4cSq3Ftqhm"
+   },
+   "source": [
+    "**Scale_features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1qEb1Cz1vzj6",
+   "metadata": {
+    "id": "1qEb1Cz1vzj6"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved scaled feature files:\")\n",
+    "for name, path in m5_scaled_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eJcGUESttqhm",
+   "metadata": {
+    "id": "eJcGUESttqhm"
+   },
+   "outputs": [],
+   "source": [
+    "m5_scaled_blocks['Create_Features'].head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "BFVUCAe3GWFy",
+   "metadata": {
+    "id": "BFVUCAe3GWFy"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (scaled, sorted):\")\n",
+    "print(m5_scaled_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aXMGezVftqhn",
+   "metadata": {
+    "id": "aXMGezVftqhn"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"M5 feature blocks:\", list(m5_raw_blocks.keys()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jh9-mi26wsya",
+   "metadata": {
+    "id": "jh9-mi26wsya"
+   },
+   "source": [
+    "## 10_min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bgh3Xz5ux75A",
+   "metadata": {
+    "id": "bgh3Xz5ux75A"
+   },
+   "outputs": [],
+   "source": [
+    "# Read the CSV file\n",
+    "df_10min = pd.read_csv(root_data + 'Data/'+symbol+'_M10.csv', index_col=0)\n",
+    "df_10min.index = pd.to_datetime(df_10min.index)\n",
+    "#df_10min = df_10min.iloc[-100000:,]\n",
+    "\n",
+    "print('Min_Date : ', df_10min.index.min())\n",
+    "print('Min_Date : ', df_10min.index.max())\n",
+    "print('Number_Rows = ',len(df_10min.index))\n",
+    "print('\\n')\n",
+    "\n",
+    "df_10min.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "WZRt7qxmx75A",
+   "metadata": {
+    "id": "WZRt7qxmx75A"
+   },
+   "source": [
+    "**Features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Enk8RNZ3x75B",
+   "metadata": {
+    "id": "Enk8RNZ3x75B"
+   },
+   "outputs": [],
+   "source": [
+    "# Create the Features Set\n",
+    "start_time = time.time()\n",
+    "\n",
+    "features_10min_raw, components_10min = create_features(df_10min, return_components=True)\n",
+    "features_10min_raw = features_10min_raw.dropna()\n",
+    "valid_index_10min = features_10min_raw.index\n",
+    "\n",
+    "m10_raw_blocks: Dict[str, pd.DataFrame] = {name: frame.loc[valid_index_10min].copy()\n",
+    "                                           for name, frame in components_10min.items()}\n",
+    "m10_raw_blocks['Create_Features'] = features_10min_raw\n",
+    "\n",
+    "# Apply the 10min_ prefix to every block\n",
+    "prefixed_blocks_10min: Dict[str, pd.DataFrame] = {}\n",
+    "for name, frame in m10_raw_blocks.items():\n",
+    "    prefixed = frame.add_prefix('10min_')\n",
+    "    prefixed = prefixed.rename(columns={'10min_Date': 'Date'})\n",
+    "    prefixed_blocks_10min[name] = prefixed\n",
+    "\n",
+    "m10_raw_blocks = prefixed_blocks_10min\n",
+    "m10_scaled_blocks: Dict[str, pd.DataFrame] = {}\n",
+    "m10_raw_paths: Dict[str, str] = {}\n",
+    "m10_scaled_paths: Dict[str, str] = {}\n",
+    "\n",
+    "for name, frame in m10_raw_blocks.items():\n",
+    "    filename_raw = f\"{symbol}_M10_{name}_Raw_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M10_Raw_Features.csv\"\n",
+    "    raw_path = os.path.join(root_data, 'Results', filename_raw)\n",
+    "    frame.to_csv(raw_path)\n",
+    "    m10_raw_paths[name] = raw_path\n",
+    "\n",
+    "    scaled_frame = scale_feature_block(frame)\n",
+    "    m10_scaled_blocks[name] = scaled_frame\n",
+    "    filename_scale = f\"{symbol}_M10_{name}_Scale_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M10_Scale_Features.csv\"\n",
+    "    scale_path = os.path.join(root_data, 'Results', filename_scale)\n",
+    "    scaled_frame.to_csv(scale_path)\n",
+    "    m10_scaled_paths[name] = scale_path\n",
+    "\n",
+    "execution_time = time.time() - start_time\n",
+    "\n",
+    "print(f\"Number of features are: {m10_raw_blocks['Create_Features'].shape[1]}\")\n",
+    "print(m10_raw_blocks['Create_Features'].shape)\n",
+    "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
+    "print(f\"Saved {len(m10_raw_blocks) * 2} DataFrames for the M10 timeframe.\")\n",
+    "m10_raw_blocks['Create_Features'].tail(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZREQYp1Px75B",
+   "metadata": {
+    "id": "ZREQYp1Px75B"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (sorted):\",'\n",
+    "')\n",
+    "print(m10_raw_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "F7wu9XEqx75B",
+   "metadata": {
+    "id": "F7wu9XEqx75B"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved raw feature files (M10):\")\n",
+    "for name, path in m10_raw_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "OM1OXL0tx75B",
+   "metadata": {
+    "id": "OM1OXL0tx75B"
+   },
+   "source": [
+    "**Scale_features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "D_ktgzyhx75C",
+   "metadata": {
+    "id": "D_ktgzyhx75C"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved scaled feature files (M10):\")\n",
+    "for name, path in m10_scaled_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qeSWEQdTx75D",
+   "metadata": {
+    "id": "qeSWEQdTx75D"
+   },
+   "outputs": [],
+   "source": [
+    "m10_scaled_blocks['Create_Features'].tail()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "g5XpLxmSeP53",
+   "metadata": {
+    "id": "g5XpLxmSeP53"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (scaled, sorted):\",'\n",
+    "')\n",
+    "print(m10_scaled_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "RAYGNhPex75E",
+   "metadata": {
+    "id": "RAYGNhPex75E"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"M10 feature blocks:\", list(m10_raw_blocks.keys()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dexDJat0XWBi",
+   "metadata": {
+    "id": "dexDJat0XWBi"
+   },
+   "source": [
+    "## 15_min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "KiPN3qSWXWBj",
+   "metadata": {
+    "id": "KiPN3qSWXWBj"
+   },
+   "outputs": [],
+   "source": [
+    "# Read the CSV file\n",
+    "df_15min = pd.read_csv(root_data + 'Data/'+symbol+'_M15.csv', index_col=0)\n",
+    "df_15min.index = pd.to_datetime(df_15min.index)\n",
+    "#df_15min = df_15min.iloc[-500000:,]\n",
+    "#df_15min = df_15min.iloc[-5000:,]\n",
+    "\n",
+    "print('Min_Date : ', df_15min.index.min())\n",
+    "print('Min_Date : ', df_15min.index.max())\n",
+    "print('Number_Rows = ',len(df_15min.index))\n",
+    "print('\\n')\n",
+    "\n",
+    "df_15min.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "V4zWjMGtXWBk",
+   "metadata": {
+    "id": "V4zWjMGtXWBk"
+   },
+   "source": [
+    "**Features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "DmkzrcRjXWBm",
+   "metadata": {
+    "id": "DmkzrcRjXWBm"
+   },
+   "outputs": [],
+   "source": [
+    "start_time = time.time()\n",
+    "\n",
+    "features_15min_raw, components_15min = create_features(df_15min, return_components=True)\n",
+    "features_15min_raw = features_15min_raw.dropna()\n",
+    "valid_index_15min = features_15min_raw.index\n",
+    "\n",
+    "m15_raw_blocks: Dict[str, pd.DataFrame] = {name: frame.loc[valid_index_15min].copy()\n",
+    "                                           for name, frame in components_15min.items()}\n",
+    "m15_raw_blocks['Create_Features'] = features_15min_raw\n",
+    "\n",
+    "prefixed_blocks_15min: Dict[str, pd.DataFrame] = {}\n",
+    "for name, frame in m15_raw_blocks.items():\n",
+    "    prefixed = frame.add_prefix('15min_')\n",
+    "    prefixed = prefixed.rename(columns={'15min_Date': 'Date'})\n",
+    "    prefixed_blocks_15min[name] = prefixed\n",
+    "\n",
+    "m15_raw_blocks = prefixed_blocks_15min\n",
+    "m15_scaled_blocks: Dict[str, pd.DataFrame] = {}\n",
+    "m15_raw_paths: Dict[str, str] = {}\n",
+    "m15_scaled_paths: Dict[str, str] = {}\n",
+    "\n",
+    "for name, frame in m15_raw_blocks.items():\n",
+    "    filename_raw = f\"{symbol}_M15_{name}_Raw_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M15_Raw_Features.csv\"\n",
+    "    raw_path = os.path.join(root_data, 'Results', filename_raw)\n",
+    "    frame.to_csv(raw_path)\n",
+    "    m15_raw_paths[name] = raw_path\n",
+    "\n",
+    "    scaled_frame = scale_feature_block(frame)\n",
+    "    m15_scaled_blocks[name] = scaled_frame\n",
+    "    filename_scale = f\"{symbol}_M15_{name}_Scale_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M15_Scale_Features.csv\"\n",
+    "    scale_path = os.path.join(root_data, 'Results', filename_scale)\n",
+    "    scaled_frame.to_csv(scale_path)\n",
+    "    m15_scaled_paths[name] = scale_path\n",
+    "\n",
+    "execution_time = time.time() - start_time\n",
+    "\n",
+    "print(f\"Number of features are: {m15_raw_blocks['Create_Features'].shape[1]}\")\n",
+    "print(m15_raw_blocks['Create_Features'].shape)\n",
+    "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
+    "print(f\"Saved {len(m15_raw_blocks) * 2} DataFrames for the M15 timeframe.\")\n",
+    "m15_raw_blocks['Create_Features'].tail(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "AVfc4FqyJ5d0",
+   "metadata": {
+    "id": "AVfc4FqyJ5d0"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(m15_raw_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "yGHSgJnYXWBn",
+   "metadata": {
+    "id": "yGHSgJnYXWBn"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved raw feature files (M15):\")\n",
+    "for name, path in m15_raw_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "VRhYUP2RXWBn",
+   "metadata": {
+    "id": "VRhYUP2RXWBn"
+   },
+   "source": [
+    "**Scale_features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "kqXbXgJWXWBn",
+   "metadata": {
+    "id": "kqXbXgJWXWBn"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved scaled feature files (M15):\")\n",
+    "for name, path in m15_scaled_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "j6kGfSpyXWBo",
+   "metadata": {
+    "id": "j6kGfSpyXWBo"
+   },
+   "outputs": [],
+   "source": [
+    "m15_scaled_blocks['Create_Features'].tail()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZmwG_RFHJyji",
+   "metadata": {
+    "id": "ZmwG_RFHJyji"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (scaled, sorted):\")\n",
+    "print(m15_scaled_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '\n",
+    "')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "IXiZG3OpXWBo",
+   "metadata": {
+    "id": "IXiZG3OpXWBo"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"M15 feature blocks:\", list(m15_raw_blocks.keys()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "W1Pk4Hkfjhvt",
+   "metadata": {
+    "id": "W1Pk4Hkfjhvt"
+   },
+   "source": [
+    "**Plots**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67453c9e",
+   "metadata": {
+    "id": "67453c9e"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "last_200_features_15min = m15_scaled_blocks['Create_Features'].tail(200)\n",
+    "last_200_df_15min = df_15min.tail(200)\n",
+    "\n",
+    "indicators_to_plot = ['Close','15min_Kal_300','15min_Kal_600']\n",
+    "\n",
+    "# Separate Close from other indicators\n",
+    "close_to_plot = 'Close' if 'Close' in indicators_to_plot else None\n",
+    "other_indicators_to_plot = [col for col in indicators_to_plot if col != 'Close' and col in last_200_features_15min.columns]\n",
+    "\n",
+    "num_plots = len(other_indicators_to_plot) + (1 if close_to_plot else 0)\n",
+    "\n",
+    "# Plotting\n",
+    "fig, axes = plt.subplots(nrows=num_plots, ncols=1, figsize=(15, 2.5 * num_plots), sharex=True)\n",
+    "\n",
+    "# Ensure axes is an array even if only one plot\n",
+    "if not isinstance(axes, np.ndarray):\n",
+    "    axes = np.array([axes])\n",
+    "\n",
+    "current_plot_index = 0\n",
+    "\n",
+    "# Plot Close price if requested\n",
+    "if close_to_plot:\n",
+    "    axes[current_plot_index].plot(last_200_df_15min.index, last_200_df_15min['Close'])\n",
+    "    axes[current_plot_index].set_title('Close Price')\n",
+    "    axes[current_plot_index].grid(True)\n",
+    "    current_plot_index += 1\n",
+    "\n",
+    "# Plot each selected indicator (excluding 'Close')\n",
+    "for col in other_indicators_to_plot:\n",
+    "    axes[current_plot_index].plot(last_200_features_15min.index, last_200_features_15min[col])\n",
+    "    axes[current_plot_index].set_title(col)\n",
+    "    axes[current_plot_index].grid(True)\n",
+    "    current_plot_index += 1\n",
+    "\n",
+    "#plt.tight_layout()\n",
+    "#plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "A5c__w6s_dtY",
+   "metadata": {
+    "id": "A5c__w6s_dtY"
+   },
+   "source": [
+    "# Feature Importance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4j7J8tk_f3o-",
+   "metadata": {
+    "id": "4j7J8tk_f3o-"
+   },
+   "source": [
+    "## Labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6XOsumPycYz3",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 386
+    },
+    "id": "6XOsumPycYz3",
+    "outputId": "1ea7780a-8f29-4d3d-fc7e-019c53182ea5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min_Date    :  2019-01-02 01:00:00\n",
+      "Min_Date    :  2025-07-25 23:55:00 \n",
+      "\n",
+      "Number_Rows :  (465718, 29) \n",
+      "\n",
+      "Columns     :  Index(['Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Spread', 'ATR',\n",
+      "       'kal_1', 'kal_2', 'kal_3', 'kal_4', 'Open_Trade', 'Close_Trade',\n",
+      "       'Entry_Date', 'Type', 'Trade_Number', 'st_Exit_Date', 'trade type',\n",
+      "       'st_Duration', 'st_row_PnL_close', 'st_row_PnL_high', 'st_row_PnL_Low',\n",
+      "       'st_row_PnL_low', 'st_Max', 'st_Min', 'st_PnL', 'st_atr_PnL',\n",
+      "       'st_atr_max_PnL'],\n",
+      "      dtype='object')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Open_Trade</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>33915</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>-1.0</th>\n",
+       "      <td>33858</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div><br><label><b>dtype:</b> int64</label>"
+      ],
+      "text/plain": [
+       "Open_Trade\n",
+       " 1.0    33915\n",
+       "-1.0    33858\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lab = pd.read_csv(root_data + 'Results/'+symbol+'_'+strategy+'_'+time_frame+'_Strategy_Gen_Labels.csv', index_col=0)\n",
+    "lab['Date'] = pd.to_datetime(lab['Date'])\n",
+    "\n",
+    "print('Min_Date    : ',lab['Date'].min())\n",
+    "print('Min_Date    : ',lab['Date'].max(),'\\n')\n",
+    "print('Number_Rows : ',lab.shape,'\\n')\n",
+    "print('Columns     : ',lab.columns)\n",
+    "\n",
+    "lab['Open_Trade'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "apV2tezPsbux",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "apV2tezPsbux",
+    "outputId": "7f607a0e-ad79-4597-e1f4-33f48387f9b2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total_Trades = 67,773\n",
+      "\n",
+      "Mean st_atr_max_PnL = 238.39\n",
+      "\n",
+      "Above_Mean = 11,463,914.00\n",
+      "Below_Mean = 4,691,967.00\n",
+      "\n",
+      "<= 0.5 = 33.00\n",
+      "> 0.5 & <= 1 = 801,960.00\n",
+      "> 1 & <= 1.5 = 1,411,119.00\n",
+      "> 1.5 & <= 2 = 1,400,438.00\n",
+      "> 2 = 11,277,394.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "#analyse_column = 'st_atr_max_PnL'\n",
+    "analyse_column = 'st_Max'\n",
+    "\n",
+    "st_max_0  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
+    "st_max_1  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
+    "st_max_2  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].sum()\n",
+    "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].sum()\n",
+    "\n",
+    "\n",
+    "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 0)),analyse_column].sum()\n",
+    "\n",
+    "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 0.7) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].sum()\n",
+    "\n",
+    "st_max_5 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 1) &\n",
+    "                   (lab['st_atr_max_PnL'] <= 1.5)),analyse_column].sum()\n",
+    "\n",
+    "st_max_6 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 1.5) &\n",
+    "                   (lab['st_atr_max_PnL'] <= 2)),analyse_column].sum()\n",
+    "\n",
+    "st_max_7 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 2)),analyse_column].sum()\n",
+    "\n",
+    "\n",
+    "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
+    "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
+    "print(f'Above_Mean = {st_max_2:,.2f}')\n",
+    "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
+    "\n",
+    "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
+    "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
+    "print(f'> 1 & <= 1.5 = {st_max_5:,.2f}')\n",
+    "print(f'> 1.5 & <= 2 = {st_max_6:,.2f}')\n",
+    "print(f'> 2 = {st_max_7:,.2f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "p2fjs4Si792v",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "p2fjs4Si792v",
+    "outputId": "3c59923a-5da8-47d2-9e1a-7e1e9a0c0962"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total_Trades = 67,773\n",
+      "\n",
+      "Mean st_atr_max_PnL = 1.89\n",
+      "\n",
+      "Above_Mean = 20,857.00\n",
+      "Below_Mean = 46,913.00\n",
+      "\n",
+      "<= 0.5 = 20,431.00\n",
+      "> 0.5 & <= 1 = 13,116.00\n",
+      "> 1 = 34,223.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "analyse_column = 'st_atr_max_PnL'\n",
+    "\n",
+    "st_max_0 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
+    "st_max_1 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
+    "st_max_2 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].count()\n",
+    "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].count()\n",
+    "\n",
+    "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                    (lab['st_atr_max_PnL'] <= 0.5)),analyse_column].count()\n",
+    "\n",
+    "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                     (lab['st_atr_max_PnL'] >= 0.5) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].count()\n",
+    "\n",
+    "st_max_5 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] >= 1), analyse_column].count()\n",
+    "\n",
+    "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
+    "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
+    "print(f'Above_Mean = {st_max_2:,.2f}')\n",
+    "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
+    "\n",
+    "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
+    "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
+    "print(f'> 1 = {st_max_5:,.2f}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85DATjQqZd66",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "85DATjQqZd66",
+    "outputId": "67c11f5a-3b3a-4b07-ecbc-f572c96d5c5f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Value counts de label 4/5/6:\n",
+      "label\n",
+      "0    33547\n",
+      "1    34223\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Parámetros / campos\n",
+    "result_field = 'st_atr_max_PnL'\n",
+    "\n",
+    "#valid = (\n",
+    "#    (lab['Type'] == direction) &\n",
+    "#    (lab['Open_Trade'].isin([1, -1])) &\n",
+    "#    (lab[result_field].notna()))\n",
+    "\n",
+    "valid = (\n",
+    "    (lab['Open_Trade'].isin([1, -1])) &\n",
+    "    (lab[result_field].notna()))\n",
+    "\n",
+    "\n",
+    "# --- Etiquetado en la columna \"label\" con valores 4/5/6\n",
+    "lab['label'] = np.nan\n",
+    "lab.loc[valid & (lab[result_field] <= 1), 'label'] = 0\n",
+    "lab.loc[valid & (lab[result_field] >= 1), 'label'] = 1\n",
+    "\n",
+    "\n",
+    "# --- Mantener solo filas válidas y con label\n",
+    "lab = lab.loc[valid & lab['label'].notna()].copy()\n",
+    "lab['label'] = lab['label'].astype('int8')\n",
+    "\n",
+    "# --- Ver distribución de labels 4/5/6\n",
+    "print('\\nValue counts de label 4/5/6:')\n",
+    "print(lab['label'].value_counts(dropna=False).sort_index())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "_BCdqt3Y0Fjm",
+   "metadata": {
+    "id": "_BCdqt3Y0Fjm"
+   },
+   "source": [
+    "## Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "u1I6_IHtGgbE",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "u1I6_IHtGgbE",
+    "outputId": "34870a70-f3ba-466d-b262-10a3f5939f29"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(268296, 366)\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_feat_15min = pd.read_csv(root_data+'Results/'+symbol+'_M15_Raw_Features.csv')\n",
+    "raw_feat_15min[\"Date\"] = pd.to_datetime(raw_feat_15min[\"Date\"])\n",
+    "print(raw_feat_15min.shape)\n",
+    "#raw_feat_15min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8jK6LavOGgbF",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 464
+    },
+    "id": "8jK6LavOGgbF",
+    "outputId": "e2efdd27-f6c2-488b-89b9-a1dd0bddda4b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(268296, 366)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "type": "dataframe"
+      },
+      "text/html": [
+       "\n",
+       "  <div id=\"df-286e3991-0362-491b-8235-b21743710d56\" class=\"colab-df-container\">\n",
+       "    <div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Date</th>\n",
+       "      <th>15min_OBV</th>\n",
+       "      <th>15min_RSI_3</th>\n",
+       "      <th>15min_MFI_3</th>\n",
+       "      <th>15min_RSI_7</th>\n",
+       "      <th>15min_MFI_7</th>\n",
+       "      <th>15min_RSI_14</th>\n",
+       "      <th>15min_MFI_14</th>\n",
+       "      <th>15min_RSI_3_diff</th>\n",
+       "      <th>15min_RSI_7_diff</th>\n",
+       "      <th>...</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6</th>\n",
+       "      <th>15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9</th>\n",
+       "      <th>15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6</th>\n",
+       "      <th>15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9</th>\n",
+       "      <th>15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>268291</th>\n",
+       "      <td>2025-07-25 23:10:00</td>\n",
+       "      <td>-0.678811</td>\n",
+       "      <td>-0.876084</td>\n",
+       "      <td>-1.302567</td>\n",
+       "      <td>0.119717</td>\n",
+       "      <td>-0.719882</td>\n",
+       "      <td>0.897443</td>\n",
+       "      <td>0.911516</td>\n",
+       "      <td>-0.368162</td>\n",
+       "      <td>-0.506248</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.081175</td>\n",
+       "      <td>0.044165</td>\n",
+       "      <td>-0.063931</td>\n",
+       "      <td>0.07562</td>\n",
+       "      <td>-0.02420</td>\n",
+       "      <td>-0.103575</td>\n",
+       "      <td>-0.026669</td>\n",
+       "      <td>-0.090598</td>\n",
+       "      <td>0.013099</td>\n",
+       "      <td>0.099235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>268292</th>\n",
+       "      <td>2025-07-25 23:20:00</td>\n",
+       "      <td>-0.713760</td>\n",
+       "      <td>-1.108173</td>\n",
+       "      <td>-1.292210</td>\n",
+       "      <td>-0.149088</td>\n",
+       "      <td>-1.438063</td>\n",
+       "      <td>0.732902</td>\n",
+       "      <td>0.520889</td>\n",
+       "      <td>-0.289632</td>\n",
+       "      <td>-0.461977</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.081175</td>\n",
+       "      <td>0.044165</td>\n",
+       "      <td>-0.063931</td>\n",
+       "      <td>0.07562</td>\n",
+       "      <td>-0.02420</td>\n",
+       "      <td>-0.103575</td>\n",
+       "      <td>-0.026669</td>\n",
+       "      <td>-0.090598</td>\n",
+       "      <td>0.013099</td>\n",
+       "      <td>0.099235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>268293</th>\n",
+       "      <td>2025-07-25 23:30:00</td>\n",
+       "      <td>-0.649067</td>\n",
+       "      <td>1.064528</td>\n",
+       "      <td>-0.311180</td>\n",
+       "      <td>1.102293</td>\n",
+       "      <td>-1.572824</td>\n",
+       "      <td>1.394754</td>\n",
+       "      <td>0.325417</td>\n",
+       "      <td>2.685337</td>\n",
+       "      <td>2.126853</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.081175</td>\n",
+       "      <td>0.044165</td>\n",
+       "      <td>-0.063931</td>\n",
+       "      <td>0.07562</td>\n",
+       "      <td>-0.02420</td>\n",
+       "      <td>-0.103575</td>\n",
+       "      <td>-0.026669</td>\n",
+       "      <td>-0.090598</td>\n",
+       "      <td>0.013099</td>\n",
+       "      <td>0.099235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>268294</th>\n",
+       "      <td>2025-07-25 23:40:00</td>\n",
+       "      <td>-0.707530</td>\n",
+       "      <td>-0.566703</td>\n",
+       "      <td>-0.264287</td>\n",
+       "      <td>-0.315545</td>\n",
+       "      <td>-1.524675</td>\n",
+       "      <td>0.396390</td>\n",
+       "      <td>0.554163</td>\n",
+       "      <td>-2.004983</td>\n",
+       "      <td>-2.380777</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.081175</td>\n",
+       "      <td>0.044165</td>\n",
+       "      <td>-0.063931</td>\n",
+       "      <td>0.07562</td>\n",
+       "      <td>-0.02420</td>\n",
+       "      <td>-0.103575</td>\n",
+       "      <td>-0.026669</td>\n",
+       "      <td>-0.090598</td>\n",
+       "      <td>0.013099</td>\n",
+       "      <td>0.099235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>268295</th>\n",
+       "      <td>2025-07-25 23:50:00</td>\n",
+       "      <td>-0.652857</td>\n",
+       "      <td>-0.487742</td>\n",
+       "      <td>-0.286408</td>\n",
+       "      <td>-0.265147</td>\n",
+       "      <td>-1.447693</td>\n",
+       "      <td>0.422128</td>\n",
+       "      <td>0.223350</td>\n",
+       "      <td>0.097241</td>\n",
+       "      <td>0.085239</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.081175</td>\n",
+       "      <td>0.030089</td>\n",
+       "      <td>-0.089578</td>\n",
+       "      <td>0.07562</td>\n",
+       "      <td>-0.03686</td>\n",
+       "      <td>-0.118712</td>\n",
+       "      <td>-0.026669</td>\n",
+       "      <td>-0.090598</td>\n",
+       "      <td>0.026669</td>\n",
+       "      <td>0.115957</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 366 columns</p>\n",
+       "</div>\n",
+       "    <div class=\"colab-df-buttons\">\n",
+       "\n",
+       "  <div class=\"colab-df-container\">\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-286e3991-0362-491b-8235-b21743710d56')\"\n",
+       "            title=\"Convert this dataframe to an interactive table.\"\n",
+       "            style=\"display:none;\">\n",
+       "\n",
+       "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+       "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+       "  </svg>\n",
+       "    </button>\n",
+       "\n",
+       "  <style>\n",
+       "    .colab-df-container {\n",
+       "      display:flex;\n",
+       "      gap: 12px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert {\n",
+       "      background-color: #E8F0FE;\n",
+       "      border: none;\n",
+       "      border-radius: 50%;\n",
+       "      cursor: pointer;\n",
+       "      display: none;\n",
+       "      fill: #1967D2;\n",
+       "      height: 32px;\n",
+       "      padding: 0 0 0 0;\n",
+       "      width: 32px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert:hover {\n",
+       "      background-color: #E2EBFA;\n",
+       "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "      fill: #174EA6;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-buttons div {\n",
+       "      margin-bottom: 4px;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert {\n",
+       "      background-color: #3B4455;\n",
+       "      fill: #D2E3FC;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert:hover {\n",
+       "      background-color: #434B5C;\n",
+       "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+       "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+       "      fill: #FFFFFF;\n",
+       "    }\n",
+       "  </style>\n",
+       "\n",
+       "    <script>\n",
+       "      const buttonEl =\n",
+       "        document.querySelector('#df-286e3991-0362-491b-8235-b21743710d56 button.colab-df-convert');\n",
+       "      buttonEl.style.display =\n",
+       "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "\n",
+       "      async function convertToInteractive(key) {\n",
+       "        const element = document.querySelector('#df-286e3991-0362-491b-8235-b21743710d56');\n",
+       "        const dataTable =\n",
+       "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+       "                                                    [key], {});\n",
+       "        if (!dataTable) return;\n",
+       "\n",
+       "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+       "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+       "          + ' to learn more about interactive tables.';\n",
+       "        element.innerHTML = '';\n",
+       "        dataTable['output_type'] = 'display_data';\n",
+       "        await google.colab.output.renderOutput(dataTable, element);\n",
+       "        const docLink = document.createElement('div');\n",
+       "        docLink.innerHTML = docLinkHtml;\n",
+       "        element.appendChild(docLink);\n",
+       "      }\n",
+       "    </script>\n",
+       "  </div>\n",
+       "\n",
+       "\n",
+       "    <div id=\"df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff\">\n",
+       "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff')\"\n",
+       "                title=\"Suggest charts\"\n",
+       "                style=\"display:none;\">\n",
+       "\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+       "     width=\"24px\">\n",
+       "    <g>\n",
+       "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+       "    </g>\n",
+       "</svg>\n",
+       "      </button>\n",
+       "\n",
+       "<style>\n",
+       "  .colab-df-quickchart {\n",
+       "      --bg-color: #E8F0FE;\n",
+       "      --fill-color: #1967D2;\n",
+       "      --hover-bg-color: #E2EBFA;\n",
+       "      --hover-fill-color: #174EA6;\n",
+       "      --disabled-fill-color: #AAA;\n",
+       "      --disabled-bg-color: #DDD;\n",
+       "  }\n",
+       "\n",
+       "  [theme=dark] .colab-df-quickchart {\n",
+       "      --bg-color: #3B4455;\n",
+       "      --fill-color: #D2E3FC;\n",
+       "      --hover-bg-color: #434B5C;\n",
+       "      --hover-fill-color: #FFFFFF;\n",
+       "      --disabled-bg-color: #3B4455;\n",
+       "      --disabled-fill-color: #666;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart {\n",
+       "    background-color: var(--bg-color);\n",
+       "    border: none;\n",
+       "    border-radius: 50%;\n",
+       "    cursor: pointer;\n",
+       "    display: none;\n",
+       "    fill: var(--fill-color);\n",
+       "    height: 32px;\n",
+       "    padding: 0;\n",
+       "    width: 32px;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart:hover {\n",
+       "    background-color: var(--hover-bg-color);\n",
+       "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "    fill: var(--button-hover-fill-color);\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart-complete:disabled,\n",
+       "  .colab-df-quickchart-complete:disabled:hover {\n",
+       "    background-color: var(--disabled-bg-color);\n",
+       "    fill: var(--disabled-fill-color);\n",
+       "    box-shadow: none;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-spinner {\n",
+       "    border: 2px solid var(--fill-color);\n",
+       "    border-color: transparent;\n",
+       "    border-bottom-color: var(--fill-color);\n",
+       "    animation:\n",
+       "      spin 1s steps(1) infinite;\n",
+       "  }\n",
+       "\n",
+       "  @keyframes spin {\n",
+       "    0% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "      border-left-color: var(--fill-color);\n",
+       "    }\n",
+       "    20% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    30% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    40% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    60% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    80% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "    90% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "  }\n",
+       "</style>\n",
+       "\n",
+       "      <script>\n",
+       "        async function quickchart(key) {\n",
+       "          const quickchartButtonEl =\n",
+       "            document.querySelector('#' + key + ' button');\n",
+       "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+       "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+       "          try {\n",
+       "            const charts = await google.colab.kernel.invokeFunction(\n",
+       "                'suggestCharts', [key], {});\n",
+       "          } catch (error) {\n",
+       "            console.error('Error during call to suggestCharts:', error);\n",
+       "          }\n",
+       "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+       "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+       "        }\n",
+       "        (() => {\n",
+       "          let quickchartButtonEl =\n",
+       "            document.querySelector('#df-5ee1e4a8-9c6a-4272-8677-7b68b9b769ff button');\n",
+       "          quickchartButtonEl.style.display =\n",
+       "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "        })();\n",
+       "      </script>\n",
+       "    </div>\n",
+       "\n",
+       "    </div>\n",
+       "  </div>\n"
+      ],
+      "text/plain": [
+       "                      Date  15min_OBV  15min_RSI_3  15min_MFI_3  15min_RSI_7  \\\n",
+       "268291 2025-07-25 23:10:00  -0.678811    -0.876084    -1.302567     0.119717   \n",
+       "268292 2025-07-25 23:20:00  -0.713760    -1.108173    -1.292210    -0.149088   \n",
+       "268293 2025-07-25 23:30:00  -0.649067     1.064528    -0.311180     1.102293   \n",
+       "268294 2025-07-25 23:40:00  -0.707530    -0.566703    -0.264287    -0.315545   \n",
+       "268295 2025-07-25 23:50:00  -0.652857    -0.487742    -0.286408    -0.265147   \n",
+       "\n",
+       "        15min_MFI_7  15min_RSI_14  15min_MFI_14  15min_RSI_3_diff  \\\n",
+       "268291    -0.719882      0.897443      0.911516         -0.368162   \n",
+       "268292    -1.438063      0.732902      0.520889         -0.289632   \n",
+       "268293    -1.572824      1.394754      0.325417          2.685337   \n",
+       "268294    -1.524675      0.396390      0.554163         -2.004983   \n",
+       "268295    -1.447693      0.422128      0.223350          0.097241   \n",
+       "\n",
+       "        15min_RSI_7_diff  ...  \\\n",
+       "268291         -0.506248  ...   \n",
+       "268292         -0.461977  ...   \n",
+       "268293          2.126853  ...   \n",
+       "268294         -2.380777  ...   \n",
+       "268295          0.085239  ...   \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9  \\\n",
+       "268291                                           0.081175               \n",
+       "268292                                           0.081175               \n",
+       "268293                                           0.081175               \n",
+       "268294                                           0.081175               \n",
+       "268295                                           0.081175               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3  \\\n",
+       "268291                                           0.044165               \n",
+       "268292                                           0.044165               \n",
+       "268293                                           0.044165               \n",
+       "268294                                           0.044165               \n",
+       "268295                                           0.030089               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6  \\\n",
+       "268291                                          -0.063931               \n",
+       "268292                                          -0.063931               \n",
+       "268293                                          -0.063931               \n",
+       "268294                                          -0.063931               \n",
+       "268295                                          -0.089578               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9  \\\n",
+       "268291                                            0.07562               \n",
+       "268292                                            0.07562               \n",
+       "268293                                            0.07562               \n",
+       "268294                                            0.07562               \n",
+       "268295                                            0.07562               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3  \\\n",
+       "268291                                           -0.02420               \n",
+       "268292                                           -0.02420               \n",
+       "268293                                           -0.02420               \n",
+       "268294                                           -0.02420               \n",
+       "268295                                           -0.03686               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6  \\\n",
+       "268291                                          -0.103575               \n",
+       "268292                                          -0.103575               \n",
+       "268293                                          -0.103575               \n",
+       "268294                                          -0.103575               \n",
+       "268295                                          -0.118712               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9  \\\n",
+       "268291                                          -0.026669               \n",
+       "268292                                          -0.026669               \n",
+       "268293                                          -0.026669               \n",
+       "268294                                          -0.026669               \n",
+       "268295                                          -0.026669               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6  \\\n",
+       "268291                                          -0.090598               \n",
+       "268292                                          -0.090598               \n",
+       "268293                                          -0.090598               \n",
+       "268294                                          -0.090598               \n",
+       "268295                                          -0.090598               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9  \\\n",
+       "268291                                           0.013099               \n",
+       "268292                                           0.013099               \n",
+       "268293                                           0.013099               \n",
+       "268294                                           0.013099               \n",
+       "268295                                           0.026669               \n",
+       "\n",
+       "        15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9  \n",
+       "268291                                           0.099235              \n",
+       "268292                                           0.099235              \n",
+       "268293                                           0.099235              \n",
+       "268294                                           0.099235              \n",
+       "268295                                           0.115957              \n",
+       "\n",
+       "[5 rows x 366 columns]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scale_feat_15min = pd.read_csv(root_data+'Results/'+symbol+'_M15_Scale_Features.csv')\n",
+    "scale_feat_15min = scale_feat_15min.drop('Unnamed: 0', axis=1)\n",
+    "scale_feat_15min.rename(columns={'15min_Date': 'Date'}, inplace=True)\n",
+    "scale_feat_15min[\"Date\"] = pd.to_datetime(scale_feat_15min[\"Date\"])\n",
+    "print(scale_feat_15min.shape)\n",
+    "scale_feat_15min.tail(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gX04ZTmfz-pK",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "gX04ZTmfz-pK",
+    "outputId": "d5f990fd-0ded-4589-e070-20b49bc5c7ba"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(465703, 366)\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
+    "raw_feat_5min[\"Date\"] = pd.to_datetime(raw_feat_5min[\"Date\"])\n",
+    "print(raw_feat_5min.shape)\n",
+    "#raw_feat_5min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "D5gxf0ke0KUx",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "D5gxf0ke0KUx",
+    "outputId": "929a5d72-b5dc-4c51-b709-02d56fd6a1d4"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(465703, 366)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scale_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Scale_Features.csv')\n",
+    "scale_feat_5min = scale_feat_5min.drop('Unnamed: 0', axis=1)\n",
+    "scale_feat_5min[\"Date\"] = pd.to_datetime(scale_feat_5min[\"Date\"])\n",
+    "print(scale_feat_5min.shape)\n",
+    "#scale_feat_5min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hwsOt0mbFWeo",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "hwsOt0mbFWeo",
+    "outputId": "3c3260c0-ae61-4eb2-fc97-103f30fed2a0"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NaN counts per column (sorted): \n",
+      "\n",
+      "slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    199\n",
+      "slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9    199\n",
+      "OBV                                                        199\n",
+      "RSI_3                                                      199\n",
+      "MFI_3                                                      199\n",
+      "                                                          ... \n",
+      "MFI_3 - MFI_7                                              199\n",
+      "MFI_3 - MFI_14                                             199\n",
+      "MFI_7 - MFI_14                                             199\n",
+      "OBV_diff                                                   199\n",
+      "Date                                                         0\n",
+      "Length: 366, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"NaN counts per column (sorted):\",'\\n')\n",
+    "print(scale_feat_5min.isnull().sum().sort_values(ascending=False), '\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cHlD0eRb0scj",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "cHlD0eRb0scj",
+    "outputId": "0005b140-a44c-4835-e176-c33df3cfb033"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(268281, 366)\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_feat_10min = pd.read_csv(root_data+'Results/'+symbol+'_M10_Raw_Features.csv')\n",
+    "raw_feat_10min[\"Date\"] = pd.to_datetime(raw_feat_10min[\"Date\"])\n",
+    "\n",
+    "# Add \"10min_\" prefix to all column names except 'Date'\n",
+    "cols_to_prefix = [col for col in raw_feat_10min.columns if col != 'Date']\n",
+    "raw_feat_10min.rename(columns={col: col for col in cols_to_prefix}, inplace=True)\n",
+    "\n",
+    "print(raw_feat_10min.shape)\n",
+    "#raw_feat_10min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "O7xrmOA90sck",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "O7xrmOA90sck",
+    "outputId": "12383796-8d5c-4941-bdd4-d9cdea8acdd1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(268281, 366)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scale_feat_10min = pd.read_csv(root_data+'Results/'+symbol+'_M10_Scale_Features.csv')\n",
+    "scale_feat_10min = scale_feat_10min.drop('Unnamed: 0', axis=1)\n",
+    "scale_feat_10min[\"Date\"] = pd.to_datetime(scale_feat_10min[\"Date\"])\n",
+    "\n",
+    "# Add \"10min_\" prefix to all column names except 'Date'\n",
+    "cols_to_prefix = [col for col in scale_feat_10min.columns if col != 'Date']\n",
+    "scale_feat_10min.rename(columns={col:col for col in cols_to_prefix}, inplace=True)\n",
+    "\n",
+    "print(scale_feat_10min.shape)\n",
+    "#scale_feat_10min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3rH4dF7HFmJy",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "3rH4dF7HFmJy",
+    "outputId": "3fb60e92-7e81-4b06-ab3e-c825b6e03f00"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NaN counts per column (sorted): \n",
+      "\n",
+      "10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    199\n",
+      "10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9    199\n",
+      "10min_OBV                                                        199\n",
+      "10min_RSI_3                                                      199\n",
+      "10min_MFI_3                                                      199\n",
+      "                                                                ... \n",
+      "10min_MFI_3 - MFI_7                                              199\n",
+      "10min_MFI_3 - MFI_14                                             199\n",
+      "10min_MFI_7 - MFI_14                                             199\n",
+      "10min_OBV_diff                                                   199\n",
+      "Date                                                               0\n",
+      "Length: 366, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"NaN counts per column (sorted):\",'\\n')\n",
+    "print(scale_feat_10min.isnull().sum().sort_values(ascending=False), '\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Hv5bsrpc03z7",
+   "metadata": {
+    "id": "Hv5bsrpc03z7"
+   },
+   "source": [
+    "## Merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Mc1y2NbRM_f1",
+   "metadata": {
+    "id": "Mc1y2NbRM_f1"
+   },
+   "outputs": [],
+   "source": [
+    "data_type = 'Scale'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "I0gkNVT60Ka5",
+   "metadata": {
+    "id": "I0gkNVT60Ka5"
+   },
+   "outputs": [],
+   "source": [
+    "# Add \"15min_\" prefix to all column names except 'Date'\n",
+    "cols_to_prefix_15min = [col for col in scale_feat_15min.columns if col != 'Date']\n",
+    "scale_feat_15min.rename(columns={col: '15min_' + col for col in cols_to_prefix_15min}, inplace=True)\n",
+    "\n",
+    "# First merge scale_feat_5min with scale_feat_10min and apply forward fill\n",
+    "merged_features = scale_feat_5min.merge(scale_feat_10min, on='Date', how='left').ffill()\n",
+    "merged_features = merged_features.merge(scale_feat_15min, on='Date', how='left').ffill()\n",
+    "\n",
+    "# Remove 'Open_Trade' from lab before merging to avoid duplicate columns and ensure correct ordering\n",
+    "df = pd.merge(lab[['Date', 'label', 'Open_Trade']], merged_features, on='Date', how='left')\n",
+    "\n",
+    "cols = df.columns.tolist()\n",
+    "cols.remove('label')\n",
+    "cols.insert(1, 'label')\n",
+    "df = df[cols]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fQPfQroWYLRM",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "fQPfQroWYLRM",
+    "outputId": "a16c0c78-937e-43ca-faa6-5146f2c0ef27"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Columns with '15min_' prefix found:\n",
+      "['15min_15min_OBV', '15min_15min_RSI_3', '15min_15min_MFI_3', '15min_15min_RSI_7', '15min_15min_MFI_7', '15min_15min_RSI_14', '15min_15min_MFI_14', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_Kal_300', '15min_15min_Close_Kal_300', '15min_15min_Kal_change_300', '15min_15min_Kal_prev_minus_now_300', '15min_15min_Kal_prev2_minus_now_300', '15min_15min_Kal_change2_300', '15min_15min_Kal_600', '15min_15min_Close_Kal_600', '15min_15min_Kal_change_600', '15min_15min_Kal_prev_minus_now_600', '15min_15min_Kal_prev2_minus_now_600', '15min_15min_Kal_change2_600', '15min_15min_Kal_900', '15min_15min_Close_Kal_900', '15min_15min_Kal_change_900', '15min_15min_Kal_prev_minus_now_900', '15min_15min_Kal_prev2_minus_now_900', '15min_15min_Kal_change2_900', '15min_15min_Kal_300_minus_Kal_600', '15min_15min_Kal_300_minus_Kal_900', '15min_15min_Kal_600_minus_Kal_900', '15min_15min_slope_div_300_3', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check for columns with '1min_' prefix\n",
+    "one_min_cols = [col for col in df.columns if '15min_' in col]\n",
+    "\n",
+    "if one_min_cols:\n",
+    "    print(\"Columns with '15min_' prefix found:\")\n",
+    "    print(one_min_cols)\n",
+    "else:\n",
+    "    print(\"No columns with '15min_' prefix found.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jXcXWty506Ur",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jXcXWty506Ur",
+    "outputId": "10f79c82-4b66-4e5b-eb07-cf2e6beda361"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(67770, 1098) \n",
+      "\n",
+      "Label_Counts :  label\n",
+      "1    34223\n",
+      "0    33547\n",
+      "Name: count, dtype: int64 \n",
+      "\n",
+      "['Date', 'label', 'Open_Trade', 'OBV', 'RSI_3', 'MFI_3', 'RSI_7', 'MFI_7', 'RSI_14', 'MFI_14', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'MFI_3_diff', 'MFI_7_diff', 'MFI_14_diff', 'MFI_3 - MFI_7', 'MFI_3 - MFI_14', 'MFI_7 - MFI_14', 'OBV_diff', 'Kal_300', 'Close_Kal_300', 'Kal_change_300', 'Kal_prev_minus_now_300', 'Kal_prev2_minus_now_300', 'Kal_change2_300', 'Kal_600', 'Close_Kal_600', 'Kal_change_600', 'Kal_prev_minus_now_600', 'Kal_prev2_minus_now_600', 'Kal_change2_600', 'Kal_900', 'Close_Kal_900', 'Kal_change_900', 'Kal_prev_minus_now_900', 'Kal_prev2_minus_now_900', 'Kal_change2_900', 'Kal_300_minus_Kal_600', 'Kal_300_minus_Kal_900', 'Kal_600_minus_Kal_900', 'slope_div_300_3', 'slope_div_300_3_diff', 'slope_signal_300_3', 'slope_signal_300_3_diff', 'slope_angle_300_3', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6', 'slope_div_300_6_diff', 'slope_signal_300_6', 'slope_signal_300_6_diff', 'slope_angle_300_6', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9', 'slope_div_300_9_diff', 'slope_signal_300_9', 'slope_signal_300_9_diff', 'slope_angle_300_9', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3', 'slope_div_600_3_diff', 'slope_signal_600_3', 'slope_signal_600_3_diff', 'slope_angle_600_3', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6', 'slope_div_600_6_diff', 'slope_signal_600_6', 'slope_signal_600_6_diff', 'slope_angle_600_6', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9', 'slope_div_600_9_diff', 'slope_signal_600_9', 'slope_signal_600_9_diff', 'slope_angle_600_9', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3', 'slope_div_900_3_diff', 'slope_signal_900_3', 'slope_signal_900_3_diff', 'slope_angle_900_3', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6', 'slope_div_900_6_diff', 'slope_signal_900_6', 'slope_signal_900_6_diff', 'slope_angle_900_6', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9', 'slope_div_900_9_diff', 'slope_signal_900_9', 'slope_signal_900_9_diff', 'slope_angle_900_9', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '10min_OBV', '10min_RSI_3', '10min_MFI_3', '10min_RSI_7', '10min_MFI_7', '10min_RSI_14', '10min_MFI_14', '10min_RSI_3_diff', '10min_RSI_7_diff', '10min_RSI_14_diff', '10min_RSI_3 - RSI_7', '10min_RSI_3 - RSI_14', '10min_RSI_7 - RSI_14', '10min_MFI_3_diff', '10min_MFI_7_diff', '10min_MFI_14_diff', '10min_MFI_3 - MFI_7', '10min_MFI_3 - MFI_14', '10min_MFI_7 - MFI_14', '10min_OBV_diff', '10min_Kal_300', '10min_Close_Kal_300', '10min_Kal_change_300', '10min_Kal_prev_minus_now_300', '10min_Kal_prev2_minus_now_300', '10min_Kal_change2_300', '10min_Kal_600', '10min_Close_Kal_600', '10min_Kal_change_600', '10min_Kal_prev_minus_now_600', '10min_Kal_prev2_minus_now_600', '10min_Kal_change2_600', '10min_Kal_900', '10min_Close_Kal_900', '10min_Kal_change_900', '10min_Kal_prev_minus_now_900', '10min_Kal_prev2_minus_now_900', '10min_Kal_change2_900', '10min_Kal_300_minus_Kal_600', '10min_Kal_300_minus_Kal_900', '10min_Kal_600_minus_Kal_900', '10min_slope_div_300_3', '10min_slope_div_300_3_diff', '10min_slope_signal_300_3', '10min_slope_signal_300_3_diff', '10min_slope_angle_300_3', '10min_slope_angle_300_3_diff', '10min_slope_angle_signal_300_3', '10min_slope_angle_signal_300_3_diff', '10min_slope_lin_reg_300_3', '10min_slope_lin_reg_300_3_diff', '10min_slope_lin_reg_signal_300_3', '10min_slope_lin_reg_signal_300_3_diff', '10min_slope_div_300_6', '10min_slope_div_300_6_diff', '10min_slope_signal_300_6', '10min_slope_signal_300_6_diff', '10min_slope_angle_300_6', '10min_slope_angle_300_6_diff', '10min_slope_angle_signal_300_6', '10min_slope_angle_signal_300_6_diff', '10min_slope_lin_reg_300_6', '10min_slope_lin_reg_300_6_diff', '10min_slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_6_diff', '10min_slope_div_300_9', '10min_slope_div_300_9_diff', '10min_slope_signal_300_9', '10min_slope_signal_300_9_diff', '10min_slope_angle_300_9', '10min_slope_angle_300_9_diff', '10min_slope_angle_signal_300_9', '10min_slope_angle_signal_300_9_diff', '10min_slope_lin_reg_300_9', '10min_slope_lin_reg_300_9_diff', '10min_slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_9_diff', '10min_slope_div_600_3', '10min_slope_div_600_3_diff', '10min_slope_signal_600_3', '10min_slope_signal_600_3_diff', '10min_slope_angle_600_3', '10min_slope_angle_600_3_diff', '10min_slope_angle_signal_600_3', '10min_slope_angle_signal_600_3_diff', '10min_slope_lin_reg_600_3', '10min_slope_lin_reg_600_3_diff', '10min_slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_600_3_diff', '10min_slope_div_600_6', '10min_slope_div_600_6_diff', '10min_slope_signal_600_6', '10min_slope_signal_600_6_diff', '10min_slope_angle_600_6', '10min_slope_angle_600_6_diff', '10min_slope_angle_signal_600_6', '10min_slope_angle_signal_600_6_diff', '10min_slope_lin_reg_600_6', '10min_slope_lin_reg_600_6_diff', '10min_slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_6_diff', '10min_slope_div_600_9', '10min_slope_div_600_9_diff', '10min_slope_signal_600_9', '10min_slope_signal_600_9_diff', '10min_slope_angle_600_9', '10min_slope_angle_600_9_diff', '10min_slope_angle_signal_600_9', '10min_slope_angle_signal_600_9_diff', '10min_slope_lin_reg_600_9', '10min_slope_lin_reg_600_9_diff', '10min_slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_9_diff', '10min_slope_div_900_3', '10min_slope_div_900_3_diff', '10min_slope_signal_900_3', '10min_slope_signal_900_3_diff', '10min_slope_angle_900_3', '10min_slope_angle_900_3_diff', '10min_slope_angle_signal_900_3', '10min_slope_angle_signal_900_3_diff', '10min_slope_lin_reg_900_3', '10min_slope_lin_reg_900_3_diff', '10min_slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_900_3_diff', '10min_slope_div_900_6', '10min_slope_div_900_6_diff', '10min_slope_signal_900_6', '10min_slope_signal_900_6_diff', '10min_slope_angle_900_6', '10min_slope_angle_900_6_diff', '10min_slope_angle_signal_900_6', '10min_slope_angle_signal_900_6_diff', '10min_slope_lin_reg_900_6', '10min_slope_lin_reg_900_6_diff', '10min_slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_6_diff', '10min_slope_div_900_9', '10min_slope_div_900_9_diff', '10min_slope_signal_900_9', '10min_slope_signal_900_9_diff', '10min_slope_angle_900_9', '10min_slope_angle_900_9_diff', '10min_slope_angle_signal_900_9', '10min_slope_angle_signal_900_9_diff', '10min_slope_lin_reg_900_9', '10min_slope_lin_reg_900_9_diff', '10min_slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_9_diff', '10min_slope_div_300_3 - slope_div_300_6', '10min_slope_div_300_3 - slope_div_300_9', '10min_slope_div_300_3 - slope_div_600_3', '10min_slope_div_300_3 - slope_div_600_6', '10min_slope_div_300_3 - slope_div_600_9', '10min_slope_div_300_3 - slope_div_900_3', '10min_slope_div_300_3 - slope_div_900_6', '10min_slope_div_300_3 - slope_div_900_9', '10min_slope_div_300_6 - slope_div_300_9', '10min_slope_div_300_6 - slope_div_600_3', '10min_slope_div_300_6 - slope_div_600_6', '10min_slope_div_300_6 - slope_div_600_9', '10min_slope_div_300_6 - slope_div_900_3', '10min_slope_div_300_6 - slope_div_900_6', '10min_slope_div_300_6 - slope_div_900_9', '10min_slope_div_300_9 - slope_div_600_3', '10min_slope_div_300_9 - slope_div_600_6', '10min_slope_div_300_9 - slope_div_600_9', '10min_slope_div_300_9 - slope_div_900_3', '10min_slope_div_300_9 - slope_div_900_6', '10min_slope_div_300_9 - slope_div_900_9', '10min_slope_div_600_3 - slope_div_600_6', '10min_slope_div_600_3 - slope_div_600_9', '10min_slope_div_600_3 - slope_div_900_3', '10min_slope_div_600_3 - slope_div_900_6', '10min_slope_div_600_3 - slope_div_900_9', '10min_slope_div_600_6 - slope_div_600_9', '10min_slope_div_600_6 - slope_div_900_3', '10min_slope_div_600_6 - slope_div_900_6', '10min_slope_div_600_6 - slope_div_900_9', '10min_slope_div_600_9 - slope_div_900_3', '10min_slope_div_600_9 - slope_div_900_6', '10min_slope_div_600_9 - slope_div_900_9', '10min_slope_div_900_3 - slope_div_900_6', '10min_slope_div_900_3 - slope_div_900_9', '10min_slope_div_900_6 - slope_div_900_9', '10min_slope_signal_300_3 - slope_signal_300_6', '10min_slope_signal_300_3 - slope_signal_300_9', '10min_slope_signal_300_3 - slope_signal_600_3', '10min_slope_signal_300_3 - slope_signal_600_6', '10min_slope_signal_300_3 - slope_signal_600_9', '10min_slope_signal_300_3 - slope_signal_900_3', '10min_slope_signal_300_3 - slope_signal_900_6', '10min_slope_signal_300_3 - slope_signal_900_9', '10min_slope_signal_300_6 - slope_signal_300_9', '10min_slope_signal_300_6 - slope_signal_600_3', '10min_slope_signal_300_6 - slope_signal_600_6', '10min_slope_signal_300_6 - slope_signal_600_9', '10min_slope_signal_300_6 - slope_signal_900_3', '10min_slope_signal_300_6 - slope_signal_900_6', '10min_slope_signal_300_6 - slope_signal_900_9', '10min_slope_signal_300_9 - slope_signal_600_3', '10min_slope_signal_300_9 - slope_signal_600_6', '10min_slope_signal_300_9 - slope_signal_600_9', '10min_slope_signal_300_9 - slope_signal_900_3', '10min_slope_signal_300_9 - slope_signal_900_6', '10min_slope_signal_300_9 - slope_signal_900_9', '10min_slope_signal_600_3 - slope_signal_600_6', '10min_slope_signal_600_3 - slope_signal_600_9', '10min_slope_signal_600_3 - slope_signal_900_3', '10min_slope_signal_600_3 - slope_signal_900_6', '10min_slope_signal_600_3 - slope_signal_900_9', '10min_slope_signal_600_6 - slope_signal_600_9', '10min_slope_signal_600_6 - slope_signal_900_3', '10min_slope_signal_600_6 - slope_signal_900_6', '10min_slope_signal_600_6 - slope_signal_900_9', '10min_slope_signal_600_9 - slope_signal_900_3', '10min_slope_signal_600_9 - slope_signal_900_6', '10min_slope_signal_600_9 - slope_signal_900_9', '10min_slope_signal_900_3 - slope_signal_900_6', '10min_slope_signal_900_3 - slope_signal_900_9', '10min_slope_signal_900_6 - slope_signal_900_9', '10min_slope_angle_300_3 - slope_angle_300_6', '10min_slope_angle_300_3 - slope_angle_300_9', '10min_slope_angle_300_3 - slope_angle_600_3', '10min_slope_angle_300_3 - slope_angle_600_6', '10min_slope_angle_300_3 - slope_angle_600_9', '10min_slope_angle_300_3 - slope_angle_900_3', '10min_slope_angle_300_3 - slope_angle_900_6', '10min_slope_angle_300_3 - slope_angle_900_9', '10min_slope_angle_300_6 - slope_angle_300_9', '10min_slope_angle_300_6 - slope_angle_600_3', '10min_slope_angle_300_6 - slope_angle_600_6', '10min_slope_angle_300_6 - slope_angle_600_9', '10min_slope_angle_300_6 - slope_angle_900_3', '10min_slope_angle_300_6 - slope_angle_900_6', '10min_slope_angle_300_6 - slope_angle_900_9', '10min_slope_angle_300_9 - slope_angle_600_3', '10min_slope_angle_300_9 - slope_angle_600_6', '10min_slope_angle_300_9 - slope_angle_600_9', '10min_slope_angle_300_9 - slope_angle_900_3', '10min_slope_angle_300_9 - slope_angle_900_6', '10min_slope_angle_300_9 - slope_angle_900_9', '10min_slope_angle_600_3 - slope_angle_600_6', '10min_slope_angle_600_3 - slope_angle_600_9', '10min_slope_angle_600_3 - slope_angle_900_3', '10min_slope_angle_600_3 - slope_angle_900_6', '10min_slope_angle_600_3 - slope_angle_900_9', '10min_slope_angle_600_6 - slope_angle_600_9', '10min_slope_angle_600_6 - slope_angle_900_3', '10min_slope_angle_600_6 - slope_angle_900_6', '10min_slope_angle_600_6 - slope_angle_900_9', '10min_slope_angle_600_9 - slope_angle_900_3', '10min_slope_angle_600_9 - slope_angle_900_6', '10min_slope_angle_600_9 - slope_angle_900_9', '10min_slope_angle_900_3 - slope_angle_900_6', '10min_slope_angle_900_3 - slope_angle_900_9', '10min_slope_angle_900_6 - slope_angle_900_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '15min_15min_OBV', '15min_15min_RSI_3', '15min_15min_MFI_3', '15min_15min_RSI_7', '15min_15min_MFI_7', '15min_15min_RSI_14', '15min_15min_MFI_14', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_Kal_300', '15min_15min_Close_Kal_300', '15min_15min_Kal_change_300', '15min_15min_Kal_prev_minus_now_300', '15min_15min_Kal_prev2_minus_now_300', '15min_15min_Kal_change2_300', '15min_15min_Kal_600', '15min_15min_Close_Kal_600', '15min_15min_Kal_change_600', '15min_15min_Kal_prev_minus_now_600', '15min_15min_Kal_prev2_minus_now_600', '15min_15min_Kal_change2_600', '15min_15min_Kal_900', '15min_15min_Close_Kal_900', '15min_15min_Kal_change_900', '15min_15min_Kal_prev_minus_now_900', '15min_15min_Kal_prev2_minus_now_900', '15min_15min_Kal_change2_900', '15min_15min_Kal_300_minus_Kal_600', '15min_15min_Kal_300_minus_Kal_900', '15min_15min_Kal_600_minus_Kal_900', '15min_15min_slope_div_300_3', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
+      "\n",
+      "NaN counts per column (sorted):\n",
+      "slope_angle_900_3 - slope_angle_900_6            29\n",
+      "slope_angle_600_9 - slope_angle_900_9            29\n",
+      "slope_angle_600_9 - slope_angle_900_6            29\n",
+      "slope_angle_600_9 - slope_angle_900_3            29\n",
+      "slope_angle_600_6 - slope_angle_900_9            29\n",
+      "                                                 ..\n",
+      "10min_slope_angle_300_3 - slope_angle_300_9       0\n",
+      "10min_slope_angle_300_3 - slope_angle_600_3       0\n",
+      "10min_slope_angle_300_3 - slope_angle_600_6       0\n",
+      "10min_slope_angle_300_3 - slope_angle_600_9       0\n",
+      "10min_slope_signal_600_6 - slope_signal_900_9     0\n",
+      "Length: 1098, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df.shape,'\\n')\n",
+    "print('Label_Counts : ',df.label.value_counts(),'\\n')\n",
+    "print(list(df.columns), '\\n')\n",
+    "\n",
+    "# Add NaN count per column, sorted\n",
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(df.isnull().sum().sort_values(ascending=False), '\\n')\n",
+    "\n",
+    "#df.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Suezit_quoZ1",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Suezit_quoZ1",
+    "outputId": "0f50a746-96f2-4a2d-d5b0-6042fc52407e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame with difference features:\n",
+      "(67770, 851) \n",
+      "\n",
+      "Label_Counts :  label\n",
+      "1    34223\n",
+      "0    33547\n",
+      "Name: count, dtype: int64 \n",
+      "\n",
+      "['Date', 'label', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'MFI_3_diff', 'MFI_7_diff', 'MFI_14_diff', 'MFI_3 - MFI_7', 'MFI_3 - MFI_14', 'MFI_7 - MFI_14', 'OBV_diff', 'slope_div_300_3_diff', 'slope_signal_300_3_diff', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6_diff', 'slope_signal_300_6_diff', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9_diff', 'slope_signal_300_9_diff', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3_diff', 'slope_signal_600_3_diff', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6_diff', 'slope_signal_600_6_diff', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9_diff', 'slope_signal_600_9_diff', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3_diff', 'slope_signal_900_3_diff', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6_diff', 'slope_signal_900_6_diff', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9_diff', 'slope_signal_900_9_diff', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '10min_RSI_3_diff', '10min_RSI_7_diff', '10min_RSI_14_diff', '10min_RSI_3 - RSI_7', '10min_RSI_3 - RSI_14', '10min_RSI_7 - RSI_14', '10min_MFI_3_diff', '10min_MFI_7_diff', '10min_MFI_14_diff', '10min_MFI_3 - MFI_7', '10min_MFI_3 - MFI_14', '10min_MFI_7 - MFI_14', '10min_OBV_diff', '10min_slope_div_300_3_diff', '10min_slope_signal_300_3_diff', '10min_slope_angle_300_3_diff', '10min_slope_angle_signal_300_3_diff', '10min_slope_lin_reg_300_3_diff', '10min_slope_lin_reg_signal_300_3_diff', '10min_slope_div_300_6_diff', '10min_slope_signal_300_6_diff', '10min_slope_angle_300_6_diff', '10min_slope_angle_signal_300_6_diff', '10min_slope_lin_reg_300_6_diff', '10min_slope_lin_reg_signal_300_6_diff', '10min_slope_div_300_9_diff', '10min_slope_signal_300_9_diff', '10min_slope_angle_300_9_diff', '10min_slope_angle_signal_300_9_diff', '10min_slope_lin_reg_300_9_diff', '10min_slope_lin_reg_signal_300_9_diff', '10min_slope_div_600_3_diff', '10min_slope_signal_600_3_diff', '10min_slope_angle_600_3_diff', '10min_slope_angle_signal_600_3_diff', '10min_slope_lin_reg_600_3_diff', '10min_slope_lin_reg_signal_600_3_diff', '10min_slope_div_600_6_diff', '10min_slope_signal_600_6_diff', '10min_slope_angle_600_6_diff', '10min_slope_angle_signal_600_6_diff', '10min_slope_lin_reg_600_6_diff', '10min_slope_lin_reg_signal_600_6_diff', '10min_slope_div_600_9_diff', '10min_slope_signal_600_9_diff', '10min_slope_angle_600_9_diff', '10min_slope_angle_signal_600_9_diff', '10min_slope_lin_reg_600_9_diff', '10min_slope_lin_reg_signal_600_9_diff', '10min_slope_div_900_3_diff', '10min_slope_signal_900_3_diff', '10min_slope_angle_900_3_diff', '10min_slope_angle_signal_900_3_diff', '10min_slope_lin_reg_900_3_diff', '10min_slope_lin_reg_signal_900_3_diff', '10min_slope_div_900_6_diff', '10min_slope_signal_900_6_diff', '10min_slope_angle_900_6_diff', '10min_slope_angle_signal_900_6_diff', '10min_slope_lin_reg_900_6_diff', '10min_slope_lin_reg_signal_900_6_diff', '10min_slope_div_900_9_diff', '10min_slope_signal_900_9_diff', '10min_slope_angle_900_9_diff', '10min_slope_angle_signal_900_9_diff', '10min_slope_lin_reg_900_9_diff', '10min_slope_lin_reg_signal_900_9_diff', '10min_slope_div_300_3 - slope_div_300_6', '10min_slope_div_300_3 - slope_div_300_9', '10min_slope_div_300_3 - slope_div_600_3', '10min_slope_div_300_3 - slope_div_600_6', '10min_slope_div_300_3 - slope_div_600_9', '10min_slope_div_300_3 - slope_div_900_3', '10min_slope_div_300_3 - slope_div_900_6', '10min_slope_div_300_3 - slope_div_900_9', '10min_slope_div_300_6 - slope_div_300_9', '10min_slope_div_300_6 - slope_div_600_3', '10min_slope_div_300_6 - slope_div_600_6', '10min_slope_div_300_6 - slope_div_600_9', '10min_slope_div_300_6 - slope_div_900_3', '10min_slope_div_300_6 - slope_div_900_6', '10min_slope_div_300_6 - slope_div_900_9', '10min_slope_div_300_9 - slope_div_600_3', '10min_slope_div_300_9 - slope_div_600_6', '10min_slope_div_300_9 - slope_div_600_9', '10min_slope_div_300_9 - slope_div_900_3', '10min_slope_div_300_9 - slope_div_900_6', '10min_slope_div_300_9 - slope_div_900_9', '10min_slope_div_600_3 - slope_div_600_6', '10min_slope_div_600_3 - slope_div_600_9', '10min_slope_div_600_3 - slope_div_900_3', '10min_slope_div_600_3 - slope_div_900_6', '10min_slope_div_600_3 - slope_div_900_9', '10min_slope_div_600_6 - slope_div_600_9', '10min_slope_div_600_6 - slope_div_900_3', '10min_slope_div_600_6 - slope_div_900_6', '10min_slope_div_600_6 - slope_div_900_9', '10min_slope_div_600_9 - slope_div_900_3', '10min_slope_div_600_9 - slope_div_900_6', '10min_slope_div_600_9 - slope_div_900_9', '10min_slope_div_900_3 - slope_div_900_6', '10min_slope_div_900_3 - slope_div_900_9', '10min_slope_div_900_6 - slope_div_900_9', '10min_slope_signal_300_3 - slope_signal_300_6', '10min_slope_signal_300_3 - slope_signal_300_9', '10min_slope_signal_300_3 - slope_signal_600_3', '10min_slope_signal_300_3 - slope_signal_600_6', '10min_slope_signal_300_3 - slope_signal_600_9', '10min_slope_signal_300_3 - slope_signal_900_3', '10min_slope_signal_300_3 - slope_signal_900_6', '10min_slope_signal_300_3 - slope_signal_900_9', '10min_slope_signal_300_6 - slope_signal_300_9', '10min_slope_signal_300_6 - slope_signal_600_3', '10min_slope_signal_300_6 - slope_signal_600_6', '10min_slope_signal_300_6 - slope_signal_600_9', '10min_slope_signal_300_6 - slope_signal_900_3', '10min_slope_signal_300_6 - slope_signal_900_6', '10min_slope_signal_300_6 - slope_signal_900_9', '10min_slope_signal_300_9 - slope_signal_600_3', '10min_slope_signal_300_9 - slope_signal_600_6', '10min_slope_signal_300_9 - slope_signal_600_9', '10min_slope_signal_300_9 - slope_signal_900_3', '10min_slope_signal_300_9 - slope_signal_900_6', '10min_slope_signal_300_9 - slope_signal_900_9', '10min_slope_signal_600_3 - slope_signal_600_6', '10min_slope_signal_600_3 - slope_signal_600_9', '10min_slope_signal_600_3 - slope_signal_900_3', '10min_slope_signal_600_3 - slope_signal_900_6', '10min_slope_signal_600_3 - slope_signal_900_9', '10min_slope_signal_600_6 - slope_signal_600_9', '10min_slope_signal_600_6 - slope_signal_900_3', '10min_slope_signal_600_6 - slope_signal_900_6', '10min_slope_signal_600_6 - slope_signal_900_9', '10min_slope_signal_600_9 - slope_signal_900_3', '10min_slope_signal_600_9 - slope_signal_900_6', '10min_slope_signal_600_9 - slope_signal_900_9', '10min_slope_signal_900_3 - slope_signal_900_6', '10min_slope_signal_900_3 - slope_signal_900_9', '10min_slope_signal_900_6 - slope_signal_900_9', '10min_slope_angle_300_3 - slope_angle_300_6', '10min_slope_angle_300_3 - slope_angle_300_9', '10min_slope_angle_300_3 - slope_angle_600_3', '10min_slope_angle_300_3 - slope_angle_600_6', '10min_slope_angle_300_3 - slope_angle_600_9', '10min_slope_angle_300_3 - slope_angle_900_3', '10min_slope_angle_300_3 - slope_angle_900_6', '10min_slope_angle_300_3 - slope_angle_900_9', '10min_slope_angle_300_6 - slope_angle_300_9', '10min_slope_angle_300_6 - slope_angle_600_3', '10min_slope_angle_300_6 - slope_angle_600_6', '10min_slope_angle_300_6 - slope_angle_600_9', '10min_slope_angle_300_6 - slope_angle_900_3', '10min_slope_angle_300_6 - slope_angle_900_6', '10min_slope_angle_300_6 - slope_angle_900_9', '10min_slope_angle_300_9 - slope_angle_600_3', '10min_slope_angle_300_9 - slope_angle_600_6', '10min_slope_angle_300_9 - slope_angle_600_9', '10min_slope_angle_300_9 - slope_angle_900_3', '10min_slope_angle_300_9 - slope_angle_900_6', '10min_slope_angle_300_9 - slope_angle_900_9', '10min_slope_angle_600_3 - slope_angle_600_6', '10min_slope_angle_600_3 - slope_angle_600_9', '10min_slope_angle_600_3 - slope_angle_900_3', '10min_slope_angle_600_3 - slope_angle_900_6', '10min_slope_angle_600_3 - slope_angle_900_9', '10min_slope_angle_600_6 - slope_angle_600_9', '10min_slope_angle_600_6 - slope_angle_900_3', '10min_slope_angle_600_6 - slope_angle_900_6', '10min_slope_angle_600_6 - slope_angle_900_9', '10min_slope_angle_600_9 - slope_angle_900_3', '10min_slope_angle_600_9 - slope_angle_900_6', '10min_slope_angle_600_9 - slope_angle_900_9', '10min_slope_angle_900_3 - slope_angle_900_6', '10min_slope_angle_900_3 - slope_angle_900_9', '10min_slope_angle_900_6 - slope_angle_900_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', '15min_15min_RSI_3_diff', '15min_15min_RSI_7_diff', '15min_15min_RSI_14_diff', '15min_15min_RSI_3 - RSI_7', '15min_15min_RSI_3 - RSI_14', '15min_15min_RSI_7 - RSI_14', '15min_15min_MFI_3_diff', '15min_15min_MFI_7_diff', '15min_15min_MFI_14_diff', '15min_15min_MFI_3 - MFI_7', '15min_15min_MFI_3 - MFI_14', '15min_15min_MFI_7 - MFI_14', '15min_15min_OBV_diff', '15min_15min_slope_div_300_3_diff', '15min_15min_slope_signal_300_3_diff', '15min_15min_slope_angle_300_3_diff', '15min_15min_slope_angle_signal_300_3_diff', '15min_15min_slope_lin_reg_300_3_diff', '15min_15min_slope_lin_reg_signal_300_3_diff', '15min_15min_slope_div_300_6_diff', '15min_15min_slope_signal_300_6_diff', '15min_15min_slope_angle_300_6_diff', '15min_15min_slope_angle_signal_300_6_diff', '15min_15min_slope_lin_reg_300_6_diff', '15min_15min_slope_lin_reg_signal_300_6_diff', '15min_15min_slope_div_300_9_diff', '15min_15min_slope_signal_300_9_diff', '15min_15min_slope_angle_300_9_diff', '15min_15min_slope_angle_signal_300_9_diff', '15min_15min_slope_lin_reg_300_9_diff', '15min_15min_slope_lin_reg_signal_300_9_diff', '15min_15min_slope_div_600_3_diff', '15min_15min_slope_signal_600_3_diff', '15min_15min_slope_angle_600_3_diff', '15min_15min_slope_angle_signal_600_3_diff', '15min_15min_slope_lin_reg_600_3_diff', '15min_15min_slope_lin_reg_signal_600_3_diff', '15min_15min_slope_div_600_6_diff', '15min_15min_slope_signal_600_6_diff', '15min_15min_slope_angle_600_6_diff', '15min_15min_slope_angle_signal_600_6_diff', '15min_15min_slope_lin_reg_600_6_diff', '15min_15min_slope_lin_reg_signal_600_6_diff', '15min_15min_slope_div_600_9_diff', '15min_15min_slope_signal_600_9_diff', '15min_15min_slope_angle_600_9_diff', '15min_15min_slope_angle_signal_600_9_diff', '15min_15min_slope_lin_reg_600_9_diff', '15min_15min_slope_lin_reg_signal_600_9_diff', '15min_15min_slope_div_900_3_diff', '15min_15min_slope_signal_900_3_diff', '15min_15min_slope_angle_900_3_diff', '15min_15min_slope_angle_signal_900_3_diff', '15min_15min_slope_lin_reg_900_3_diff', '15min_15min_slope_lin_reg_signal_900_3_diff', '15min_15min_slope_div_900_6_diff', '15min_15min_slope_signal_900_6_diff', '15min_15min_slope_angle_900_6_diff', '15min_15min_slope_angle_signal_900_6_diff', '15min_15min_slope_lin_reg_900_6_diff', '15min_15min_slope_lin_reg_signal_900_6_diff', '15min_15min_slope_div_900_9_diff', '15min_15min_slope_signal_900_9_diff', '15min_15min_slope_angle_900_9_diff', '15min_15min_slope_angle_signal_900_9_diff', '15min_15min_slope_lin_reg_900_9_diff', '15min_15min_slope_lin_reg_signal_900_9_diff', '15min_15min_slope_div_300_3 - slope_div_300_6', '15min_15min_slope_div_300_3 - slope_div_300_9', '15min_15min_slope_div_300_3 - slope_div_600_3', '15min_15min_slope_div_300_3 - slope_div_600_6', '15min_15min_slope_div_300_3 - slope_div_600_9', '15min_15min_slope_div_300_3 - slope_div_900_3', '15min_15min_slope_div_300_3 - slope_div_900_6', '15min_15min_slope_div_300_3 - slope_div_900_9', '15min_15min_slope_div_300_6 - slope_div_300_9', '15min_15min_slope_div_300_6 - slope_div_600_3', '15min_15min_slope_div_300_6 - slope_div_600_6', '15min_15min_slope_div_300_6 - slope_div_600_9', '15min_15min_slope_div_300_6 - slope_div_900_3', '15min_15min_slope_div_300_6 - slope_div_900_6', '15min_15min_slope_div_300_6 - slope_div_900_9', '15min_15min_slope_div_300_9 - slope_div_600_3', '15min_15min_slope_div_300_9 - slope_div_600_6', '15min_15min_slope_div_300_9 - slope_div_600_9', '15min_15min_slope_div_300_9 - slope_div_900_3', '15min_15min_slope_div_300_9 - slope_div_900_6', '15min_15min_slope_div_300_9 - slope_div_900_9', '15min_15min_slope_div_600_3 - slope_div_600_6', '15min_15min_slope_div_600_3 - slope_div_600_9', '15min_15min_slope_div_600_3 - slope_div_900_3', '15min_15min_slope_div_600_3 - slope_div_900_6', '15min_15min_slope_div_600_3 - slope_div_900_9', '15min_15min_slope_div_600_6 - slope_div_600_9', '15min_15min_slope_div_600_6 - slope_div_900_3', '15min_15min_slope_div_600_6 - slope_div_900_6', '15min_15min_slope_div_600_6 - slope_div_900_9', '15min_15min_slope_div_600_9 - slope_div_900_3', '15min_15min_slope_div_600_9 - slope_div_900_6', '15min_15min_slope_div_600_9 - slope_div_900_9', '15min_15min_slope_div_900_3 - slope_div_900_6', '15min_15min_slope_div_900_3 - slope_div_900_9', '15min_15min_slope_div_900_6 - slope_div_900_9', '15min_15min_slope_signal_300_3 - slope_signal_300_6', '15min_15min_slope_signal_300_3 - slope_signal_300_9', '15min_15min_slope_signal_300_3 - slope_signal_600_3', '15min_15min_slope_signal_300_3 - slope_signal_600_6', '15min_15min_slope_signal_300_3 - slope_signal_600_9', '15min_15min_slope_signal_300_3 - slope_signal_900_3', '15min_15min_slope_signal_300_3 - slope_signal_900_6', '15min_15min_slope_signal_300_3 - slope_signal_900_9', '15min_15min_slope_signal_300_6 - slope_signal_300_9', '15min_15min_slope_signal_300_6 - slope_signal_600_3', '15min_15min_slope_signal_300_6 - slope_signal_600_6', '15min_15min_slope_signal_300_6 - slope_signal_600_9', '15min_15min_slope_signal_300_6 - slope_signal_900_3', '15min_15min_slope_signal_300_6 - slope_signal_900_6', '15min_15min_slope_signal_300_6 - slope_signal_900_9', '15min_15min_slope_signal_300_9 - slope_signal_600_3', '15min_15min_slope_signal_300_9 - slope_signal_600_6', '15min_15min_slope_signal_300_9 - slope_signal_600_9', '15min_15min_slope_signal_300_9 - slope_signal_900_3', '15min_15min_slope_signal_300_9 - slope_signal_900_6', '15min_15min_slope_signal_300_9 - slope_signal_900_9', '15min_15min_slope_signal_600_3 - slope_signal_600_6', '15min_15min_slope_signal_600_3 - slope_signal_600_9', '15min_15min_slope_signal_600_3 - slope_signal_900_3', '15min_15min_slope_signal_600_3 - slope_signal_900_6', '15min_15min_slope_signal_600_3 - slope_signal_900_9', '15min_15min_slope_signal_600_6 - slope_signal_600_9', '15min_15min_slope_signal_600_6 - slope_signal_900_3', '15min_15min_slope_signal_600_6 - slope_signal_900_6', '15min_15min_slope_signal_600_6 - slope_signal_900_9', '15min_15min_slope_signal_600_9 - slope_signal_900_3', '15min_15min_slope_signal_600_9 - slope_signal_900_6', '15min_15min_slope_signal_600_9 - slope_signal_900_9', '15min_15min_slope_signal_900_3 - slope_signal_900_6', '15min_15min_slope_signal_900_3 - slope_signal_900_9', '15min_15min_slope_signal_900_6 - slope_signal_900_9', '15min_15min_slope_angle_300_3 - slope_angle_300_6', '15min_15min_slope_angle_300_3 - slope_angle_300_9', '15min_15min_slope_angle_300_3 - slope_angle_600_3', '15min_15min_slope_angle_300_3 - slope_angle_600_6', '15min_15min_slope_angle_300_3 - slope_angle_600_9', '15min_15min_slope_angle_300_3 - slope_angle_900_3', '15min_15min_slope_angle_300_3 - slope_angle_900_6', '15min_15min_slope_angle_300_3 - slope_angle_900_9', '15min_15min_slope_angle_300_6 - slope_angle_300_9', '15min_15min_slope_angle_300_6 - slope_angle_600_3', '15min_15min_slope_angle_300_6 - slope_angle_600_6', '15min_15min_slope_angle_300_6 - slope_angle_600_9', '15min_15min_slope_angle_300_6 - slope_angle_900_3', '15min_15min_slope_angle_300_6 - slope_angle_900_6', '15min_15min_slope_angle_300_6 - slope_angle_900_9', '15min_15min_slope_angle_300_9 - slope_angle_600_3', '15min_15min_slope_angle_300_9 - slope_angle_600_6', '15min_15min_slope_angle_300_9 - slope_angle_600_9', '15min_15min_slope_angle_300_9 - slope_angle_900_3', '15min_15min_slope_angle_300_9 - slope_angle_900_6', '15min_15min_slope_angle_300_9 - slope_angle_900_9', '15min_15min_slope_angle_600_3 - slope_angle_600_6', '15min_15min_slope_angle_600_3 - slope_angle_600_9', '15min_15min_slope_angle_600_3 - slope_angle_900_3', '15min_15min_slope_angle_600_3 - slope_angle_900_6', '15min_15min_slope_angle_600_3 - slope_angle_900_9', '15min_15min_slope_angle_600_6 - slope_angle_600_9', '15min_15min_slope_angle_600_6 - slope_angle_900_3', '15min_15min_slope_angle_600_6 - slope_angle_900_6', '15min_15min_slope_angle_600_6 - slope_angle_900_9', '15min_15min_slope_angle_600_9 - slope_angle_900_3', '15min_15min_slope_angle_600_9 - slope_angle_900_6', '15min_15min_slope_angle_600_9 - slope_angle_900_9', '15min_15min_slope_angle_900_3 - slope_angle_900_6', '15min_15min_slope_angle_900_3 - slope_angle_900_9', '15min_15min_slope_angle_900_6 - slope_angle_900_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', '15min_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', '15min_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', '15min_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', '15min_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', '15min_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
+      "\n",
+      "NaN counts per column (sorted):\n",
+      "slope_angle_signal_300_9 - slope_angle_signal_900_6          29\n",
+      "slope_angle_signal_300_9 - slope_angle_signal_900_3          29\n",
+      "slope_angle_signal_300_9 - slope_angle_signal_600_9          29\n",
+      "slope_angle_signal_300_9 - slope_angle_signal_600_6          29\n",
+      "slope_angle_signal_300_9 - slope_angle_signal_600_3          29\n",
+      "                                                             ..\n",
+      "10min_slope_angle_signal_300_6 - slope_angle_signal_900_3     0\n",
+      "10min_slope_angle_signal_300_6 - slope_angle_signal_900_6     0\n",
+      "10min_slope_angle_signal_300_6 - slope_angle_signal_900_9     0\n",
+      "10min_slope_angle_signal_300_9 - slope_angle_signal_600_3     0\n",
+      "10min_slope_angle_signal_300_3 - slope_angle_signal_900_9     0\n",
+      "Length: 851, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Select features containing 'diff' or '-' in their names\n",
+    "diff_features = df.filter(regex='diff|-')\n",
+    "\n",
+    "# Create a new dataframe with the Date column, label and the selected features\n",
+    "df_diff = pd.concat([df[['Date', 'label']], diff_features], axis=1)\n",
+    "\n",
+    "print(\"DataFrame with difference features:\")\n",
+    "print(df_diff.shape,'\\n')\n",
+    "print('Label_Counts : ',df_diff.label.value_counts(),'\\n')\n",
+    "print(list(df_diff.columns), '\\n')\n",
+    "\n",
+    "# Add NaN count per column, sorted\n",
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(df_diff.isnull().sum().sort_values(ascending=False), '\\n')\n",
+    "\n",
+    "#df_diff.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4TPpba7UChUY",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4TPpba7UChUY",
+    "outputId": "2f81a31c-2de8-4fbd-f1c6-a847eac106a7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flipped 33857 rows with Open_Trade = -1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Align feature directions so that shorts mirror longs\n",
+    "if 'Open_Trade' not in df.columns:\n",
+    "    raise KeyError(\"'Open_Trade' column is required in df to flip feature signs.\")\n",
+    "\n",
+    "# Attach the trade direction to the diff dataframe (kept for reference).\n",
+    "df_diff = df_diff.merge(df[['Date', 'Open_Trade']], on='Date', how='left')\n",
+    "\n",
+    "# Identify feature columns to flip (exclude identifiers/targets).\n",
+    "feature_cols = [col for col in df_diff.columns if col not in ['Date', 'label', 'Open_Trade']]\n",
+    "short_mask = df_diff['Open_Trade'] == -1\n",
+    "\n",
+    "if short_mask.any():\n",
+    "    df_diff.loc[short_mask, feature_cols] = df_diff.loc[short_mask, feature_cols] * -1\n",
+    "    print(f\"Flipped {short_mask.sum()} rows with Open_Trade = -1.\")\n",
+    "else:\n",
+    "    print(\"No rows with Open_Trade = -1 were found.\")\n",
+    "\n",
+    "# Reorder columns so Open_Trade stays next to the label for downstream steps.\n",
+    "ordered_cols = ['Date', 'label', 'Open_Trade'] + [col for col in feature_cols]\n",
+    "df_diff = df_diff[ordered_cols]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pQa8_4GpvRRf",
+   "metadata": {
+    "id": "pQa8_4GpvRRf"
+   },
+   "outputs": [],
+   "source": [
+    "df = df_diff.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lBtQecOO08zB",
+   "metadata": {
+    "id": "lBtQecOO08zB"
+   },
+   "source": [
+    "## ML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8rlkmypd9DJj",
+   "metadata": {
+    "id": "8rlkmypd9DJj"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 1. ENTRENAR Y OBTENER IMPORTANCIAS =====================\n",
+    "def compute_xgb_importance(\n",
+    "    X: pd.DataFrame,\n",
+    "    y: pd.Series,\n",
+    "    task: str = \"classification\",\n",
+    "    random_state: int = 42,\n",
+    "    **xgb_params: Any\n",
+    ") -> Tuple[pd.DataFrame, Any]:\n",
+    "    \"\"\"\n",
+    "    Entrena un modelo XGBoost y devuelve:\n",
+    "      - imp_df: DataFrame con 'feature', 'importance' y 'cum_importance'.\n",
+    "      - model : modelo ya entrenado.\n",
+    "\n",
+    "    Soporta:\n",
+    "      • Clasificación binaria o multiclase (detecta nº de clases).\n",
+    "      • Regresión (si task != 'classification').\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X : pd.DataFrame\n",
+    "        Matriz de características (sin la columna objetivo).\n",
+    "    y : pd.Series\n",
+    "        Etiquetas objetivo. Puede ser binaria (0/1) o multiclase (0..K-1).\n",
+    "    task : str, opcional\n",
+    "        \"classification\" (default) o \"regression\".\n",
+    "    random_state : int, opcional\n",
+    "        Semilla para reproducibilidad.\n",
+    "    **xgb_params : dict\n",
+    "        Parámetros adicionales para el estimador de XGBoost.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (imp_df, model)\n",
+    "        imp_df : DataFrame con importancias y su acumulado.\n",
+    "        model  : instancia entrenada de XGBClassifier / XGBRegressor.\n",
+    "    \"\"\"\n",
+    "    default_params: Dict[str, Any] = dict(\n",
+    "        n_estimators=500,\n",
+    "        max_depth=6,\n",
+    "        learning_rate=0.05,\n",
+    "        subsample=0.8,\n",
+    "        colsample_bytree=0.8,\n",
+    "        random_state=random_state,\n",
+    "        n_jobs=-1,\n",
+    "        tree_method=\"hist\",\n",
+    "    )\n",
+    "    default_params.update(xgb_params)\n",
+    "\n",
+    "    if task == \"classification\":\n",
+    "        # Detectar nº de clases\n",
+    "        classes = np.unique(y)\n",
+    "        n_classes = len(classes)\n",
+    "\n",
+    "        # XGBClassifier ajusta objetivo automáticamente, pero lo explicitamos:\n",
+    "        if n_classes > 2:\n",
+    "            default_params.setdefault(\"objective\", \"multi:softprob\")\n",
+    "            default_params.setdefault(\"num_class\", n_classes)\n",
+    "            eval_metric = \"mlogloss\"\n",
+    "        else:\n",
+    "            default_params.setdefault(\"objective\", \"binary:logistic\")\n",
+    "            eval_metric = \"logloss\"\n",
+    "\n",
+    "        model = XGBClassifier(eval_metric=eval_metric, **default_params)\n",
+    "\n",
+    "    else:\n",
+    "        model = XGBRegressor(**default_params)\n",
+    "\n",
+    "    model.fit(X, y)\n",
+    "\n",
+    "    imp_df = (\n",
+    "        pd.DataFrame({\n",
+    "            \"feature\": X.columns,\n",
+    "            \"importance\": model.feature_importances_\n",
+    "        })\n",
+    "        .sort_values(\"importance\", ascending=False)\n",
+    "        .reset_index(drop=True)\n",
+    "    )\n",
+    "    total_imp = imp_df[\"importance\"].sum()\n",
+    "    if total_imp == 0:\n",
+    "        # Evitar división por cero si el modelo devuelve todo cero (raro, pero posible)\n",
+    "        imp_df[\"cum_importance\"] = 0.0\n",
+    "    else:\n",
+    "        imp_df[\"cum_importance\"] = imp_df[\"importance\"].cumsum() / total_imp\n",
+    "\n",
+    "    return imp_df, model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3r9Di4Xx9DOU",
+   "metadata": {
+    "id": "3r9Di4Xx9DOU"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 2. SELECCIÓN DE FEATURES =====================\n",
+    "def select_features_with_importance(\n",
+    "    X: pd.DataFrame,\n",
+    "    imp_df: pd.DataFrame,\n",
+    "    top_n: Optional[int] = None,\n",
+    "    threshold: Optional[str | float] = None,\n",
+    "    cum_threshold: Optional[float] = 0.8\n",
+    ") -> Tuple[pd.DataFrame, List[str]]:\n",
+    "    \"\"\"\n",
+    "    Selección flexible de variables a partir de importancias de XGBoost.\n",
+    "\n",
+    "    Reglas:\n",
+    "      - Si top_n no es None           => usa el top_n.\n",
+    "      - Else si cum_threshold no None => usa importancia acumulada (p.ej. 0.8 = 80%).\n",
+    "      - Else usa threshold ('median', 'mean' o valor numérico).\n",
+    "\n",
+    "    Devuelve (X_reducido, lista_de_features).\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X : pd.DataFrame\n",
+    "        Matriz de características original.\n",
+    "    imp_df : pd.DataFrame\n",
+    "        DataFrame devuelto por compute_xgb_importance.\n",
+    "    top_n : int | None\n",
+    "        Número fijo de variables a conservar.\n",
+    "    threshold : str | float | None\n",
+    "        Umbral de importancia. Si str, usar 'median' o 'mean'.\n",
+    "    cum_threshold : float | None\n",
+    "        Porcentaje acumulado de importancia (0-1). Si None, se ignora.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (X_sel, keep)\n",
+    "        X_sel : subset de X con columnas seleccionadas.\n",
+    "        keep  : lista de nombres de columnas seleccionadas.\n",
+    "    \"\"\"\n",
+    "    if top_n is not None:\n",
+    "        keep = imp_df.head(top_n)[\"feature\"].tolist()\n",
+    "\n",
+    "    elif cum_threshold is not None:\n",
+    "        keep_mask = imp_df[\"cum_importance\"] <= float(cum_threshold)\n",
+    "        keep = imp_df.loc[keep_mask, \"feature\"].tolist()\n",
+    "        # asegurar que haya al menos una más para no quedarnos exactamente en el corte\n",
+    "        if len(keep) < len(imp_df):\n",
+    "            keep.append(imp_df.iloc[len(keep)][\"feature\"])\n",
+    "\n",
+    "    else:\n",
+    "        if threshold is None:\n",
+    "            threshold = \"median\"\n",
+    "        if isinstance(threshold, str):\n",
+    "            thr_val = imp_df[\"importance\"].agg(threshold)\n",
+    "        else:\n",
+    "            thr_val = float(threshold)\n",
+    "        keep = imp_df.loc[imp_df[\"importance\"] >= thr_val, \"feature\"].tolist()\n",
+    "\n",
+    "    return X[keep], keep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tCDZCTz2_v9z",
+   "metadata": {
+    "id": "tCDZCTz2_v9z"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 3. BÚSQUEDA DEL MEJOR UMBRAL ACUMULADO =====================\n",
+    "def find_best_cum_threshold(\n",
+    "    X_train: pd.DataFrame,\n",
+    "    y_train: pd.Series,\n",
+    "    X_valid: pd.DataFrame,\n",
+    "    y_valid: pd.Series,\n",
+    "    task: str = \"classification\",\n",
+    "    thresholds: Tuple[float, ...] = (0.6, 0.7, 0.8, 0.9),\n",
+    "    random_state: int = 42,\n",
+    "    metric: str = \"auto\",\n",
+    "    **xgb_params: Any\n",
+    ") -> Tuple[float, pd.DataFrame, pd.DataFrame]:\n",
+    "    \"\"\"\n",
+    "    Entrena un XGB en train, calcula importancias y prueba varios umbrales\n",
+    "    acumulados para ver cuál da la mejor métrica en valid.\n",
+    "\n",
+    "    Para CLASIFICACIÓN:\n",
+    "        - Detecta nº de clases.\n",
+    "        - Métrica por defecto (metric=\"auto\"):\n",
+    "            • Binaria: ROC-AUC (probabilidades de la clase positiva).\n",
+    "            • Multiclase: ROC-AUC macro OVR (usa predict_proba).\n",
+    "          Alternativas: metric=\"f1_macro\", \"accuracy\", \"logloss\" (se MINIMIZA).\n",
+    "    Para REGRESIÓN:\n",
+    "        - Usa R^2.\n",
+    "\n",
+    "    Devuelve:\n",
+    "        best_thr, res_df_ordenado_por_score_desc, imp_df\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X_train, y_train, X_valid, y_valid : pd.DataFrame / pd.Series\n",
+    "        Particiones de entrenamiento y validación.\n",
+    "    task : str\n",
+    "        \"classification\" (default) o \"regression\".\n",
+    "    thresholds : tuple[float, ...]\n",
+    "        Valores de umbral de importancia acumulada a evaluar (0-1).\n",
+    "    random_state : int\n",
+    "        Semilla para reproducibilidad.\n",
+    "    metric : str\n",
+    "        \"auto\" (default), \"roc_auc\", \"f1_macro\", \"accuracy\", \"logloss\" (clasif) o \"r2\" (regresión).\n",
+    "    **xgb_params : dict\n",
+    "        Parámetros extra para el estimador de XGBoost (pasan a compute y a los modelos internos).\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (best_thr, res_df, imp_df)\n",
+    "        best_thr : float\n",
+    "            Umbral con mejor score (o menor logloss si metric='logloss').\n",
+    "        res_df : pd.DataFrame\n",
+    "            Tabla con resultados por umbral (n_features, score).\n",
+    "        imp_df : pd.DataFrame\n",
+    "            Importancias calculadas en X_train / y_train.\n",
+    "    \"\"\"\n",
+    "    imp_df, _ = compute_xgb_importance(\n",
+    "        X_train, y_train, task=task, random_state=random_state, **xgb_params\n",
+    "    )\n",
+    "\n",
+    "    results = []\n",
+    "\n",
+    "    # Detectar nº de clases si es clasificación\n",
+    "    if task == \"classification\":\n",
+    "        classes = np.unique(y_train)\n",
+    "        n_classes = len(classes)\n",
+    "        if metric == \"auto\":\n",
+    "            metric_to_use = \"roc_auc\" if n_classes == 2 else \"roc_auc\"\n",
+    "        else:\n",
+    "            metric_to_use = metric\n",
+    "    else:\n",
+    "        metric_to_use = \"r2\" if metric == \"auto\" else metric\n",
+    "\n",
+    "    for thr in thresholds:\n",
+    "        X_tr_sel, cols = select_features_with_importance(\n",
+    "            X_train, imp_df, cum_threshold=thr, top_n=None, threshold=None\n",
+    "        )\n",
+    "        X_va_sel = X_valid[cols]\n",
+    "\n",
+    "        if task == \"classification\":\n",
+    "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
+    "            params.update(xgb_params)\n",
+    "\n",
+    "            if n_classes > 2:\n",
+    "                params.setdefault(\"objective\", \"multi:softprob\")\n",
+    "                params.setdefault(\"num_class\", n_classes)\n",
+    "                eval_metric = \"mlogloss\"\n",
+    "            else:\n",
+    "                params.setdefault(\"objective\", \"binary:logistic\")\n",
+    "                eval_metric = \"logloss\"\n",
+    "\n",
+    "            model_sel = XGBClassifier(eval_metric=eval_metric, **params)\n",
+    "            model_sel.fit(X_tr_sel, y_train)\n",
+    "\n",
+    "            # Probabilidades y predicciones\n",
+    "            proba = model_sel.predict_proba(X_va_sel)\n",
+    "            pred  = np.argmax(proba, axis=1) if n_classes > 2 else (proba[:, 1] >= 0.5).astype(int)\n",
+    "\n",
+    "            # Calcular métrica\n",
+    "            if metric_to_use == \"roc_auc\":\n",
+    "                if n_classes == 2:\n",
+    "                    score = roc_auc_score(y_valid, proba[:, 1])\n",
+    "                else:\n",
+    "                    # AUC macro One-vs-Rest\n",
+    "                    score = roc_auc_score(y_valid, proba, multi_class=\"ovr\", average=\"macro\")\n",
+    "            elif metric_to_use == \"f1_macro\":\n",
+    "                score = f1_score(y_valid, pred, average=\"macro\")\n",
+    "            elif metric_to_use == \"accuracy\":\n",
+    "                score = accuracy_score(y_valid, pred)\n",
+    "            elif metric_to_use == \"logloss\":\n",
+    "                # En este caso, menor es mejor. Guardamos negativo para mantener criterio \"mayor mejor\".\n",
+    "                score = -log_loss(y_valid, proba, labels=np.unique(y_train))\n",
+    "            else:\n",
+    "                raise ValueError(f\"Métrica no soportada: {metric_to_use}\")\n",
+    "\n",
+    "        else:\n",
+    "            # REGRESIÓN\n",
+    "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
+    "            params.update(xgb_params)\n",
+    "            model_sel = XGBRegressor(**params)\n",
+    "            model_sel.fit(X_tr_sel, y_train)\n",
+    "            pred = model_sel.predict(X_va_sel)\n",
+    "\n",
+    "            if metric_to_use == \"r2\":\n",
+    "                score = r2_score(y_valid, pred)\n",
+    "            else:\n",
+    "                raise ValueError(f\"Métrica de regresión no soportada: {metric_to_use}\")\n",
+    "\n",
+    "        results.append({\"cum_threshold\": thr, \"n_features\": len(cols), \"score\": score})\n",
+    "\n",
+    "    # Ordenar (si usamos logloss negado, mayor sigue siendo mejor)\n",
+    "    res_df = pd.DataFrame(results).sort_values(\"score\", ascending=False).reset_index(drop=True)\n",
+    "    best_thr = float(res_df.iloc[0][\"cum_threshold\"])\n",
+    "    return best_thr, res_df, imp_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "R0Dm8ZPGcBr7",
+   "metadata": {
+    "id": "R0Dm8ZPGcBr7"
+   },
+   "outputs": [],
+   "source": [
+    "def remove_highly_correlated_features(df, threshold=0.9):\n",
+    "\n",
+    "    # Solo numéricos para evitar errores y acelerar\n",
+    "    corr_matrix = df.corr(numeric_only=True).abs()\n",
+    "    upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape, dtype=bool), k=1))\n",
+    "\n",
+    "    to_drop = []\n",
+    "    for col in tqdm(upper.columns, desc=f\"Pruning corr > {threshold}\", unit=\"col\", leave=False):\n",
+    "        if (upper[col] > threshold).any():\n",
+    "            to_drop.append(col)\n",
+    "\n",
+    "    return df.drop(columns=to_drop, errors=\"ignore\"), to_drop\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WodcQEBJ_wAW",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 850,
+     "referenced_widgets": [
+      "9609059e3a254435ad1ac68a6a404d33",
+      "4290faf2225a4d32bde385b6521e9ab2",
+      "74a6582880894069ad603643f92d7690",
+      "da5e8d42499b429d9b286ba00635148a",
+      "aaaaf872df124159b5d3af65c70d3e83",
+      "24978cca329a49de8aa7134bfb61be2b",
+      "fc87caee4db1426fadc04572c74617b5",
+      "31586bc636e84cf8a9a8e287c337ded4",
+      "f033e19b4ce74802907e77d074d358dd",
+      "cde12ad7e71c47a7a3429ced6e034fcd",
+      "3abde22d56a04951806f97ceb50efa92"
+     ]
+    },
+    "id": "WodcQEBJ_wAW",
+    "outputId": "95371cc4-7f94-4d1e-cd81-846cddd81d9e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9609059e3a254435ad1ac68a6a404d33",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Pruning corr > 0.9:   0%|          | 0/850 [00:00<?, ?col/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logistic regression CV accuracy: 0.611824623560673\n",
+      "=== Importancias XGBoost ===\n",
+      "                                            feature  importance  \\\n",
+      "0                                  10min_RSI_3_diff    0.028439   \n",
+      "1                               10min_RSI_3 - RSI_7    0.024041   \n",
+      "2                      10min_slope_angle_300_3_diff    0.014504   \n",
+      "3                              10min_RSI_7 - RSI_14    0.007869   \n",
+      "4                                    RSI_7 - RSI_14    0.007382   \n",
+      "5                        10min_slope_div_300_3_diff    0.007044   \n",
+      "6                                        RSI_3_diff    0.006131   \n",
+      "7                                    10min_OBV_diff    0.005756   \n",
+      "8                     10min_slope_signal_900_9_diff    0.005219   \n",
+      "9                      10min_slope_angle_900_6_diff    0.005199   \n",
+      "10                                 10min_MFI_7_diff    0.005177   \n",
+      "11  10min_slope_lin_reg_300_3 - slope_lin_reg_600_3    0.005173   \n",
+      "12                             slope_div_300_6_diff    0.004984   \n",
+      "13      10min_slope_angle_600_3 - slope_angle_900_3    0.004778   \n",
+      "14                                 10min_MFI_3_diff    0.004606   \n",
+      "15      10min_slope_angle_300_3 - slope_angle_300_9    0.004583   \n",
+      "16                           slope_angle_300_6_diff    0.004534   \n",
+      "17                             slope_div_300_3_diff    0.004482   \n",
+      "18                     10min_slope_angle_900_9_diff    0.004434   \n",
+      "19      10min_slope_angle_300_6 - slope_angle_300_9    0.004397   \n",
+      "\n",
+      "    cum_importance  \n",
+      "0         0.028439  \n",
+      "1         0.052480  \n",
+      "2         0.066984  \n",
+      "3         0.074852  \n",
+      "4         0.082234  \n",
+      "5         0.089279  \n",
+      "6         0.095409  \n",
+      "7         0.101166  \n",
+      "8         0.106385  \n",
+      "9         0.111584  \n",
+      "10        0.116761  \n",
+      "11        0.121933  \n",
+      "12        0.126917  \n",
+      "13        0.131695  \n",
+      "14        0.136301  \n",
+      "15        0.140885  \n",
+      "16        0.145419  \n",
+      "17        0.149901  \n",
+      "18        0.154335  \n",
+      "19        0.158732  \n",
+      "Total features: 252\n",
+      "Features seleccionadas: 192\n",
+      "XGBoost CV accuracy: 0.6071302037201063\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ===================== 3. PIPELINE PRINCIPAL =====================\n",
+    "df = df.dropna()\n",
+    "y = df['label']\n",
+    "X = df.iloc[:, 2:]\n",
+    "\n",
+    "# --- 3.3 Split temporal (ejemplo simple 80/20) ---\n",
+    "split_idx = int(len(X) * 0.8)\n",
+    "X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]\n",
+    "y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]\n",
+    "\n",
+    "# --- 3.4 Remove correlated features ---\n",
+    "X_train_filtered, dropped_features = remove_highly_correlated_features(X_train, threshold=0.9)\n",
+    "X_test_filtered = X_test.drop(columns=dropped_features)\n",
+    "\n",
+    "# Baseline logistic regression with time-series CV\n",
+    "scaler = StandardScaler()\n",
+    "X_scaled = scaler.fit_transform(X_train_filtered)\n",
+    "tscv = TimeSeriesSplit(n_splits=5)\n",
+    "baseline = cross_val_score(LogisticRegression(max_iter=1000), X_scaled, y_train, cv=tscv).mean()\n",
+    "print('Logistic regression CV accuracy:', baseline)\n",
+    "\n",
+    "# --- 3.5 Importancias con XGBoost ---\n",
+    "imp_df, xgb_model = compute_xgb_importance(X_train_filtered, y_train, task='classification')\n",
+    "\n",
+    "print('=== Importancias XGBoost ===')\n",
+    "print(imp_df.head(20))\n",
+    "print(f'Total features: {len(imp_df)}')\n",
+    "\n",
+    "# --- 3.6 Selección (elige una opción) ---\n",
+    "X_train_sel, keep_cols = select_features_with_importance(X_train_filtered, imp_df, cum_threshold=0.8)\n",
+    "X_test_sel = X_test_filtered[keep_cols]\n",
+    "\n",
+    "print(f'Features seleccionadas: {len(keep_cols)}')\n",
+    "importance_map = imp_df.set_index(\"feature\")[\"importance\"]\n",
+    "selected_importances = pd.DataFrame({\n",
+    "    \"feature\": keep_cols,\n",
+    "    \"importance\": importance_map.reindex(keep_cols).values\n",
+    "})\n",
+    "selected_importances.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_ImportantCols.csv', index=False)\n",
+    "\n",
+    "# Save dataset with selected features\n",
+    "df_selected = df[['Date', 'label'] + keep_cols]\n",
+    "df_selected.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_Features.csv', index=False)\n",
+    "\n",
+    "# Time-series cross-validation with XGBoost\n",
+    "xgb_cv = XGBClassifier(eval_metric='logloss', n_estimators=500, max_depth=6, learning_rate=0.05, subsample=0.8, colsample_bytree=0.8, random_state=42, n_jobs=-1, tree_method='hist')\n",
+    "xgb_scores = cross_val_score(xgb_cv, X_train_sel, y_train, cv=tscv, scoring='accuracy')\n",
+    "print('XGBoost CV accuracy:', xgb_scores.mean())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2RFfhHT2AwAJ",
+   "metadata": {
+    "id": "2RFfhHT2AwAJ"
+   },
+   "source": [
+    "# Encode_Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jRl6BZWUZ-WI",
+   "metadata": {
+    "id": "jRl6BZWUZ-WI"
+   },
+   "outputs": [],
+   "source": [
+    "### Encode Features\n",
+    "\n",
+    "cols_to_scale = df.columns[1:]\n",
+    "model = Sequential()\n",
+    "model.add(Dense(64, activation='relu', input_shape=(len(cols_to_scale),)))\n",
+    "model.add(Dense(32, activation='relu'))\n",
+    "model.add(Dense(8, activation='relu'))\n",
+    "model.add(Dense(32, activation='relu'))\n",
+    "model.add(Dense(64, activation='relu'))\n",
+    "model.add(Dense(len(cols_to_scale), activation='linear'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3hmEdGGclTxU",
+   "metadata": {
+    "id": "3hmEdGGclTxU"
+   },
+   "outputs": [],
+   "source": [
+    "# Compile the model\n",
+    "model.compile(optimizer='adam', loss='mean_squared_error')\n",
+    "\n",
+    "# Train the autoencoder using the scaled features\n",
+    "cols_to_scale = df.columns[1:]\n",
+    "autoencoder = model.fit(df[cols_to_scale], df[cols_to_scale], epochs=100, batch_size=32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gfyyEElYwPQ_",
+   "metadata": {
+    "id": "gfyyEElYwPQ_"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the graph of Loss versus Epoch\n",
+    "plt.plot(autoencoder.history[\"loss\"])\n",
+    "plt.plot(figsize=(15, 7))\n",
+    "plt.title('Loss vs. Epoch', fontsize=16)\n",
+    "plt.xlabel('Epoch', fontsize=14)\n",
+    "plt.ylabel('Loss', fontsize=14)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "DmJ8a4TuwPRA",
+   "metadata": {
+    "id": "DmJ8a4TuwPRA"
+   },
+   "outputs": [],
+   "source": [
+    "# Select the columns to be scaled (from index 6 onwards)\n",
+    "cols_to_scale = df.columns[1:]\n",
+    "\n",
+    "reconstruction_error = np.square(df[cols_to_scale] - model.predict(df[cols_to_scale]))\n",
+    "feature_reconstruction_error = np.mean(reconstruction_error, axis=0)\n",
+    "feature_reconstruction_error_df = pd.DataFrame(feature_reconstruction_error, index=cols_to_scale).T\n",
+    "\n",
+    "overall_reconstruction_error = feature_reconstruction_error_df.mean().mean()\n",
+    "print('\\n','\\n', f\"\\033[1mOverall Reconstruction Error: {overall_reconstruction_error:.4f}\\033[0m\", '\\n','\\n')\n",
+    "\n",
+    "# Print the individual features error in a horizontal format\n",
+    "display(feature_reconstruction_error_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Nr2MdqXlwPRA",
+   "metadata": {
+    "id": "Nr2MdqXlwPRA"
+   },
+   "source": [
+    "You can see that certain features have very low error, but some might have an error as high as 0.2. However, overall the error rate is 0.04 and thus, we can move forward.\n",
+    "\n",
+    "Let us now move towards finding the reduced features. This is done in the following steps.\n",
+    "\n",
+    "**Extract the encoder part of the autoencoder**:\n",
+    "You will extract the encoder part of the autoencoder, which compresses the data into a reduced-dimensional representation. This part includes the first three layers of the model.\n",
+    "\n",
+    "Use the encoder to obtain the reduced-dimensional representation:\n",
+    "We use the encoder to transform the input test data `(X_test)` into a reduced-dimensional representation `(X_encoded_test)`. This represents an encoded version of the input data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pvDj7316wPRA",
+   "metadata": {
+    "id": "pvDj7316wPRA",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Re-create the encoder from the layers of the successfully trained model\n",
+    "encoder = Sequential(model.layers[:3])\n",
+    "X_encoded_test = encoder.predict(X[cols_to_scale]) # Use the scaled features for prediction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bmIW_EmxwPRB",
+   "metadata": {
+    "id": "bmIW_EmxwPRB"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# ── NUEVO: añade la columna Date al DataFrame codificado ──\n",
+    "dates = df['Date'].reset_index(drop=True)                 # 1) copia la fecha\n",
+    "features_enc = pd.DataFrame(                              # 2) crea el DF codificado\n",
+    "    X_encoded_test,\n",
+    "    columns=[f'Encoded_{i}' for i in range(X_encoded_test.shape[1])]\n",
+    ")\n",
+    "features_enc.insert(0, 'Date', dates)\n",
+    "features_enc.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "B-uYkk3_e3wF",
+   "metadata": {
+    "id": "B-uYkk3_e3wF"
+   },
+   "outputs": [],
+   "source": [
+    "features_enc.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3614702",
+   "metadata": {
+    "id": "d3614702"
+   },
+   "outputs": [],
+   "source": [
+    "### Save the encoder model\n",
+    "\n",
+    "encoder_save_path = root_data+'Models/'+symbol+'_'+direction+'_'+data_type+'_ahm_encoder_model.keras'\n",
+    "os.makedirs(os.path.dirname(encoder_save_path), exist_ok=True)\n",
+    "encoder.save(encoder_save_path)\n",
+    "print(f\"Encoder model saved successfully at: {encoder_save_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "lHzi4304z00U",
+   "metadata": {
+    "id": "lHzi4304z00U"
+   },
+   "outputs": [],
+   "source": [
+    "features_enc.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_Enc_Features.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kEzuAKPE3KBb",
+   "metadata": {
+    "id": "kEzuAKPE3KBb"
+   },
+   "source": [
+    "# Varios"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [
+    "Ysa-7eLvEMpE",
+    "m8CIB8vltFfH",
+    "y6QRdBKwrX98",
+    "zhTndYVi1TEV",
+    "jh9-mi26wsya",
+    "Hv5bsrpc03z7",
+    "2RFfhHT2AwAJ"
+   ],
+   "gpuType": "T4",
+   "machine_shape": "hm",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "24978cca329a49de8aa7134bfb61be2b": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "31586bc636e84cf8a9a8e287c337ded4": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "3abde22d56a04951806f97ceb50efa92": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "4290faf2225a4d32bde385b6521e9ab2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_24978cca329a49de8aa7134bfb61be2b",
+      "placeholder": "​",
+      "style": "IPY_MODEL_fc87caee4db1426fadc04572c74617b5",
+      "value": "Pruning corr &gt; 0.9:   0%"
+     }
+    },
+    "74a6582880894069ad603643f92d7690": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_31586bc636e84cf8a9a8e287c337ded4",
+      "max": 850,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_f033e19b4ce74802907e77d074d358dd",
+      "value": 850
+     }
+    },
+    "9609059e3a254435ad1ac68a6a404d33": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_4290faf2225a4d32bde385b6521e9ab2",
+       "IPY_MODEL_74a6582880894069ad603643f92d7690",
+       "IPY_MODEL_da5e8d42499b429d9b286ba00635148a"
+      ],
+      "layout": "IPY_MODEL_aaaaf872df124159b5d3af65c70d3e83"
+     }
+    },
+    "aaaaf872df124159b5d3af65c70d3e83": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": "hidden",
+      "width": null
+     }
+    },
+    "cde12ad7e71c47a7a3429ced6e034fcd": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "da5e8d42499b429d9b286ba00635148a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_cde12ad7e71c47a7a3429ced6e034fcd",
+      "placeholder": "​",
+      "style": "IPY_MODEL_3abde22d56a04951806f97ceb50efa92",
+      "value": " 0/850 [00:00&lt;?, ?col/s]"
+     }
+    },
+    "f033e19b4ce74802907e77d074d358dd": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "fc87caee4db1426fadc04572c74617b5": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- update feature generation helpers to return standalone data blocks and keep slope features modular
- extend create_features to provide component dataframes alongside the combined feature set
- persist raw and scaled feature blocks for 5, 10 and 15 minute data, saving independent CSVs per feature family

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3ec3bcf108328a78d820f3eac0155