### PR TITLE
Remove slope feature engineering from DRL notebook

### DIFF
--- a/8_XAUUSD_DRL_Features.ipynb
+++ b/8_XAUUSD_DRL_Features.ipynb
@@ -1,2776 +1,2634 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "bf83164c",
-      "metadata": {
-        "id": "bf83164c"
-      },
-      "source": [
-        "# Pendientes\n",
-        "\n",
-        "Nada"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Ysa-7eLvEMpE",
-      "metadata": {
-        "id": "Ysa-7eLvEMpE"
-      },
-      "source": [
-        "# Gpu"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "9GJAW8qAEM8f",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "9GJAW8qAEM8f",
-        "outputId": "a399319e-f240-48c9-c725-16a0184f2476"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Thu Sep 25 21:45:43 2025       \n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
-            "|-----------------------------------------+------------------------+----------------------+\n",
-            "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
-            "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
-            "|                                         |                        |               MIG M. |\n",
-            "|=========================================+========================+======================|\n",
-            "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
-            "| N/A   35C    P8             11W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
-            "|                                         |                        |                  N/A |\n",
-            "+-----------------------------------------+------------------------+----------------------+\n",
-            "                                                                                         \n",
-            "+-----------------------------------------------------------------------------------------+\n",
-            "| Processes:                                                                              |\n",
-            "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
-            "|        ID   ID                                                               Usage      |\n",
-            "|=========================================================================================|\n",
-            "|  No running processes found                                                             |\n",
-            "+-----------------------------------------------------------------------------------------+\n"
-          ]
-        }
-      ],
-      "source": [
-        "!nvidia-smi"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "FcIdAmrNERw-",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "FcIdAmrNERw-",
-        "outputId": "97294001-26cf-4c92-851d-7fc055f6cfaf"
-      },
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 2
-        }
-      ],
-      "source": [
-        "import tensorflow as tf\n",
-        "tf.config.list_physical_devices('GPU')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "m8CIB8vltFfH",
-      "metadata": {
-        "id": "m8CIB8vltFfH"
-      },
-      "source": [
-        "# Set_Up"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "EB5RqjoAtFwl",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "EB5RqjoAtFwl",
-        "outputId": "0890d842-0745-4541-9601-3af632e44a70"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "/content/drive/MyDrive/Course Folder/Forex/XAUUSD/\n"
-          ]
-        }
-      ],
-      "source": [
-        "\n",
-        "root_data = f'/content/drive/MyDrive/Course Folder/Forex/XAUUSD/'\n",
-        "print(root_data)\n",
-        "\n",
-        "direction = 'Short'\n",
-        "direction_number = -1\n",
-        "\n",
-        "symbol = 'XAUUSD'\n",
-        "strategy = 'Kalman'\n",
-        "time_frame = 'M5'\n",
-        "\n",
-        "trade_evolution = 'st_Max'\n",
-        "result_field = 'st_PnL'\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "y6QRdBKwrX98",
-      "metadata": {
-        "id": "y6QRdBKwrX98"
-      },
-      "source": [
-        "# Libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "R9bTNmBwK_Up",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "R9bTNmBwK_Up",
-        "outputId": "b86df12c-9494-4628-861b-4feae0317865"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting ta-lib\n",
-            "  Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (24 kB)\n",
-            "Requirement already satisfied: build in /usr/local/lib/python3.12/dist-packages (from ta-lib) (1.3.0)\n",
-            "Requirement already satisfied: cython in /usr/local/lib/python3.12/dist-packages (from ta-lib) (3.0.12)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.12/dist-packages (from ta-lib) (2.0.2)\n",
-            "Requirement already satisfied: packaging>=19.1 in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (25.0)\n",
-            "Requirement already satisfied: pyproject_hooks in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (1.2.0)\n",
-            "Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl (4.1 MB)\n",
-            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/4.1 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m227.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m115.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hInstalling collected packages: ta-lib\n",
-            "Successfully installed ta-lib-0.6.7\n",
-            "0.6.7\n"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install ta-lib\n",
-        "import talib as ta\n",
-        "print(ta.__version__)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "bda1a01c",
-      "metadata": {
-        "id": "bda1a01c"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import os\n",
-        "import joblib\n",
-        "import math\n",
-        "import time\n",
-        "\n",
-        "from itertools import combinations, product\n",
-        "\n",
-        "from tqdm.auto import tqdm\n",
-        "\n",
-        "from tensorflow.keras.models import Sequential\n",
-        "from tensorflow.keras.layers import Dense\n",
-        "\n",
-        "from sklearn.cluster import KMeans\n",
-        "from sklearn.preprocessing import StandardScaler\n",
-        "from sklearn.ensemble import RandomForestClassifier\n",
-        "from sklearn.feature_selection import RFECV\n",
-        "from sklearn.model_selection import StratifiedKFold\n",
-        "from sklearn.feature_selection import SelectFromModel\n",
-        "from sklearn.metrics import roc_auc_score, r2_score\n",
-        "from sklearn.model_selection import TimeSeriesSplit\n",
-        "from sklearn.linear_model import LogisticRegression\n",
-        "from sklearn.model_selection import cross_val_score\n",
-        "\n",
-        "from scipy.cluster.hierarchy import linkage, fcluster\n",
-        "from scipy.spatial.distance import squareform\n",
-        "\n",
-        "from xgboost import XGBClassifier, XGBRegressor\n",
-        "\n",
-        "import tensorflow as tf\n",
-        "\n",
-        "import sys\n",
-        "sys.path.append(\"..\")\n",
-        "\n",
-        "from __future__ import annotations\n",
-        "from typing import Tuple, List, Optional, Dict, Any, Union\n",
-        "\n",
-        "from xgboost import XGBClassifier, XGBRegressor\n",
-        "from sklearn.metrics import (roc_auc_score, f1_score, accuracy_score, log_loss, r2_score)\n",
-        "\n",
-        "from sklearn.preprocessing import LabelEncoder\n",
-        "\n",
-        "import warnings\n",
-        "warnings.filterwarnings('ignore')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "id": "7JweuZy755ym",
-      "metadata": {
-        "id": "7JweuZy755ym"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "%matplotlib inline\n",
-        "plt.style.use(\"seaborn-v0_8-darkgrid\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "id": "KFfn45ty82qv",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "KFfn45ty82qv",
-        "outputId": "c553119e-49e8-4345-a6ed-6bd4e69be76a"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mounted at /content/drive\n"
-          ]
-        }
-      ],
-      "source": [
-        "from google.colab import drive\n",
-        "drive.mount('/content/drive')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9aa65d54",
-      "metadata": {
-        "id": "9aa65d54"
-      },
-      "source": [
-        "# Calculate_Features\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "I23127P7lBq_",
-      "metadata": {
-        "id": "I23127P7lBq_"
-      },
-      "source": [
-        "## Features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "id": "kp4yJdGAjoeA",
-      "metadata": {
-        "id": "kp4yJdGAjoeA"
-      },
-      "outputs": [],
-      "source": [
-        "def kalman_line(source, kalman_length: int, smooth: int):\n",
-        "    \"\"\"\n",
-        "    Pine -> Python (solo 'kalman_line'), replicando la EMA de TradingView con\n",
-        "    *semilla SMA* (como ta.ema) sobre el núcleo Kalman kf_c.\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    source : pd.Series o array-like de floats (precio crudo, sin diff/returns)\n",
-        "    kalman_length : int   (equivale a length_kal en Pine)\n",
-        "    smooth : int          (equivale a smooth_kal en Pine -> ta.ema(kf_c, smooth))\n",
-        "\n",
-        "    Retorna\n",
-        "    -------\n",
-        "    Mismo tipo que `source`: pd.Series o np.ndarray con la línea Kalman suavizada.\n",
-        "    \"\"\"\n",
-        "    import numpy as np\n",
-        "    import pandas as pd\n",
-        "\n",
-        "    # normalizamos tipos\n",
-        "    is_series = hasattr(source, \"index\")\n",
-        "    idx = source.index if is_series else None\n",
-        "    x = np.asarray(source, dtype=np.float64)\n",
-        "    n = x.shape[0]\n",
-        "    if n == 0:\n",
-        "        return source\n",
-        "\n",
-        "    # ---------- núcleo Kalman idéntico al Pine ----------\n",
-        "    sqrt_term   = np.sqrt((kalman_length / 10000.0) * 2.0)\n",
-        "    length_term = kalman_length / 10000.0\n",
-        "\n",
-        "    kf_c   = np.empty(n, dtype=np.float64)\n",
-        "    velo_c = np.empty(n, dtype=np.float64)\n",
-        "\n",
-        "    # bar 0 (nz(kf_c[1], source) y nz(velo_c[1], 0))\n",
-        "    kf_c[0] = x[0]\n",
-        "    velo_c[0] = 0.0\n",
-        "\n",
-        "    for i in range(1, n):\n",
-        "        prev_kf = kf_c[i - 1]\n",
-        "        dk_c = x[i] - prev_kf\n",
-        "        smooth_c = prev_kf + dk_c * sqrt_term\n",
-        "        velo_c[i] = velo_c[i - 1] + length_term * dk_c\n",
-        "        kf_c[i] = smooth_c + velo_c[i]\n",
-        "\n",
-        "    # ---------- EMA con semilla SMA (comportamiento ta.ema de TV) ----------\n",
-        "    L = int(max(1, smooth))\n",
-        "    alpha = 2.0 / (L + 1.0)\n",
-        "    ema = np.full(n, np.nan, dtype=np.float64)\n",
-        "\n",
-        "    if n < L:\n",
-        "        # con pocas barras, igualamos al promedio simple disponible\n",
-        "        ema[-1] = np.nanmean(kf_c)\n",
-        "    else:\n",
-        "        # seed = SMA de las primeras L barras\n",
-        "        seed = np.mean(kf_c[:L])\n",
-        "        ema[L - 1] = seed\n",
-        "        for i in range(L, n):\n",
-        "            ema[i] = alpha * kf_c[i] + (1.0 - alpha) * ema[i - 1]\n",
-        "\n",
-        "    return (pd.Series(ema, index=idx) if is_series else ema)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "id": "HahbLzEkjoeB",
-      "metadata": {
-        "id": "HahbLzEkjoeB"
-      },
-      "outputs": [],
-      "source": [
-        "def slope(src: pd.Series,\n",
-        "          length_kal: int,\n",
-        "          smooth_kal: int,\n",
-        "          slopeLen: int,\n",
-        "          offset: int) -> pd.DataFrame:\n",
-        "\n",
-        "    n = len(src)\n",
-        "    kf_state = np.full(n, np.nan)\n",
-        "    kf_velo  = np.zeros(n)\n",
-        "    sqrt_factor = np.sqrt(length_kal / 10000.0 * 2.0)\n",
-        "    vel_factor  = length_kal / 10000.0\n",
-        "\n",
-        "    for i in range(n):\n",
-        "        if i == 0:\n",
-        "            prev_state = src.iloc[0]\n",
-        "            prev_velo  = 0.0\n",
-        "        else:\n",
-        "            prev_state = kf_state[i-1] if not np.isnan(kf_state[i-1]) else src.iloc[i]\n",
-        "            prev_velo  = kf_velo[i-1]\n",
-        "\n",
-        "        dk = src.iloc[i] - prev_state\n",
-        "        smooth = prev_state + dk * sqrt_factor\n",
-        "        kf_velo[i]  = prev_velo + vel_factor * dk\n",
-        "        kf_state[i] = smooth + kf_velo[i]\n",
-        "\n",
-        "    # 2) EMA smoothing --------------------------------------------------\n",
-        "    kal = pd.Series(kf_state, index=src.index).ewm(span=smooth_kal, adjust=False).mean()\n",
-        "\n",
-        "    # 3) Slope/divergence -----------------------------------------------\n",
-        "    validLen = max(slopeLen, 1)\n",
-        "    slope_div = kal.diff(validLen) / validLen\n",
-        "    slope_signal = (slope_div > slope_div.shift(1)).astype(int)\n",
-        "\n",
-        "    # 4) Angle in degrees -----------------------------------------------\n",
-        "    price_change = kal - kal.shift(validLen)\n",
-        "    slope_angle = np.degrees(np.arctan(price_change))\n",
-        "    slope_angle_signal = (slope_angle > slope_angle.shift(1)).astype(int)\n",
-        "\n",
-        "    # 5) Linear regression prediction ----------------------------------\n",
-        "    def _linreg(y):\n",
-        "        x = np.arange(len(y))\n",
-        "        m, b = np.polyfit(x, y, 1)\n",
-        "        return b + m * (len(y)-1)\n",
-        "\n",
-        "    slope_lin_reg = kal.rolling(window=slopeLen).apply(_linreg, raw=False)\n",
-        "    slope_lin_reg = slope_lin_reg.shift(-offset)  # apply Pine-style offset\n",
-        "    slope_lin_reg_signal = (slope_lin_reg > slope_lin_reg.shift(1)).astype(int)\n",
-        "\n",
-        "    # 6) Pack results ---------------------------------------------------\n",
-        "    return pd.DataFrame({\n",
-        "        'slope_div':            slope_div,\n",
-        "        'slope_signal':         slope_signal,\n",
-        "        'slope_angle':          slope_angle,\n",
-        "        'slope_angle_signal':   slope_angle_signal,\n",
-        "        'slope_lin_reg':        slope_lin_reg,\n",
-        "        'slope_lin_reg_signal': slope_lin_reg_signal\n",
-        "    })"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "id": "4d988ef9",
-      "metadata": {
-        "id": "4d988ef9"
-      },
-      "outputs": [],
-      "source": [
-        "def build_slope_feature_block(stock_data: pd.DataFrame,\n",
-        "                                 kalman_periods: List[int],\n",
-        "                                 slope_lengths: List[int]) -> pd.DataFrame:\n",
-        "    \"\"\"Assemble the complete slope feature block for the provided parameters.\n",
-        "\n",
-        "    Parameters\n",
-        "    ----------\n",
-        "    stock_data : pd.DataFrame\n",
-        "        Input OHLCV data.\n",
-        "    kalman_periods : List[int]\n",
-        "        Window lengths used for the Kalman filter baseline.\n",
-        "    slope_lengths : List[int]\n",
-        "        Lookback windows used when computing the slope statistics.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    pd.DataFrame\n",
-        "        A DataFrame containing all slope-based indicators, their diffs and pairwise combinations.\n",
-        "    \"\"\"\n",
-        "    slope_features = pd.DataFrame(index=stock_data.index)\n",
-        "    slope_indicator_columns: Dict[str, List[str]] = {\n",
-        "        'slope_div': [],\n",
-        "        'slope_signal': [],\n",
-        "        'slope_angle': [],\n",
-        "        'slope_angle_signal': [],\n",
-        "        'slope_lin_reg': [],\n",
-        "        'slope_lin_reg_signal': []\n",
-        "    }\n",
-        "\n",
-        "    slope_jobs = list(product(kalman_periods, slope_lengths))\n",
-        "\n",
-        "    for period, s_len in tqdm(slope_jobs, desc=\"Slopes (kal_len × slope_len)\"):\n",
-        "        df_s = slope(stock_data['Close'], length_kal=period, smooth_kal=3,\n",
-        "                     slopeLen=s_len, offset=-1)\n",
-        "\n",
-        "        column_mapping = {\n",
-        "            'slope_div':            f'slope_div_{period}_{s_len}',\n",
-        "            'slope_signal':         f'slope_signal_{period}_{s_len}',\n",
-        "            'slope_angle':          f'slope_angle_{period}_{s_len}',\n",
-        "            'slope_angle_signal':   f'slope_angle_signal_{period}_{s_len}',\n",
-        "            'slope_lin_reg':        f'slope_lin_reg_{period}_{s_len}',\n",
-        "            'slope_lin_reg_signal': f'slope_lin_reg_signal_{period}_{s_len}'\n",
-        "        }\n",
-        "\n",
-        "        for indicator, col_name in column_mapping.items():\n",
-        "            series = df_s[indicator]\n",
-        "            slope_features[col_name] = series\n",
-        "            slope_features[f'{col_name}_diff'] = series.diff()\n",
-        "            slope_indicator_columns[indicator].append(col_name)\n",
-        "\n",
-        "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
-        "        unique_columns = list(dict.fromkeys(columns))\n",
-        "        return list(combinations(unique_columns, 2))\n",
-        "\n",
-        "    for indicator, cols in slope_indicator_columns.items():\n",
-        "        pairs = _unique_pairwise(cols)\n",
-        "        for c1, c2 in pairs:\n",
-        "            slope_features[f'{c1} - {c2}'] = slope_features[c1] - slope_features[c2]\n",
-        "\n",
-        "    return slope_features\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "id": "ZnVB7nObuG_e",
-      "metadata": {
-        "id": "ZnVB7nObuG_e"
-      },
-      "outputs": [],
-      "source": [
-        "def create_features(\n",
-        "    stock_data: pd.DataFrame,\n",
-        "    return_components: bool = False\n",
-        ") -> Union[pd.DataFrame, Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]]:\n",
-        "\n",
-        "    periods        = [3, 7, 14]\n",
-        "    kalman_periods = [300, 600, 900]\n",
-        "    slope_length   = [3, 6, 9]\n",
-        "\n",
-        "    features = pd.DataFrame(index=stock_data.index)\n",
-        "    component_frames: Dict[str, pd.DataFrame] = {}\n",
-        "\n",
-        "\n",
-        "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
-        "        \"\"\"Return ordered unique column pairs without self-pairings.\"\"\"\n",
-        "        unique_columns = list(dict.fromkeys(columns))\n",
-        "        return list(combinations(unique_columns, 2))\n",
-        "\n",
-        "    # ───────────────────────── Kalman y derivados ───────────────────────\n",
-        "    t0 = time.time()\n",
-        "    kal_cols = []\n",
-        "    kalman_900_series: Optional[pd.Series] = None\n",
-        "    for period in tqdm(kalman_periods, desc=\"Kalman & Derivatives\"):\n",
-        "        kal = pd.Series(\n",
-        "            kalman_line(stock_data['Close'], kalman_length=period, smooth=3),\n",
-        "            index=stock_data.index\n",
-        "        )\n",
-        "        kname = f'Kal_{period}'\n",
-        "        kal_cols.append(kname)\n",
-        "\n",
-        "        features[kname]                           = kal\n",
-        "        if period == 900:\n",
-        "            kalman_900_series = kal\n",
-        "        features[f'Close_Kal_{period}']           = stock_data['Close'] - kal\n",
-        "        features[f'Kal_change_{period}']          = kal.diff(1)\n",
-        "\n",
-        "\n",
-        "    kal_pairs = _unique_pairwise(kal_cols)\n",
-        "    for c1, c2 in tqdm(kal_pairs, desc=\"Kalman pairwise\"):\n",
-        "        features[f'{c1}_minus_{c2}'] = features[c1] - features[c2]\n",
-        "    tqdm.write(f\"[Timing] Kalman block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    # ───────────────────────── RSI (Close & Kalman_900) ────────────────────\n",
-        "    t0 = time.time()\n",
-        "    rsi_sources: Dict[str, pd.Series] = {'Close': stock_data['Close']}\n",
-        "    if kalman_900_series is not None:\n",
-        "        rsi_sources['Kalman_900'] = kalman_900_series\n",
-        "\n",
-        "    for source_name, series in rsi_sources.items():\n",
-        "        rsi_cols: List[str] = []\n",
-        "        for period in tqdm(periods, desc=f\"RSI ({source_name})\", leave=False):\n",
-        "            if source_name == 'Close':\n",
-        "                col_name = f'RSI_{period}'\n",
-        "            else:\n",
-        "                col_name = f'RSI_{source_name}_{period}'\n",
-        "            features[col_name] = ta.RSI(series, timeperiod=period)\n",
-        "            rsi_cols.append(col_name)\n",
-        "\n",
-        "        for col in tqdm(rsi_cols, desc=f\"RSI ({source_name}) diffs\", leave=False):\n",
-        "            features[f'{col}_diff'] = features[col].diff()\n",
-        "\n",
-        "        for col1, col2 in tqdm(_unique_pairwise(rsi_cols), desc=f\"RSI ({source_name}) pairwise\", leave=False):\n",
-        "            features[f'{col1} - {col2}'] = features[col1] - features[col2]\n",
-        "\n",
-        "    tqdm.write(f\"[Timing] RSI block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    # ───────────────────────── Slopes ───────────────────────────────────\n",
-        "    t0 = time.time()\n",
-        "    slope_features = build_slope_feature_block(stock_data, kalman_periods, slope_length)\n",
-        "    component_frames['Slope'] = slope_features\n",
-        "    features = features.join(slope_features)\n",
-        "    tqdm.write(f\"[Timing] Slopes block: {time.time()-t0:.2f}s\")\n",
-        "\n",
-        "    if return_components:\n",
-        "        component_frames['Create_Features'] = features.copy()\n",
-        "        return features, component_frames\n",
-        "\n",
-        "    return features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "id": "1e0c0f79",
-      "metadata": {
-        "id": "1e0c0f79"
-      },
-      "outputs": [],
-      "source": [
-        "def scale_feature_block(features: pd.DataFrame, window: int = 200) -> pd.DataFrame:\n",
-        "    \"\"\"Scale features using a rolling window standardization.\n",
-        "\n",
-        "    Parameters\n",
-        "    ----------\n",
-        "    features : pd.DataFrame\n",
-        "        Feature block to scale.\n",
-        "    window : int, optional\n",
-        "        Rolling window size, by default 200.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    pd.DataFrame\n",
-        "        Scaled feature block preserving the original index.\n",
-        "    \"\"\"\n",
-        "    if features.empty:\n",
-        "        return features.copy()\n",
-        "\n",
-        "    scaled = features.copy()\n",
-        "    rolling = scaled.rolling(window)\n",
-        "    scaled = (scaled - rolling.mean()) / rolling.std()\n",
-        "    return scaled\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "DoqqPJxPxnBF",
-      "metadata": {
-        "id": "DoqqPJxPxnBF"
-      },
-      "source": [
-        "## 5_min"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "id": "d7l7vt7QxvyC",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 324
-        },
-        "id": "d7l7vt7QxvyC",
-        "outputId": "6631bd4e-4408-411e-fed4-d3fe055b5f4d"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Min_Date :  2024-11-08 21:20:00\n",
-            "Min_Date :  2025-07-25 23:55:00\n",
-            "Number_Rows =  50000\n",
-            "\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "                        Open     High      Low    Close  Volume  Spread\n",
-              "Date                                                                   \n",
-              "2025-07-25 23:35:00  3338.59  3339.14  3338.04  3338.81     197       5\n",
-              "2025-07-25 23:40:00  3338.81  3338.92  3337.56  3338.69     194       5\n",
-              "2025-07-25 23:45:00  3338.69  3338.69  3336.64  3336.73     195      40\n",
-              "2025-07-25 23:50:00  3336.73  3336.86  3336.12  3336.52     192      40\n",
-              "2025-07-25 23:55:00  3336.52  3336.88  3336.44  3336.80      82      40"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-27443eb1-e42b-4b98-913f-742dbafd3d8e\" class=\"colab-df-container\">\n",
-              "    <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Open</th>\n",
-              "      <th>High</th>\n",
-              "      <th>Low</th>\n",
-              "      <th>Close</th>\n",
-              "      <th>Volume</th>\n",
-              "      <th>Spread</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Date</th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:35:00</th>\n",
-              "      <td>3338.59</td>\n",
-              "      <td>3339.14</td>\n",
-              "      <td>3338.04</td>\n",
-              "      <td>3338.81</td>\n",
-              "      <td>197</td>\n",
-              "      <td>5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:40:00</th>\n",
-              "      <td>3338.81</td>\n",
-              "      <td>3338.92</td>\n",
-              "      <td>3337.56</td>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>194</td>\n",
-              "      <td>5</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:45:00</th>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>3338.69</td>\n",
-              "      <td>3336.64</td>\n",
-              "      <td>3336.73</td>\n",
-              "      <td>195</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:50:00</th>\n",
-              "      <td>3336.73</td>\n",
-              "      <td>3336.86</td>\n",
-              "      <td>3336.12</td>\n",
-              "      <td>3336.52</td>\n",
-              "      <td>192</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2025-07-25 23:55:00</th>\n",
-              "      <td>3336.52</td>\n",
-              "      <td>3336.88</td>\n",
-              "      <td>3336.44</td>\n",
-              "      <td>3336.80</td>\n",
-              "      <td>82</td>\n",
-              "      <td>40</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "    <div class=\"colab-df-buttons\">\n",
-              "\n",
-              "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-27443eb1-e42b-4b98-913f-742dbafd3d8e')\"\n",
-              "            title=\"Convert this dataframe to an interactive table.\"\n",
-              "            style=\"display:none;\">\n",
-              "\n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-              "  </svg>\n",
-              "    </button>\n",
-              "\n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-buttons div {\n",
-              "      margin-bottom: 4px;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "    <script>\n",
-              "      const buttonEl =\n",
-              "        document.querySelector('#df-27443eb1-e42b-4b98-913f-742dbafd3d8e button.colab-df-convert');\n",
-              "      buttonEl.style.display =\n",
-              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-27443eb1-e42b-4b98-913f-742dbafd3d8e');\n",
-              "        const dataTable =\n",
-              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                    [key], {});\n",
-              "        if (!dataTable) return;\n",
-              "\n",
-              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "          + ' to learn more about interactive tables.';\n",
-              "        element.innerHTML = '';\n",
-              "        dataTable['output_type'] = 'display_data';\n",
-              "        await google.colab.output.renderOutput(dataTable, element);\n",
-              "        const docLink = document.createElement('div');\n",
-              "        docLink.innerHTML = docLinkHtml;\n",
-              "        element.appendChild(docLink);\n",
-              "      }\n",
-              "    </script>\n",
-              "  </div>\n",
-              "\n",
-              "\n",
-              "    <div id=\"df-557978d1-a72f-4d4e-acd1-1cece514161a\">\n",
-              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-557978d1-a72f-4d4e-acd1-1cece514161a')\"\n",
-              "                title=\"Suggest charts\"\n",
-              "                style=\"display:none;\">\n",
-              "\n",
-              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "     width=\"24px\">\n",
-              "    <g>\n",
-              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-              "    </g>\n",
-              "</svg>\n",
-              "      </button>\n",
-              "\n",
-              "<style>\n",
-              "  .colab-df-quickchart {\n",
-              "      --bg-color: #E8F0FE;\n",
-              "      --fill-color: #1967D2;\n",
-              "      --hover-bg-color: #E2EBFA;\n",
-              "      --hover-fill-color: #174EA6;\n",
-              "      --disabled-fill-color: #AAA;\n",
-              "      --disabled-bg-color: #DDD;\n",
-              "  }\n",
-              "\n",
-              "  [theme=dark] .colab-df-quickchart {\n",
-              "      --bg-color: #3B4455;\n",
-              "      --fill-color: #D2E3FC;\n",
-              "      --hover-bg-color: #434B5C;\n",
-              "      --hover-fill-color: #FFFFFF;\n",
-              "      --disabled-bg-color: #3B4455;\n",
-              "      --disabled-fill-color: #666;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart {\n",
-              "    background-color: var(--bg-color);\n",
-              "    border: none;\n",
-              "    border-radius: 50%;\n",
-              "    cursor: pointer;\n",
-              "    display: none;\n",
-              "    fill: var(--fill-color);\n",
-              "    height: 32px;\n",
-              "    padding: 0;\n",
-              "    width: 32px;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart:hover {\n",
-              "    background-color: var(--hover-bg-color);\n",
-              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "    fill: var(--button-hover-fill-color);\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-quickchart-complete:disabled,\n",
-              "  .colab-df-quickchart-complete:disabled:hover {\n",
-              "    background-color: var(--disabled-bg-color);\n",
-              "    fill: var(--disabled-fill-color);\n",
-              "    box-shadow: none;\n",
-              "  }\n",
-              "\n",
-              "  .colab-df-spinner {\n",
-              "    border: 2px solid var(--fill-color);\n",
-              "    border-color: transparent;\n",
-              "    border-bottom-color: var(--fill-color);\n",
-              "    animation:\n",
-              "      spin 1s steps(1) infinite;\n",
-              "  }\n",
-              "\n",
-              "  @keyframes spin {\n",
-              "    0% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "      border-left-color: var(--fill-color);\n",
-              "    }\n",
-              "    20% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    30% {\n",
-              "      border-color: transparent;\n",
-              "      border-left-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    40% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-top-color: var(--fill-color);\n",
-              "    }\n",
-              "    60% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "    }\n",
-              "    80% {\n",
-              "      border-color: transparent;\n",
-              "      border-right-color: var(--fill-color);\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "    90% {\n",
-              "      border-color: transparent;\n",
-              "      border-bottom-color: var(--fill-color);\n",
-              "    }\n",
-              "  }\n",
-              "</style>\n",
-              "\n",
-              "      <script>\n",
-              "        async function quickchart(key) {\n",
-              "          const quickchartButtonEl =\n",
-              "            document.querySelector('#' + key + ' button');\n",
-              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
-              "          try {\n",
-              "            const charts = await google.colab.kernel.invokeFunction(\n",
-              "                'suggestCharts', [key], {});\n",
-              "          } catch (error) {\n",
-              "            console.error('Error during call to suggestCharts:', error);\n",
-              "          }\n",
-              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-              "        }\n",
-              "        (() => {\n",
-              "          let quickchartButtonEl =\n",
-              "            document.querySelector('#df-557978d1-a72f-4d4e-acd1-1cece514161a button');\n",
-              "          quickchartButtonEl.style.display =\n",
-              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "        })();\n",
-              "      </script>\n",
-              "    </div>\n",
-              "\n",
-              "    </div>\n",
-              "  </div>\n"
-            ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "summary": "{\n  \"name\": \"df_5min\",\n  \"rows\": 5,\n  \"fields\": [\n    {\n      \"column\": \"Date\",\n      \"properties\": {\n        \"dtype\": \"date\",\n        \"min\": \"2025-07-25 23:35:00\",\n        \"max\": \"2025-07-25 23:55:00\",\n        \"num_unique_values\": 5,\n        \"samples\": [\n          \"2025-07-25 23:40:00\",\n          \"2025-07-25 23:55:00\",\n          \"2025-07-25 23:45:00\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Open\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1397894542414626,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.81,\n          3336.52,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"High\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.132263220280441,\n        \"min\": 3336.86,\n        \"max\": 3339.14,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.92,\n          3336.88,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Low\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.8069696400732905,\n        \"min\": 3336.12,\n        \"max\": 3338.04,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3337.56,\n          3336.44,\n          3336.64\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Close\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1374313166077035,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.69,\n          3336.8,\n          3336.73\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Volume\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 50,\n        \"min\": 82,\n        \"max\": 197,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          194,\n          82,\n          195\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Spread\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 5,\n        \"max\": 40,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          40,\n          5\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
-            }
-          },
-          "metadata": {},
-          "execution_count": 15
-        }
-      ],
-      "source": [
-        "# Read the CSV file\n",
-        "df_5min = pd.read_csv(root_data + 'Data/'+symbol+'_M5.csv', index_col=0)\n",
-        "df_5min.index = pd.to_datetime(df_5min.index)\n",
-        "df_5min = df_5min.iloc[-50000:,]\n",
-        "\n",
-        "print('Min_Date : ', df_5min.index.min())\n",
-        "print('Min_Date : ', df_5min.index.max())\n",
-        "print('Number_Rows = ',len(df_5min.index))\n",
-        "print('\\n')\n",
-        "\n",
-        "df_5min.tail()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "HBicVZcDx2CF",
-      "metadata": {
-        "id": "HBicVZcDx2CF"
-      },
-      "source": [
-        "**Features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "XxU4wllsEUcN",
-      "metadata": {
-        "id": "XxU4wllsEUcN"
-      },
-      "outputs": [],
-      "source": [
-        "start_time = time.time()\n",
-        "\n",
-        "features_5min_raw, components_5min = create_features(df_5min, return_components=True)\n",
-        "features_5min_raw = features_5min_raw.dropna()\n",
-        "valid_index_5min = features_5min_raw.index\n",
-        "\n",
-        "# Align every component to the valid index coming from the full feature set\n",
-        "m5_raw_blocks: Dict[str, pd.DataFrame] = {name: frame.loc[valid_index_5min].copy()\n",
-        "                                           for name, frame in components_5min.items()}\n",
-        "m5_raw_blocks['Create_Features'] = features_5min_raw\n",
-        "\n",
-        "m5_scaled_blocks: Dict[str, pd.DataFrame] = {}\n",
-        "m5_raw_paths: Dict[str, str] = {}\n",
-        "m5_scaled_paths: Dict[str, str] = {}\n",
-        "\n",
-        "for name, frame in m5_raw_blocks.items():\n",
-        "    filename_raw = f\"{symbol}_M5_{name}_Raw_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Raw_Features.csv\"\n",
-        "    raw_path = os.path.join(root_data, 'Results', filename_raw)\n",
-        "    frame.to_csv(raw_path)\n",
-        "    m5_raw_paths[name] = raw_path\n",
-        "\n",
-        "    scaled_frame = scale_feature_block(frame)\n",
-        "    m5_scaled_blocks[name] = scaled_frame\n",
-        "    filename_scale = f\"{symbol}_M5_{name}_Scale_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Scale_Features.csv\"\n",
-        "    scale_path = os.path.join(root_data, 'Results', filename_scale)\n",
-        "    scaled_frame.to_csv(scale_path)\n",
-        "    m5_scaled_paths[name] = scale_path\n",
-        "\n",
-        "execution_time = time.time() - start_time\n",
-        "\n",
-        "print(f\"Number of features are: {features_5min_raw.shape[1]}\")\n",
-        "print(features_5min_raw.shape)\n",
-        "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
-        "print(f\"Saved {len(m5_raw_blocks) * 2} DataFrames for the M5 timeframe.\")\n",
-        "features_5min_raw.tail(5)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "id": "7Vw_2C-ZEO57",
-      "metadata": {
-        "id": "7Vw_2C-ZEO57",
-        "outputId": "68b5b48f-0948-4a38-c1e6-e1669b0aa9e6",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "NaN counts per column (sorted):\n",
-            "slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    0\n",
-            "Kal_300                                                    0\n",
-            "Close_Kal_300                                              0\n",
-            "Kal_change_300                                             0\n",
-            "Kal_prev_minus_now_300                                     0\n",
-            "                                                          ..\n",
-            "Kal_change_900                                             0\n",
-            "Kal_prev_minus_now_900                                     0\n",
-            "Kal_prev2_minus_now_900                                    0\n",
-            "Kal_change2_900                                            0\n",
-            "Kal_300_minus_Kal_600                                      0\n",
-            "Length: 363, dtype: int64 \n"
-          ]
-        }
-      ],
-      "source": [
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(m5_raw_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "id": "j4AwNJic6icv",
-      "metadata": {
-        "id": "j4AwNJic6icv",
-        "outputId": "b03aa827-f15c-42a7-804f-a0508c9e998d",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Saved raw feature files:\n",
-            " - Slope: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_M5_Slope_Raw_Features.csv\n",
-            " - Create_Features: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_M5_Raw_Features.csv\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(\"Saved raw feature files:\")\n",
-        "for name, path in m5_raw_paths.items():\n",
-        "    print(f\" - {name}: {path}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(list(features_5min_raw.columns))"
-      ],
-      "metadata": {
-        "id": "71edtpuJ4Y-E",
-        "outputId": "6a15ce4a-64bf-49f4-c081-68d15162dd09",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "id": "71edtpuJ4Y-E",
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "['Kal_300', 'Close_Kal_300', 'Kal_change_300', 'Kal_prev_minus_now_300', 'Kal_prev2_minus_now_300', 'Kal_change2_300', 'Kal_600', 'Close_Kal_600', 'Kal_change_600', 'Kal_prev_minus_now_600', 'Kal_prev2_minus_now_600', 'Kal_change2_600', 'Kal_900', 'Close_Kal_900', 'Kal_change_900', 'Kal_prev_minus_now_900', 'Kal_prev2_minus_now_900', 'Kal_change2_900', 'Kal_300_minus_Kal_600', 'Kal_300_minus_Kal_900', 'Kal_600_minus_Kal_900', 'RSI_3', 'RSI_7', 'RSI_14', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'RSI_Kalman_900_3', 'RSI_Kalman_900_7', 'RSI_Kalman_900_14', 'RSI_Kalman_900_3_diff', 'RSI_Kalman_900_7_diff', 'RSI_Kalman_900_14_diff', 'RSI_Kalman_900_3 - RSI_Kalman_900_7', 'RSI_Kalman_900_3 - RSI_Kalman_900_14', 'RSI_Kalman_900_7 - RSI_Kalman_900_14', 'slope_div_300_3', 'slope_div_300_3_diff', 'slope_signal_300_3', 'slope_signal_300_3_diff', 'slope_angle_300_3', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6', 'slope_div_300_6_diff', 'slope_signal_300_6', 'slope_signal_300_6_diff', 'slope_angle_300_6', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9', 'slope_div_300_9_diff', 'slope_signal_300_9', 'slope_signal_300_9_diff', 'slope_angle_300_9', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3', 'slope_div_600_3_diff', 'slope_signal_600_3', 'slope_signal_600_3_diff', 'slope_angle_600_3', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6', 'slope_div_600_6_diff', 'slope_signal_600_6', 'slope_signal_600_6_diff', 'slope_angle_600_6', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9', 'slope_div_600_9_diff', 'slope_signal_600_9', 'slope_signal_600_9_diff', 'slope_angle_600_9', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3', 'slope_div_900_3_diff', 'slope_signal_900_3', 'slope_signal_900_3_diff', 'slope_angle_900_3', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6', 'slope_div_900_6_diff', 'slope_signal_900_6', 'slope_signal_900_6_diff', 'slope_angle_900_6', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9', 'slope_div_900_9_diff', 'slope_signal_900_9', 'slope_signal_900_9_diff', 'slope_angle_900_9', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9']\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "QX4cSq3Ftqhm",
-      "metadata": {
-        "id": "QX4cSq3Ftqhm"
-      },
-      "source": [
-        "**Scale_features**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1qEb1Cz1vzj6",
-      "metadata": {
-        "id": "1qEb1Cz1vzj6"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"Saved scaled feature files:\")\n",
-        "for name, path in m5_scaled_paths.items():\n",
-        "    print(f\" - {name}: {path}\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "eJcGUESttqhm",
-      "metadata": {
-        "id": "eJcGUESttqhm"
-      },
-      "outputs": [],
-      "source": [
-        "m5_scaled_blocks['Create_Features'].head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "BFVUCAe3GWFy",
-      "metadata": {
-        "id": "BFVUCAe3GWFy"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"NaN counts per column (scaled, sorted):\")\n",
-        "print(m5_scaled_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "aXMGezVftqhn",
-      "metadata": {
-        "id": "aXMGezVftqhn"
-      },
-      "outputs": [],
-      "source": [
-        "print(\"M5 feature blocks:\", list(m5_raw_blocks.keys()))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "W1Pk4Hkfjhvt",
-      "metadata": {
-        "id": "W1Pk4Hkfjhvt"
-      },
-      "source": [
-        "**Plots**"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "67453c9e",
-      "metadata": {
-        "id": "67453c9e"
-      },
-      "outputs": [],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "last_200_features_15min = m15_scaled_blocks['Create_Features'].tail(200)\n",
-        "last_200_df_15min = df_15min.tail(200)\n",
-        "\n",
-        "indicators_to_plot = ['Close','15min_Kal_300','15min_Kal_600']\n",
-        "\n",
-        "# Separate Close from other indicators\n",
-        "close_to_plot = 'Close' if 'Close' in indicators_to_plot else None\n",
-        "other_indicators_to_plot = [col for col in indicators_to_plot if col != 'Close' and col in last_200_features_15min.columns]\n",
-        "\n",
-        "num_plots = len(other_indicators_to_plot) + (1 if close_to_plot else 0)\n",
-        "\n",
-        "# Plotting\n",
-        "fig, axes = plt.subplots(nrows=num_plots, ncols=1, figsize=(15, 2.5 * num_plots), sharex=True)\n",
-        "\n",
-        "# Ensure axes is an array even if only one plot\n",
-        "if not isinstance(axes, np.ndarray):\n",
-        "    axes = np.array([axes])\n",
-        "\n",
-        "current_plot_index = 0\n",
-        "\n",
-        "# Plot Close price if requested\n",
-        "if close_to_plot:\n",
-        "    axes[current_plot_index].plot(last_200_df_15min.index, last_200_df_15min['Close'])\n",
-        "    axes[current_plot_index].set_title('Close Price')\n",
-        "    axes[current_plot_index].grid(True)\n",
-        "    current_plot_index += 1\n",
-        "\n",
-        "# Plot each selected indicator (excluding 'Close')\n",
-        "for col in other_indicators_to_plot:\n",
-        "    axes[current_plot_index].plot(last_200_features_15min.index, last_200_features_15min[col])\n",
-        "    axes[current_plot_index].set_title(col)\n",
-        "    axes[current_plot_index].grid(True)\n",
-        "    current_plot_index += 1\n",
-        "\n",
-        "#plt.tight_layout()\n",
-        "#plt.show()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "A5c__w6s_dtY",
-      "metadata": {
-        "id": "A5c__w6s_dtY"
-      },
-      "source": [
-        "# Feature Importance"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "4j7J8tk_f3o-",
-      "metadata": {
-        "id": "4j7J8tk_f3o-"
-      },
-      "source": [
-        "## Labels"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6XOsumPycYz3",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "6XOsumPycYz3",
-        "outputId": "a9e8a2d3-e9b2-41ff-d9f9-1c5e5fe408ac"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Min_Date    :  2019-01-02 01:00:00\n",
-            "Min_Date    :  2025-07-25 23:55:00 \n",
-            "\n",
-            "Number_Rows :  (465718, 29) \n",
-            "\n",
-            "Columns     :  Index(['Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Spread', 'ATR',\n",
-            "       'kal_1', 'kal_2', 'kal_3', 'kal_4', 'Open_Trade', 'Close_Trade',\n",
-            "       'Entry_Date', 'Type', 'Trade_Number', 'st_Exit_Date', 'trade type',\n",
-            "       'st_Duration', 'st_row_PnL_close', 'st_row_PnL_high', 'st_row_PnL_Low',\n",
-            "       'st_row_PnL_low', 'st_Max', 'st_Min', 'st_PnL', 'st_atr_PnL',\n",
-            "       'st_atr_max_PnL'],\n",
-            "      dtype='object')\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Open_Trade\n",
-              " 1.0    33915\n",
-              "-1.0    33858\n",
-              "Name: count, dtype: int64"
-            ],
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>count</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Open_Trade</th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>1.0</th>\n",
-              "      <td>33915</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>-1.0</th>\n",
-              "      <td>33858</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div><br><label><b>dtype:</b> int64</label>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 8
-        }
-      ],
-      "source": [
-        "lab = pd.read_csv(root_data + 'Results/'+symbol+'_'+strategy+'_'+time_frame+'_Strategy_Gen_Labels.csv', index_col=0)\n",
-        "lab['Date'] = pd.to_datetime(lab['Date'])\n",
-        "\n",
-        "print('Min_Date    : ',lab['Date'].min())\n",
-        "print('Min_Date    : ',lab['Date'].max(),'\\n')\n",
-        "print('Number_Rows : ',lab.shape,'\\n')\n",
-        "print('Columns     : ',lab.columns)\n",
-        "\n",
-        "lab['Open_Trade'].value_counts()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "apV2tezPsbux",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "apV2tezPsbux",
-        "outputId": "3d49cf8e-7890-472b-d936-66d4a46b4056"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Total_Trades = 67,773\n",
-            "\n",
-            "Mean st_atr_max_PnL = 238.39\n",
-            "\n",
-            "Above_Mean = 11,463,914.00\n",
-            "Below_Mean = 4,691,967.00\n",
-            "\n",
-            "<= 0.5 = 33.00\n",
-            "> 0.5 & <= 1 = 801,960.00\n",
-            "> 1 & <= 1.5 = 1,411,119.00\n",
-            "> 1.5 & <= 2 = 1,400,438.00\n",
-            "> 2 = 11,277,394.00\n"
-          ]
-        }
-      ],
-      "source": [
-        "#analyse_column = 'st_atr_max_PnL'\n",
-        "analyse_column = 'st_Max'\n",
-        "\n",
-        "st_max_0  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
-        "st_max_1  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
-        "st_max_2  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].sum()\n",
-        "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].sum()\n",
-        "\n",
-        "\n",
-        "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 0)),analyse_column].sum()\n",
-        "\n",
-        "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 0.7) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].sum()\n",
-        "\n",
-        "st_max_5 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 1) &\n",
-        "                   (lab['st_atr_max_PnL'] <= 1.5)),analyse_column].sum()\n",
-        "\n",
-        "st_max_6 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 1.5) &\n",
-        "                   (lab['st_atr_max_PnL'] <= 2)),analyse_column].sum()\n",
-        "\n",
-        "st_max_7 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] > 2)),analyse_column].sum()\n",
-        "\n",
-        "\n",
-        "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
-        "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
-        "print(f'Above_Mean = {st_max_2:,.2f}')\n",
-        "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
-        "\n",
-        "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
-        "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
-        "print(f'> 1 & <= 1.5 = {st_max_5:,.2f}')\n",
-        "print(f'> 1.5 & <= 2 = {st_max_6:,.2f}')\n",
-        "print(f'> 2 = {st_max_7:,.2f}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "p2fjs4Si792v",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "p2fjs4Si792v",
-        "outputId": "8a038f41-3186-4478-d0f3-c3cb11e10685"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Total_Trades = 67,773\n",
-            "\n",
-            "Mean st_atr_max_PnL = 1.89\n",
-            "\n",
-            "Above_Mean = 20,857.00\n",
-            "Below_Mean = 46,913.00\n",
-            "\n",
-            "<= 0.5 = 20,431.00\n",
-            "> 0.5 & <= 1 = 13,116.00\n",
-            "> 1 = 34,223.00\n"
-          ]
-        }
-      ],
-      "source": [
-        "analyse_column = 'st_atr_max_PnL'\n",
-        "\n",
-        "st_max_0 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
-        "st_max_1 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
-        "st_max_2 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].count()\n",
-        "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].count()\n",
-        "\n",
-        "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                    (lab['st_atr_max_PnL'] <= 0.5)),analyse_column].count()\n",
-        "\n",
-        "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                     (lab['st_atr_max_PnL'] >= 0.5) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].count()\n",
-        "\n",
-        "st_max_5 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
-        "                   (lab['st_atr_max_PnL'] >= 1), analyse_column].count()\n",
-        "\n",
-        "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
-        "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
-        "print(f'Above_Mean = {st_max_2:,.2f}')\n",
-        "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
-        "\n",
-        "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
-        "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
-        "print(f'> 1 = {st_max_5:,.2f}')\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "85DATjQqZd66",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "85DATjQqZd66",
-        "outputId": "a438b83c-e4f9-406e-d934-d6f79255edcc"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "Value counts de label 4/5/6:\n",
-            "label\n",
-            "0    33547\n",
-            "1    34223\n",
-            "Name: count, dtype: int64\n"
-          ]
-        }
-      ],
-      "source": [
-        "# --- Parámetros / campos\n",
-        "result_field = 'st_atr_max_PnL'\n",
-        "\n",
-        "#valid = (\n",
-        "#    (lab['Type'] == direction) &\n",
-        "#    (lab['Open_Trade'].isin([1, -1])) &\n",
-        "#    (lab[result_field].notna()))\n",
-        "\n",
-        "valid = (\n",
-        "    (lab['Open_Trade'].isin([1, -1])) &\n",
-        "    (lab[result_field].notna()))\n",
-        "\n",
-        "\n",
-        "# --- Etiquetado en la columna \"label\" con valores 4/5/6\n",
-        "lab['label'] = np.nan\n",
-        "lab.loc[valid & (lab[result_field] <= 1), 'label'] = 0\n",
-        "lab.loc[valid & (lab[result_field] >= 1), 'label'] = 1\n",
-        "\n",
-        "\n",
-        "# --- Mantener solo filas válidas y con label\n",
-        "lab = lab.loc[valid & lab['label'].notna()].copy()\n",
-        "lab['label'] = lab['label'].astype('int8')\n",
-        "\n",
-        "# --- Ver distribución de labels 4/5/6\n",
-        "print('\\nValue counts de label 4/5/6:')\n",
-        "print(lab['label'].value_counts(dropna=False).sort_index())\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "_BCdqt3Y0Fjm",
-      "metadata": {
-        "id": "_BCdqt3Y0Fjm"
-      },
-      "source": [
-        "## Features"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "gX04ZTmfz-pK",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gX04ZTmfz-pK",
-        "outputId": "0a28e505-dec9-4d54-9711-705a904a0050"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "(465518, 455)\n"
-          ]
-        }
-      ],
-      "source": [
-        "raw_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
-        "raw_feat_5min[\"Date\"] = pd.to_datetime(raw_feat_5min[\"Date\"])\n",
-        "print(raw_feat_5min.shape)\n",
-        "#raw_feat_5min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "D5gxf0ke0KUx",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "D5gxf0ke0KUx",
-        "outputId": "da7c18db-8bd4-4865-b8c5-93e5f4adefc8"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "(465518, 455)\n"
-          ]
-        }
-      ],
-      "source": [
-        "scale_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Scale_Features.csv')\n",
-        "#scale_feat_5min = scale_feat_5min.drop('Unnamed: 0', axis=1)\n",
-        "scale_feat_5min[\"Date\"] = pd.to_datetime(scale_feat_5min[\"Date\"])\n",
-        "print(scale_feat_5min.shape)\n",
-        "#scale_feat_5min.head(5)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "Hv5bsrpc03z7",
-      "metadata": {
-        "id": "Hv5bsrpc03z7"
-      },
-      "source": [
-        "## Merge"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Mc1y2NbRM_f1",
-      "metadata": {
-        "id": "Mc1y2NbRM_f1"
-      },
-      "outputs": [],
-      "source": [
-        "data_type = 'Scale'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "I0gkNVT60Ka5",
-      "metadata": {
-        "id": "I0gkNVT60Ka5",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "dfb633fb-e39e-48fa-e77b-f013b4ffc321"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Feature blocks merged:\n",
-            " - M5_raw: 454 columns\n",
-            " - M5_scale: 454 columns\n",
-            " - M10_raw: 454 columns\n",
-            " - M10_scale: 454 columns\n",
-            " - M15_raw: 454 columns\n",
-            " - M15_scale: 454 columns\n",
-            "Combined feature dataframe shape: (67770, 2727)\n",
-            "Saved combined feature dataframe to: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_Short_AllFeatures.csv\n"
-          ]
-        }
-      ],
-      "source": [
-        "def prepare_feature_block(frame: pd.DataFrame, prefix: str) -> pd.DataFrame:\n",
-        "    \"\"\"Return a copy of the feature block with a consistent prefix.\"\"\"\n",
-        "    block = frame.copy()\n",
-        "    if 'Unnamed: 0' in block.columns:\n",
-        "        block = block.drop(columns='Unnamed: 0')\n",
-        "    block = block.drop_duplicates(subset='Date').sort_values('Date')\n",
-        "    rename_map = {col: f\"{prefix}{col}\" for col in block.columns if col != 'Date'}\n",
-        "    block = block.rename(columns=rename_map)\n",
-        "    return block\n",
-        "\n",
-        "feature_blocks = {\n",
-        "    'M5_raw': prepare_feature_block(raw_feat_5min, 'M5_raw_'),\n",
-        "    'M5_scale': prepare_feature_block(scale_feat_5min, 'M5_scale_'),\n",
-        "    'M10_raw': prepare_feature_block(raw_feat_10min, 'M10_raw_'),\n",
-        "    'M10_scale': prepare_feature_block(scale_feat_10min, 'M10_scale_'),\n",
-        "    'M15_raw': prepare_feature_block(raw_feat_15min, 'M15_raw_'),\n",
-        "    'M15_scale': prepare_feature_block(scale_feat_15min, 'M15_scale_'),\n",
-        "}\n",
-        "\n",
-        "feature_df = lab[['Date']].drop_duplicates().copy()\n",
-        "\n",
-        "print('Feature blocks merged:')\n",
-        "for name, block in feature_blocks.items():\n",
-        "    feature_df = feature_df.merge(block, on='Date', how='left')\n",
-        "    print(f\" - {name}: {block.shape[1] - 1} columns\")\n",
-        "\n",
-        "feature_df = feature_df.sort_values('Date').set_index('Date').ffill().reset_index()\n",
-        "\n",
-        "df = lab[['Date', 'label', 'Open_Trade']].merge(feature_df, on='Date', how='left')\n",
-        "\n",
-        "cols = df.columns.tolist()\n",
-        "cols.remove('label')\n",
-        "cols.insert(1, 'label')\n",
-        "df = df[cols]\n",
-        "\n",
-        "combined_feature_path = os.path.join(root_data, 'Results', f\"{symbol}_{direction}_AllFeatures.csv\")\n",
-        "df.to_csv(combined_feature_path, index=False)\n",
-        "\n",
-        "print(f\"Combined feature dataframe shape: {df.shape}\")\n",
-        "print(f\"Saved combined feature dataframe to: {combined_feature_path}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fQPfQroWYLRM",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "fQPfQroWYLRM",
-        "outputId": "dd1cbd5e-8b0e-40fc-ec7f-57c1caf2cfc1"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "M5_raw_: 454 columns\n",
-            "M5_scale_: 454 columns\n",
-            "M10_raw_: 454 columns\n",
-            "M10_scale_: 454 columns\n",
-            "M15_raw_: 454 columns\n",
-            "M15_scale_: 454 columns\n",
-            "No duplicated feature columns detected.\n"
-          ]
-        }
-      ],
-      "source": [
-        "expected_prefixes = ['M5_raw_', 'M5_scale_', 'M10_raw_', 'M10_scale_', 'M15_raw_', 'M15_scale_']\n",
-        "for prefix in expected_prefixes:\n",
-        "    matching_cols = [col for col in df.columns if col.startswith(prefix)]\n",
-        "    print(f\"{prefix}: {len(matching_cols)} columns\")\n",
-        "\n",
-        "duplicated_columns = df.columns[df.columns.duplicated()].tolist()\n",
-        "if duplicated_columns:\n",
-        "    print('Duplicated feature columns detected:', duplicated_columns)\n",
-        "else:\n",
-        "    print('No duplicated feature columns detected.')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "jXcXWty506Ur",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "jXcXWty506Ur",
-        "outputId": "79d68240-6c14-403f-f12e-dfb1c562cfe8"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "(67770, 2727) \n",
-            "\n",
-            "Label_Counts :  label\n",
-            "1    34223\n",
-            "0    33547\n",
-            "Name: count, dtype: int64 \n",
-            "\n",
-            "['Date', 'label', 'Open_Trade', 'M5_raw_MACD_12_26_9', 'M5_raw_MACD_12_26_9_diff', 'M5_raw_MACD_signal_12_26_9', 'M5_raw_MACD_signal_12_26_9_diff', 'M5_raw_MACD_hist_12_26_9', 'M5_raw_MACD_hist_12_26_9_diff', 'M5_raw_RSI_basic_14', 'M5_raw_RSI_basic_14_diff', 'M5_raw_BB_upper_20', 'M5_raw_BB_upper_20_diff', 'M5_raw_BB_middle_20', 'M5_raw_BB_middle_20_diff', 'M5_raw_BB_lower_20', 'M5_raw_BB_lower_20_diff', 'M5_raw_ATR_14', 'M5_raw_ATR_14_diff', 'M5_raw_OBV_basic', 'M5_raw_OBV_basic_diff', 'M5_raw_VWAP_basic', 'M5_raw_VWAP_basic_diff', 'M5_raw_Momentum_10', 'M5_raw_Momentum_10_diff', 'M5_raw_ROC_10', 'M5_raw_ROC_10_diff', 'M5_raw_Stoch_K_14_3_3', 'M5_raw_Stoch_K_14_3_3_diff', 'M5_raw_Stoch_D_14_3_3', 'M5_raw_Stoch_D_14_3_3_diff', 'M5_raw_CCI_20', 'M5_raw_CCI_20_diff', 'M5_raw_MFI_basic_14', 'M5_raw_MFI_basic_14_diff', 'M5_raw_ADX_14', 'M5_raw_ADX_14_diff', 'M5_raw_WilliamsR_14', 'M5_raw_WilliamsR_14_diff', 'M5_raw_CMF', 'M5_raw_CMF_diff', 'M5_raw_TMF', 'M5_raw_TMF_diff', 'M5_raw_MFI_14_volume', 'M5_raw_MFI_14_volume_diff', 'M5_raw_KO', 'M5_raw_KO_diff', 'M5_raw_EFI', 'M5_raw_EFI_diff', 'M5_raw_EOM', 'M5_raw_EOM_diff', 'M5_raw_VPT', 'M5_raw_VPT_diff', 'M5_raw_NVI', 'M5_raw_NVI_diff', 'M5_raw_PVI', 'M5_raw_PVI_diff', 'M5_raw_VFI', 'M5_raw_VFI_diff', 'M5_raw_VWAP', 'M5_raw_VWAP_diff', 'M5_raw_Market_Facilitation_Index', 'M5_raw_Market_Facilitation_Index_diff', 'M5_raw_AD_Line', 'M5_raw_AD_Line_diff', 'M5_raw_WAD', 'M5_raw_WAD_diff', 'M5_raw_EMA_15', 'M5_raw_EMA_15_diff', 'M5_raw_Close_minus_EMA_15', 'M5_raw_EMA_21', 'M5_raw_EMA_21_diff', 'M5_raw_Close_minus_EMA_21', 'M5_raw_EMA_50', 'M5_raw_EMA_50_diff', 'M5_raw_Close_minus_EMA_50', 'M5_raw_EMA_100', 'M5_raw_EMA_100_diff', 'M5_raw_Close_minus_EMA_100', 'M5_raw_EMA_200', 'M5_raw_EMA_200_diff', 'M5_raw_Close_minus_EMA_200', 'M5_raw_EMA_15_above_EMA_21', 'M5_raw_EMA_15_above_EMA_50', 'M5_raw_EMA_15_above_EMA_100', 'M5_raw_EMA_15_above_EMA_200', 'M5_raw_EMA_21_above_EMA_50', 'M5_raw_EMA_21_above_EMA_100', 'M5_raw_EMA_21_above_EMA_200', 'M5_raw_EMA_50_above_EMA_100', 'M5_raw_EMA_50_above_EMA_200', 'M5_raw_EMA_100_above_EMA_200', 'M5_raw_OBV', 'M5_raw_RSI_3', 'M5_raw_MFI_3', 'M5_raw_RSI_7', 'M5_raw_MFI_7', 'M5_raw_RSI_14', 'M5_raw_MFI_14', 'M5_raw_RSI_3_diff', 'M5_raw_RSI_7_diff', 'M5_raw_RSI_14_diff', 'M5_raw_RSI_3 - RSI_7', 'M5_raw_RSI_3 - RSI_14', 'M5_raw_RSI_7 - RSI_14', 'M5_raw_MFI_3_diff', 'M5_raw_MFI_7_diff', 'M5_raw_MFI_14_diff', 'M5_raw_MFI_3 - MFI_7', 'M5_raw_MFI_3 - MFI_14', 'M5_raw_MFI_7 - MFI_14', 'M5_raw_OBV_diff', 'M5_raw_Kal_300', 'M5_raw_Close_Kal_300', 'M5_raw_Kal_change_300', 'M5_raw_Kal_prev_minus_now_300', 'M5_raw_Kal_prev2_minus_now_300', 'M5_raw_Kal_change2_300', 'M5_raw_Kal_600', 'M5_raw_Close_Kal_600', 'M5_raw_Kal_change_600', 'M5_raw_Kal_prev_minus_now_600', 'M5_raw_Kal_prev2_minus_now_600', 'M5_raw_Kal_change2_600', 'M5_raw_Kal_900', 'M5_raw_Close_Kal_900', 'M5_raw_Kal_change_900', 'M5_raw_Kal_prev_minus_now_900', 'M5_raw_Kal_prev2_minus_now_900', 'M5_raw_Kal_change2_900', 'M5_raw_Kal_300_minus_Kal_600', 'M5_raw_Kal_300_minus_Kal_900', 'M5_raw_Kal_600_minus_Kal_900', 'M5_raw_slope_div_300_3', 'M5_raw_slope_div_300_3_diff', 'M5_raw_slope_signal_300_3', 'M5_raw_slope_signal_300_3_diff', 'M5_raw_slope_angle_300_3', 'M5_raw_slope_angle_300_3_diff', 'M5_raw_slope_angle_signal_300_3', 'M5_raw_slope_angle_signal_300_3_diff', 'M5_raw_slope_lin_reg_300_3', 'M5_raw_slope_lin_reg_300_3_diff', 'M5_raw_slope_lin_reg_signal_300_3', 'M5_raw_slope_lin_reg_signal_300_3_diff', 'M5_raw_slope_div_300_6', 'M5_raw_slope_div_300_6_diff', 'M5_raw_slope_signal_300_6', 'M5_raw_slope_signal_300_6_diff', 'M5_raw_slope_angle_300_6', 'M5_raw_slope_angle_300_6_diff', 'M5_raw_slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_6_diff', 'M5_raw_slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_6_diff', 'M5_raw_slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_6_diff', 'M5_raw_slope_div_300_9', 'M5_raw_slope_div_300_9_diff', 'M5_raw_slope_signal_300_9', 'M5_raw_slope_signal_300_9_diff', 'M5_raw_slope_angle_300_9', 'M5_raw_slope_angle_300_9_diff', 'M5_raw_slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_9_diff', 'M5_raw_slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_9_diff', 'M5_raw_slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_9_diff', 'M5_raw_slope_div_600_3', 'M5_raw_slope_div_600_3_diff', 'M5_raw_slope_signal_600_3', 'M5_raw_slope_signal_600_3_diff', 'M5_raw_slope_angle_600_3', 'M5_raw_slope_angle_600_3_diff', 'M5_raw_slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_600_3_diff', 'M5_raw_slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_600_3_diff', 'M5_raw_slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_600_3_diff', 'M5_raw_slope_div_600_6', 'M5_raw_slope_div_600_6_diff', 'M5_raw_slope_signal_600_6', 'M5_raw_slope_signal_600_6_diff', 'M5_raw_slope_angle_600_6', 'M5_raw_slope_angle_600_6_diff', 'M5_raw_slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_6_diff', 'M5_raw_slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_6_diff', 'M5_raw_slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_6_diff', 'M5_raw_slope_div_600_9', 'M5_raw_slope_div_600_9_diff', 'M5_raw_slope_signal_600_9', 'M5_raw_slope_signal_600_9_diff', 'M5_raw_slope_angle_600_9', 'M5_raw_slope_angle_600_9_diff', 'M5_raw_slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_9_diff', 'M5_raw_slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_9_diff', 'M5_raw_slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_9_diff', 'M5_raw_slope_div_900_3', 'M5_raw_slope_div_900_3_diff', 'M5_raw_slope_signal_900_3', 'M5_raw_slope_signal_900_3_diff', 'M5_raw_slope_angle_900_3', 'M5_raw_slope_angle_900_3_diff', 'M5_raw_slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_900_3_diff', 'M5_raw_slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_900_3_diff', 'M5_raw_slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_900_3_diff', 'M5_raw_slope_div_900_6', 'M5_raw_slope_div_900_6_diff', 'M5_raw_slope_signal_900_6', 'M5_raw_slope_signal_900_6_diff', 'M5_raw_slope_angle_900_6', 'M5_raw_slope_angle_900_6_diff', 'M5_raw_slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_6_diff', 'M5_raw_slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_6_diff', 'M5_raw_slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_6_diff', 'M5_raw_slope_div_900_9', 'M5_raw_slope_div_900_9_diff', 'M5_raw_slope_signal_900_9', 'M5_raw_slope_signal_900_9_diff', 'M5_raw_slope_angle_900_9', 'M5_raw_slope_angle_900_9_diff', 'M5_raw_slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_9_diff', 'M5_raw_slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_9_diff', 'M5_raw_slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_9_diff', 'M5_raw_slope_div_300_3 - slope_div_300_6', 'M5_raw_slope_div_300_3 - slope_div_300_9', 'M5_raw_slope_div_300_3 - slope_div_600_3', 'M5_raw_slope_div_300_3 - slope_div_600_6', 'M5_raw_slope_div_300_3 - slope_div_600_9', 'M5_raw_slope_div_300_3 - slope_div_900_3', 'M5_raw_slope_div_300_3 - slope_div_900_6', 'M5_raw_slope_div_300_3 - slope_div_900_9', 'M5_raw_slope_div_300_6 - slope_div_300_9', 'M5_raw_slope_div_300_6 - slope_div_600_3', 'M5_raw_slope_div_300_6 - slope_div_600_6', 'M5_raw_slope_div_300_6 - slope_div_600_9', 'M5_raw_slope_div_300_6 - slope_div_900_3', 'M5_raw_slope_div_300_6 - slope_div_900_6', 'M5_raw_slope_div_300_6 - slope_div_900_9', 'M5_raw_slope_div_300_9 - slope_div_600_3', 'M5_raw_slope_div_300_9 - slope_div_600_6', 'M5_raw_slope_div_300_9 - slope_div_600_9', 'M5_raw_slope_div_300_9 - slope_div_900_3', 'M5_raw_slope_div_300_9 - slope_div_900_6', 'M5_raw_slope_div_300_9 - slope_div_900_9', 'M5_raw_slope_div_600_3 - slope_div_600_6', 'M5_raw_slope_div_600_3 - slope_div_600_9', 'M5_raw_slope_div_600_3 - slope_div_900_3', 'M5_raw_slope_div_600_3 - slope_div_900_6', 'M5_raw_slope_div_600_3 - slope_div_900_9', 'M5_raw_slope_div_600_6 - slope_div_600_9', 'M5_raw_slope_div_600_6 - slope_div_900_3', 'M5_raw_slope_div_600_6 - slope_div_900_6', 'M5_raw_slope_div_600_6 - slope_div_900_9', 'M5_raw_slope_div_600_9 - slope_div_900_3', 'M5_raw_slope_div_600_9 - slope_div_900_6', 'M5_raw_slope_div_600_9 - slope_div_900_9', 'M5_raw_slope_div_900_3 - slope_div_900_6', 'M5_raw_slope_div_900_3 - slope_div_900_9', 'M5_raw_slope_div_900_6 - slope_div_900_9', 'M5_raw_slope_signal_300_3 - slope_signal_300_6', 'M5_raw_slope_signal_300_3 - slope_signal_300_9', 'M5_raw_slope_signal_300_3 - slope_signal_600_3', 'M5_raw_slope_signal_300_3 - slope_signal_600_6', 'M5_raw_slope_signal_300_3 - slope_signal_600_9', 'M5_raw_slope_signal_300_3 - slope_signal_900_3', 'M5_raw_slope_signal_300_3 - slope_signal_900_6', 'M5_raw_slope_signal_300_3 - slope_signal_900_9', 'M5_raw_slope_signal_300_6 - slope_signal_300_9', 'M5_raw_slope_signal_300_6 - slope_signal_600_3', 'M5_raw_slope_signal_300_6 - slope_signal_600_6', 'M5_raw_slope_signal_300_6 - slope_signal_600_9', 'M5_raw_slope_signal_300_6 - slope_signal_900_3', 'M5_raw_slope_signal_300_6 - slope_signal_900_6', 'M5_raw_slope_signal_300_6 - slope_signal_900_9', 'M5_raw_slope_signal_300_9 - slope_signal_600_3', 'M5_raw_slope_signal_300_9 - slope_signal_600_6', 'M5_raw_slope_signal_300_9 - slope_signal_600_9', 'M5_raw_slope_signal_300_9 - slope_signal_900_3', 'M5_raw_slope_signal_300_9 - slope_signal_900_6', 'M5_raw_slope_signal_300_9 - slope_signal_900_9', 'M5_raw_slope_signal_600_3 - slope_signal_600_6', 'M5_raw_slope_signal_600_3 - slope_signal_600_9', 'M5_raw_slope_signal_600_3 - slope_signal_900_3', 'M5_raw_slope_signal_600_3 - slope_signal_900_6', 'M5_raw_slope_signal_600_3 - slope_signal_900_9', 'M5_raw_slope_signal_600_6 - slope_signal_600_9', 'M5_raw_slope_signal_600_6 - slope_signal_900_3', 'M5_raw_slope_signal_600_6 - slope_signal_900_6', 'M5_raw_slope_signal_600_6 - slope_signal_900_9', 'M5_raw_slope_signal_600_9 - slope_signal_900_3', 'M5_raw_slope_signal_600_9 - slope_signal_900_6', 'M5_raw_slope_signal_600_9 - slope_signal_900_9', 'M5_raw_slope_signal_900_3 - slope_signal_900_6', 'M5_raw_slope_signal_900_3 - slope_signal_900_9', 'M5_raw_slope_signal_900_6 - slope_signal_900_9', 'M5_raw_slope_angle_300_3 - slope_angle_300_6', 'M5_raw_slope_angle_300_3 - slope_angle_300_9', 'M5_raw_slope_angle_300_3 - slope_angle_600_3', 'M5_raw_slope_angle_300_3 - slope_angle_600_6', 'M5_raw_slope_angle_300_3 - slope_angle_600_9', 'M5_raw_slope_angle_300_3 - slope_angle_900_3', 'M5_raw_slope_angle_300_3 - slope_angle_900_6', 'M5_raw_slope_angle_300_3 - slope_angle_900_9', 'M5_raw_slope_angle_300_6 - slope_angle_300_9', 'M5_raw_slope_angle_300_6 - slope_angle_600_3', 'M5_raw_slope_angle_300_6 - slope_angle_600_6', 'M5_raw_slope_angle_300_6 - slope_angle_600_9', 'M5_raw_slope_angle_300_6 - slope_angle_900_3', 'M5_raw_slope_angle_300_6 - slope_angle_900_6', 'M5_raw_slope_angle_300_6 - slope_angle_900_9', 'M5_raw_slope_angle_300_9 - slope_angle_600_3', 'M5_raw_slope_angle_300_9 - slope_angle_600_6', 'M5_raw_slope_angle_300_9 - slope_angle_600_9', 'M5_raw_slope_angle_300_9 - slope_angle_900_3', 'M5_raw_slope_angle_300_9 - slope_angle_900_6', 'M5_raw_slope_angle_300_9 - slope_angle_900_9', 'M5_raw_slope_angle_600_3 - slope_angle_600_6', 'M5_raw_slope_angle_600_3 - slope_angle_600_9', 'M5_raw_slope_angle_600_3 - slope_angle_900_3', 'M5_raw_slope_angle_600_3 - slope_angle_900_6', 'M5_raw_slope_angle_600_3 - slope_angle_900_9', 'M5_raw_slope_angle_600_6 - slope_angle_600_9', 'M5_raw_slope_angle_600_6 - slope_angle_900_3', 'M5_raw_slope_angle_600_6 - slope_angle_900_6', 'M5_raw_slope_angle_600_6 - slope_angle_900_9', 'M5_raw_slope_angle_600_9 - slope_angle_900_3', 'M5_raw_slope_angle_600_9 - slope_angle_900_6', 'M5_raw_slope_angle_600_9 - slope_angle_900_9', 'M5_raw_slope_angle_900_3 - slope_angle_900_6', 'M5_raw_slope_angle_900_3 - slope_angle_900_9', 'M5_raw_slope_angle_900_6 - slope_angle_900_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M5_scale_MACD_12_26_9', 'M5_scale_MACD_12_26_9_diff', 'M5_scale_MACD_signal_12_26_9', 'M5_scale_MACD_signal_12_26_9_diff', 'M5_scale_MACD_hist_12_26_9', 'M5_scale_MACD_hist_12_26_9_diff', 'M5_scale_RSI_basic_14', 'M5_scale_RSI_basic_14_diff', 'M5_scale_BB_upper_20', 'M5_scale_BB_upper_20_diff', 'M5_scale_BB_middle_20', 'M5_scale_BB_middle_20_diff', 'M5_scale_BB_lower_20', 'M5_scale_BB_lower_20_diff', 'M5_scale_ATR_14', 'M5_scale_ATR_14_diff', 'M5_scale_OBV_basic', 'M5_scale_OBV_basic_diff', 'M5_scale_VWAP_basic', 'M5_scale_VWAP_basic_diff', 'M5_scale_Momentum_10', 'M5_scale_Momentum_10_diff', 'M5_scale_ROC_10', 'M5_scale_ROC_10_diff', 'M5_scale_Stoch_K_14_3_3', 'M5_scale_Stoch_K_14_3_3_diff', 'M5_scale_Stoch_D_14_3_3', 'M5_scale_Stoch_D_14_3_3_diff', 'M5_scale_CCI_20', 'M5_scale_CCI_20_diff', 'M5_scale_MFI_basic_14', 'M5_scale_MFI_basic_14_diff', 'M5_scale_ADX_14', 'M5_scale_ADX_14_diff', 'M5_scale_WilliamsR_14', 'M5_scale_WilliamsR_14_diff', 'M5_scale_CMF', 'M5_scale_CMF_diff', 'M5_scale_TMF', 'M5_scale_TMF_diff', 'M5_scale_MFI_14_volume', 'M5_scale_MFI_14_volume_diff', 'M5_scale_KO', 'M5_scale_KO_diff', 'M5_scale_EFI', 'M5_scale_EFI_diff', 'M5_scale_EOM', 'M5_scale_EOM_diff', 'M5_scale_VPT', 'M5_scale_VPT_diff', 'M5_scale_NVI', 'M5_scale_NVI_diff', 'M5_scale_PVI', 'M5_scale_PVI_diff', 'M5_scale_VFI', 'M5_scale_VFI_diff', 'M5_scale_VWAP', 'M5_scale_VWAP_diff', 'M5_scale_Market_Facilitation_Index', 'M5_scale_Market_Facilitation_Index_diff', 'M5_scale_AD_Line', 'M5_scale_AD_Line_diff', 'M5_scale_WAD', 'M5_scale_WAD_diff', 'M5_scale_EMA_15', 'M5_scale_EMA_15_diff', 'M5_scale_Close_minus_EMA_15', 'M5_scale_EMA_21', 'M5_scale_EMA_21_diff', 'M5_scale_Close_minus_EMA_21', 'M5_scale_EMA_50', 'M5_scale_EMA_50_diff', 'M5_scale_Close_minus_EMA_50', 'M5_scale_EMA_100', 'M5_scale_EMA_100_diff', 'M5_scale_Close_minus_EMA_100', 'M5_scale_EMA_200', 'M5_scale_EMA_200_diff', 'M5_scale_Close_minus_EMA_200', 'M5_scale_EMA_15_above_EMA_21', 'M5_scale_EMA_15_above_EMA_50', 'M5_scale_EMA_15_above_EMA_100', 'M5_scale_EMA_15_above_EMA_200', 'M5_scale_EMA_21_above_EMA_50', 'M5_scale_EMA_21_above_EMA_100', 'M5_scale_EMA_21_above_EMA_200', 'M5_scale_EMA_50_above_EMA_100', 'M5_scale_EMA_50_above_EMA_200', 'M5_scale_EMA_100_above_EMA_200', 'M5_scale_OBV', 'M5_scale_RSI_3', 'M5_scale_MFI_3', 'M5_scale_RSI_7', 'M5_scale_MFI_7', 'M5_scale_RSI_14', 'M5_scale_MFI_14', 'M5_scale_RSI_3_diff', 'M5_scale_RSI_7_diff', 'M5_scale_RSI_14_diff', 'M5_scale_RSI_3 - RSI_7', 'M5_scale_RSI_3 - RSI_14', 'M5_scale_RSI_7 - RSI_14', 'M5_scale_MFI_3_diff', 'M5_scale_MFI_7_diff', 'M5_scale_MFI_14_diff', 'M5_scale_MFI_3 - MFI_7', 'M5_scale_MFI_3 - MFI_14', 'M5_scale_MFI_7 - MFI_14', 'M5_scale_OBV_diff', 'M5_scale_Kal_300', 'M5_scale_Close_Kal_300', 'M5_scale_Kal_change_300', 'M5_scale_Kal_prev_minus_now_300', 'M5_scale_Kal_prev2_minus_now_300', 'M5_scale_Kal_change2_300', 'M5_scale_Kal_600', 'M5_scale_Close_Kal_600', 'M5_scale_Kal_change_600', 'M5_scale_Kal_prev_minus_now_600', 'M5_scale_Kal_prev2_minus_now_600', 'M5_scale_Kal_change2_600', 'M5_scale_Kal_900', 'M5_scale_Close_Kal_900', 'M5_scale_Kal_change_900', 'M5_scale_Kal_prev_minus_now_900', 'M5_scale_Kal_prev2_minus_now_900', 'M5_scale_Kal_change2_900', 'M5_scale_Kal_300_minus_Kal_600', 'M5_scale_Kal_300_minus_Kal_900', 'M5_scale_Kal_600_minus_Kal_900', 'M5_scale_slope_div_300_3', 'M5_scale_slope_div_300_3_diff', 'M5_scale_slope_signal_300_3', 'M5_scale_slope_signal_300_3_diff', 'M5_scale_slope_angle_300_3', 'M5_scale_slope_angle_300_3_diff', 'M5_scale_slope_angle_signal_300_3', 'M5_scale_slope_angle_signal_300_3_diff', 'M5_scale_slope_lin_reg_300_3', 'M5_scale_slope_lin_reg_300_3_diff', 'M5_scale_slope_lin_reg_signal_300_3', 'M5_scale_slope_lin_reg_signal_300_3_diff', 'M5_scale_slope_div_300_6', 'M5_scale_slope_div_300_6_diff', 'M5_scale_slope_signal_300_6', 'M5_scale_slope_signal_300_6_diff', 'M5_scale_slope_angle_300_6', 'M5_scale_slope_angle_300_6_diff', 'M5_scale_slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_6_diff', 'M5_scale_slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_6_diff', 'M5_scale_slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_6_diff', 'M5_scale_slope_div_300_9', 'M5_scale_slope_div_300_9_diff', 'M5_scale_slope_signal_300_9', 'M5_scale_slope_signal_300_9_diff', 'M5_scale_slope_angle_300_9', 'M5_scale_slope_angle_300_9_diff', 'M5_scale_slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_9_diff', 'M5_scale_slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_9_diff', 'M5_scale_slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_9_diff', 'M5_scale_slope_div_600_3', 'M5_scale_slope_div_600_3_diff', 'M5_scale_slope_signal_600_3', 'M5_scale_slope_signal_600_3_diff', 'M5_scale_slope_angle_600_3', 'M5_scale_slope_angle_600_3_diff', 'M5_scale_slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_600_3_diff', 'M5_scale_slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_600_3_diff', 'M5_scale_slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_600_3_diff', 'M5_scale_slope_div_600_6', 'M5_scale_slope_div_600_6_diff', 'M5_scale_slope_signal_600_6', 'M5_scale_slope_signal_600_6_diff', 'M5_scale_slope_angle_600_6', 'M5_scale_slope_angle_600_6_diff', 'M5_scale_slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_6_diff', 'M5_scale_slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_6_diff', 'M5_scale_slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_6_diff', 'M5_scale_slope_div_600_9', 'M5_scale_slope_div_600_9_diff', 'M5_scale_slope_signal_600_9', 'M5_scale_slope_signal_600_9_diff', 'M5_scale_slope_angle_600_9', 'M5_scale_slope_angle_600_9_diff', 'M5_scale_slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_9_diff', 'M5_scale_slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_9_diff', 'M5_scale_slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_9_diff', 'M5_scale_slope_div_900_3', 'M5_scale_slope_div_900_3_diff', 'M5_scale_slope_signal_900_3', 'M5_scale_slope_signal_900_3_diff', 'M5_scale_slope_angle_900_3', 'M5_scale_slope_angle_900_3_diff', 'M5_scale_slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_900_3_diff', 'M5_scale_slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_900_3_diff', 'M5_scale_slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_900_3_diff', 'M5_scale_slope_div_900_6', 'M5_scale_slope_div_900_6_diff', 'M5_scale_slope_signal_900_6', 'M5_scale_slope_signal_900_6_diff', 'M5_scale_slope_angle_900_6', 'M5_scale_slope_angle_900_6_diff', 'M5_scale_slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_6_diff', 'M5_scale_slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_6_diff', 'M5_scale_slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_6_diff', 'M5_scale_slope_div_900_9', 'M5_scale_slope_div_900_9_diff', 'M5_scale_slope_signal_900_9', 'M5_scale_slope_signal_900_9_diff', 'M5_scale_slope_angle_900_9', 'M5_scale_slope_angle_900_9_diff', 'M5_scale_slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_9_diff', 'M5_scale_slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_9_diff', 'M5_scale_slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_9_diff', 'M5_scale_slope_div_300_3 - slope_div_300_6', 'M5_scale_slope_div_300_3 - slope_div_300_9', 'M5_scale_slope_div_300_3 - slope_div_600_3', 'M5_scale_slope_div_300_3 - slope_div_600_6', 'M5_scale_slope_div_300_3 - slope_div_600_9', 'M5_scale_slope_div_300_3 - slope_div_900_3', 'M5_scale_slope_div_300_3 - slope_div_900_6', 'M5_scale_slope_div_300_3 - slope_div_900_9', 'M5_scale_slope_div_300_6 - slope_div_300_9', 'M5_scale_slope_div_300_6 - slope_div_600_3', 'M5_scale_slope_div_300_6 - slope_div_600_6', 'M5_scale_slope_div_300_6 - slope_div_600_9', 'M5_scale_slope_div_300_6 - slope_div_900_3', 'M5_scale_slope_div_300_6 - slope_div_900_6', 'M5_scale_slope_div_300_6 - slope_div_900_9', 'M5_scale_slope_div_300_9 - slope_div_600_3', 'M5_scale_slope_div_300_9 - slope_div_600_6', 'M5_scale_slope_div_300_9 - slope_div_600_9', 'M5_scale_slope_div_300_9 - slope_div_900_3', 'M5_scale_slope_div_300_9 - slope_div_900_6', 'M5_scale_slope_div_300_9 - slope_div_900_9', 'M5_scale_slope_div_600_3 - slope_div_600_6', 'M5_scale_slope_div_600_3 - slope_div_600_9', 'M5_scale_slope_div_600_3 - slope_div_900_3', 'M5_scale_slope_div_600_3 - slope_div_900_6', 'M5_scale_slope_div_600_3 - slope_div_900_9', 'M5_scale_slope_div_600_6 - slope_div_600_9', 'M5_scale_slope_div_600_6 - slope_div_900_3', 'M5_scale_slope_div_600_6 - slope_div_900_6', 'M5_scale_slope_div_600_6 - slope_div_900_9', 'M5_scale_slope_div_600_9 - slope_div_900_3', 'M5_scale_slope_div_600_9 - slope_div_900_6', 'M5_scale_slope_div_600_9 - slope_div_900_9', 'M5_scale_slope_div_900_3 - slope_div_900_6', 'M5_scale_slope_div_900_3 - slope_div_900_9', 'M5_scale_slope_div_900_6 - slope_div_900_9', 'M5_scale_slope_signal_300_3 - slope_signal_300_6', 'M5_scale_slope_signal_300_3 - slope_signal_300_9', 'M5_scale_slope_signal_300_3 - slope_signal_600_3', 'M5_scale_slope_signal_300_3 - slope_signal_600_6', 'M5_scale_slope_signal_300_3 - slope_signal_600_9', 'M5_scale_slope_signal_300_3 - slope_signal_900_3', 'M5_scale_slope_signal_300_3 - slope_signal_900_6', 'M5_scale_slope_signal_300_3 - slope_signal_900_9', 'M5_scale_slope_signal_300_6 - slope_signal_300_9', 'M5_scale_slope_signal_300_6 - slope_signal_600_3', 'M5_scale_slope_signal_300_6 - slope_signal_600_6', 'M5_scale_slope_signal_300_6 - slope_signal_600_9', 'M5_scale_slope_signal_300_6 - slope_signal_900_3', 'M5_scale_slope_signal_300_6 - slope_signal_900_6', 'M5_scale_slope_signal_300_6 - slope_signal_900_9', 'M5_scale_slope_signal_300_9 - slope_signal_600_3', 'M5_scale_slope_signal_300_9 - slope_signal_600_6', 'M5_scale_slope_signal_300_9 - slope_signal_600_9', 'M5_scale_slope_signal_300_9 - slope_signal_900_3', 'M5_scale_slope_signal_300_9 - slope_signal_900_6', 'M5_scale_slope_signal_300_9 - slope_signal_900_9', 'M5_scale_slope_signal_600_3 - slope_signal_600_6', 'M5_scale_slope_signal_600_3 - slope_signal_600_9', 'M5_scale_slope_signal_600_3 - slope_signal_900_3', 'M5_scale_slope_signal_600_3 - slope_signal_900_6', 'M5_scale_slope_signal_600_3 - slope_signal_900_9', 'M5_scale_slope_signal_600_6 - slope_signal_600_9', 'M5_scale_slope_signal_600_6 - slope_signal_900_3', 'M5_scale_slope_signal_600_6 - slope_signal_900_6', 'M5_scale_slope_signal_600_6 - slope_signal_900_9', 'M5_scale_slope_signal_600_9 - slope_signal_900_3', 'M5_scale_slope_signal_600_9 - slope_signal_900_6', 'M5_scale_slope_signal_600_9 - slope_signal_900_9', 'M5_scale_slope_signal_900_3 - slope_signal_900_6', 'M5_scale_slope_signal_900_3 - slope_signal_900_9', 'M5_scale_slope_signal_900_6 - slope_signal_900_9', 'M5_scale_slope_angle_300_3 - slope_angle_300_6', 'M5_scale_slope_angle_300_3 - slope_angle_300_9', 'M5_scale_slope_angle_300_3 - slope_angle_600_3', 'M5_scale_slope_angle_300_3 - slope_angle_600_6', 'M5_scale_slope_angle_300_3 - slope_angle_600_9', 'M5_scale_slope_angle_300_3 - slope_angle_900_3', 'M5_scale_slope_angle_300_3 - slope_angle_900_6', 'M5_scale_slope_angle_300_3 - slope_angle_900_9', 'M5_scale_slope_angle_300_6 - slope_angle_300_9', 'M5_scale_slope_angle_300_6 - slope_angle_600_3', 'M5_scale_slope_angle_300_6 - slope_angle_600_6', 'M5_scale_slope_angle_300_6 - slope_angle_600_9', 'M5_scale_slope_angle_300_6 - slope_angle_900_3', 'M5_scale_slope_angle_300_6 - slope_angle_900_6', 'M5_scale_slope_angle_300_6 - slope_angle_900_9', 'M5_scale_slope_angle_300_9 - slope_angle_600_3', 'M5_scale_slope_angle_300_9 - slope_angle_600_6', 'M5_scale_slope_angle_300_9 - slope_angle_600_9', 'M5_scale_slope_angle_300_9 - slope_angle_900_3', 'M5_scale_slope_angle_300_9 - slope_angle_900_6', 'M5_scale_slope_angle_300_9 - slope_angle_900_9', 'M5_scale_slope_angle_600_3 - slope_angle_600_6', 'M5_scale_slope_angle_600_3 - slope_angle_600_9', 'M5_scale_slope_angle_600_3 - slope_angle_900_3', 'M5_scale_slope_angle_600_3 - slope_angle_900_6', 'M5_scale_slope_angle_600_3 - slope_angle_900_9', 'M5_scale_slope_angle_600_6 - slope_angle_600_9', 'M5_scale_slope_angle_600_6 - slope_angle_900_3', 'M5_scale_slope_angle_600_6 - slope_angle_900_6', 'M5_scale_slope_angle_600_6 - slope_angle_900_9', 'M5_scale_slope_angle_600_9 - slope_angle_900_3', 'M5_scale_slope_angle_600_9 - slope_angle_900_6', 'M5_scale_slope_angle_600_9 - slope_angle_900_9', 'M5_scale_slope_angle_900_3 - slope_angle_900_6', 'M5_scale_slope_angle_900_3 - slope_angle_900_9', 'M5_scale_slope_angle_900_6 - slope_angle_900_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_MACD_12_26_9', 'M10_raw_10min_MACD_12_26_9_diff', 'M10_raw_10min_MACD_signal_12_26_9', 'M10_raw_10min_MACD_signal_12_26_9_diff', 'M10_raw_10min_MACD_hist_12_26_9', 'M10_raw_10min_MACD_hist_12_26_9_diff', 'M10_raw_10min_RSI_basic_14', 'M10_raw_10min_RSI_basic_14_diff', 'M10_raw_10min_BB_upper_20', 'M10_raw_10min_BB_upper_20_diff', 'M10_raw_10min_BB_middle_20', 'M10_raw_10min_BB_middle_20_diff', 'M10_raw_10min_BB_lower_20', 'M10_raw_10min_BB_lower_20_diff', 'M10_raw_10min_ATR_14', 'M10_raw_10min_ATR_14_diff', 'M10_raw_10min_OBV_basic', 'M10_raw_10min_OBV_basic_diff', 'M10_raw_10min_VWAP_basic', 'M10_raw_10min_VWAP_basic_diff', 'M10_raw_10min_Momentum_10', 'M10_raw_10min_Momentum_10_diff', 'M10_raw_10min_ROC_10', 'M10_raw_10min_ROC_10_diff', 'M10_raw_10min_Stoch_K_14_3_3', 'M10_raw_10min_Stoch_K_14_3_3_diff', 'M10_raw_10min_Stoch_D_14_3_3', 'M10_raw_10min_Stoch_D_14_3_3_diff', 'M10_raw_10min_CCI_20', 'M10_raw_10min_CCI_20_diff', 'M10_raw_10min_MFI_basic_14', 'M10_raw_10min_MFI_basic_14_diff', 'M10_raw_10min_ADX_14', 'M10_raw_10min_ADX_14_diff', 'M10_raw_10min_WilliamsR_14', 'M10_raw_10min_WilliamsR_14_diff', 'M10_raw_10min_CMF', 'M10_raw_10min_CMF_diff', 'M10_raw_10min_TMF', 'M10_raw_10min_TMF_diff', 'M10_raw_10min_MFI_14_volume', 'M10_raw_10min_MFI_14_volume_diff', 'M10_raw_10min_KO', 'M10_raw_10min_KO_diff', 'M10_raw_10min_EFI', 'M10_raw_10min_EFI_diff', 'M10_raw_10min_EOM', 'M10_raw_10min_EOM_diff', 'M10_raw_10min_VPT', 'M10_raw_10min_VPT_diff', 'M10_raw_10min_NVI', 'M10_raw_10min_NVI_diff', 'M10_raw_10min_PVI', 'M10_raw_10min_PVI_diff', 'M10_raw_10min_VFI', 'M10_raw_10min_VFI_diff', 'M10_raw_10min_VWAP', 'M10_raw_10min_VWAP_diff', 'M10_raw_10min_Market_Facilitation_Index', 'M10_raw_10min_Market_Facilitation_Index_diff', 'M10_raw_10min_AD_Line', 'M10_raw_10min_AD_Line_diff', 'M10_raw_10min_WAD', 'M10_raw_10min_WAD_diff', 'M10_raw_10min_EMA_15', 'M10_raw_10min_EMA_15_diff', 'M10_raw_10min_Close_minus_EMA_15', 'M10_raw_10min_EMA_21', 'M10_raw_10min_EMA_21_diff', 'M10_raw_10min_Close_minus_EMA_21', 'M10_raw_10min_EMA_50', 'M10_raw_10min_EMA_50_diff', 'M10_raw_10min_Close_minus_EMA_50', 'M10_raw_10min_EMA_100', 'M10_raw_10min_EMA_100_diff', 'M10_raw_10min_Close_minus_EMA_100', 'M10_raw_10min_EMA_200', 'M10_raw_10min_EMA_200_diff', 'M10_raw_10min_Close_minus_EMA_200', 'M10_raw_10min_EMA_15_above_EMA_21', 'M10_raw_10min_EMA_15_above_EMA_50', 'M10_raw_10min_EMA_15_above_EMA_100', 'M10_raw_10min_EMA_15_above_EMA_200', 'M10_raw_10min_EMA_21_above_EMA_50', 'M10_raw_10min_EMA_21_above_EMA_100', 'M10_raw_10min_EMA_21_above_EMA_200', 'M10_raw_10min_EMA_50_above_EMA_100', 'M10_raw_10min_EMA_50_above_EMA_200', 'M10_raw_10min_EMA_100_above_EMA_200', 'M10_raw_10min_OBV', 'M10_raw_10min_RSI_3', 'M10_raw_10min_MFI_3', 'M10_raw_10min_RSI_7', 'M10_raw_10min_MFI_7', 'M10_raw_10min_RSI_14', 'M10_raw_10min_MFI_14', 'M10_raw_10min_RSI_3_diff', 'M10_raw_10min_RSI_7_diff', 'M10_raw_10min_RSI_14_diff', 'M10_raw_10min_RSI_3 - RSI_7', 'M10_raw_10min_RSI_3 - RSI_14', 'M10_raw_10min_RSI_7 - RSI_14', 'M10_raw_10min_MFI_3_diff', 'M10_raw_10min_MFI_7_diff', 'M10_raw_10min_MFI_14_diff', 'M10_raw_10min_MFI_3 - MFI_7', 'M10_raw_10min_MFI_3 - MFI_14', 'M10_raw_10min_MFI_7 - MFI_14', 'M10_raw_10min_OBV_diff', 'M10_raw_10min_Kal_300', 'M10_raw_10min_Close_Kal_300', 'M10_raw_10min_Kal_change_300', 'M10_raw_10min_Kal_prev_minus_now_300', 'M10_raw_10min_Kal_prev2_minus_now_300', 'M10_raw_10min_Kal_change2_300', 'M10_raw_10min_Kal_600', 'M10_raw_10min_Close_Kal_600', 'M10_raw_10min_Kal_change_600', 'M10_raw_10min_Kal_prev_minus_now_600', 'M10_raw_10min_Kal_prev2_minus_now_600', 'M10_raw_10min_Kal_change2_600', 'M10_raw_10min_Kal_900', 'M10_raw_10min_Close_Kal_900', 'M10_raw_10min_Kal_change_900', 'M10_raw_10min_Kal_prev_minus_now_900', 'M10_raw_10min_Kal_prev2_minus_now_900', 'M10_raw_10min_Kal_change2_900', 'M10_raw_10min_Kal_300_minus_Kal_600', 'M10_raw_10min_Kal_300_minus_Kal_900', 'M10_raw_10min_Kal_600_minus_Kal_900', 'M10_raw_10min_slope_div_300_3', 'M10_raw_10min_slope_div_300_3_diff', 'M10_raw_10min_slope_signal_300_3', 'M10_raw_10min_slope_signal_300_3_diff', 'M10_raw_10min_slope_angle_300_3', 'M10_raw_10min_slope_angle_300_3_diff', 'M10_raw_10min_slope_angle_signal_300_3', 'M10_raw_10min_slope_angle_signal_300_3_diff', 'M10_raw_10min_slope_lin_reg_300_3', 'M10_raw_10min_slope_lin_reg_300_3_diff', 'M10_raw_10min_slope_lin_reg_signal_300_3', 'M10_raw_10min_slope_lin_reg_signal_300_3_diff', 'M10_raw_10min_slope_div_300_6', 'M10_raw_10min_slope_div_300_6_diff', 'M10_raw_10min_slope_signal_300_6', 'M10_raw_10min_slope_signal_300_6_diff', 'M10_raw_10min_slope_angle_300_6', 'M10_raw_10min_slope_angle_300_6_diff', 'M10_raw_10min_slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_6_diff', 'M10_raw_10min_slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_6_diff', 'M10_raw_10min_slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_6_diff', 'M10_raw_10min_slope_div_300_9', 'M10_raw_10min_slope_div_300_9_diff', 'M10_raw_10min_slope_signal_300_9', 'M10_raw_10min_slope_signal_300_9_diff', 'M10_raw_10min_slope_angle_300_9', 'M10_raw_10min_slope_angle_300_9_diff', 'M10_raw_10min_slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_9_diff', 'M10_raw_10min_slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_9_diff', 'M10_raw_10min_slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_9_diff', 'M10_raw_10min_slope_div_600_3', 'M10_raw_10min_slope_div_600_3_diff', 'M10_raw_10min_slope_signal_600_3', 'M10_raw_10min_slope_signal_600_3_diff', 'M10_raw_10min_slope_angle_600_3', 'M10_raw_10min_slope_angle_600_3_diff', 'M10_raw_10min_slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_600_3_diff', 'M10_raw_10min_slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_600_3_diff', 'M10_raw_10min_slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_600_3_diff', 'M10_raw_10min_slope_div_600_6', 'M10_raw_10min_slope_div_600_6_diff', 'M10_raw_10min_slope_signal_600_6', 'M10_raw_10min_slope_signal_600_6_diff', 'M10_raw_10min_slope_angle_600_6', 'M10_raw_10min_slope_angle_600_6_diff', 'M10_raw_10min_slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_6_diff', 'M10_raw_10min_slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_6_diff', 'M10_raw_10min_slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_6_diff', 'M10_raw_10min_slope_div_600_9', 'M10_raw_10min_slope_div_600_9_diff', 'M10_raw_10min_slope_signal_600_9', 'M10_raw_10min_slope_signal_600_9_diff', 'M10_raw_10min_slope_angle_600_9', 'M10_raw_10min_slope_angle_600_9_diff', 'M10_raw_10min_slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_9_diff', 'M10_raw_10min_slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_9_diff', 'M10_raw_10min_slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_9_diff', 'M10_raw_10min_slope_div_900_3', 'M10_raw_10min_slope_div_900_3_diff', 'M10_raw_10min_slope_signal_900_3', 'M10_raw_10min_slope_signal_900_3_diff', 'M10_raw_10min_slope_angle_900_3', 'M10_raw_10min_slope_angle_900_3_diff', 'M10_raw_10min_slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_900_3_diff', 'M10_raw_10min_slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_900_3_diff', 'M10_raw_10min_slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_900_3_diff', 'M10_raw_10min_slope_div_900_6', 'M10_raw_10min_slope_div_900_6_diff', 'M10_raw_10min_slope_signal_900_6', 'M10_raw_10min_slope_signal_900_6_diff', 'M10_raw_10min_slope_angle_900_6', 'M10_raw_10min_slope_angle_900_6_diff', 'M10_raw_10min_slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_6_diff', 'M10_raw_10min_slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_6_diff', 'M10_raw_10min_slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_6_diff', 'M10_raw_10min_slope_div_900_9', 'M10_raw_10min_slope_div_900_9_diff', 'M10_raw_10min_slope_signal_900_9', 'M10_raw_10min_slope_signal_900_9_diff', 'M10_raw_10min_slope_angle_900_9', 'M10_raw_10min_slope_angle_900_9_diff', 'M10_raw_10min_slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_9_diff', 'M10_raw_10min_slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_9_diff', 'M10_raw_10min_slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_9_diff', 'M10_raw_10min_slope_div_300_3 - slope_div_300_6', 'M10_raw_10min_slope_div_300_3 - slope_div_300_9', 'M10_raw_10min_slope_div_300_3 - slope_div_600_3', 'M10_raw_10min_slope_div_300_3 - slope_div_600_6', 'M10_raw_10min_slope_div_300_3 - slope_div_600_9', 'M10_raw_10min_slope_div_300_3 - slope_div_900_3', 'M10_raw_10min_slope_div_300_3 - slope_div_900_6', 'M10_raw_10min_slope_div_300_3 - slope_div_900_9', 'M10_raw_10min_slope_div_300_6 - slope_div_300_9', 'M10_raw_10min_slope_div_300_6 - slope_div_600_3', 'M10_raw_10min_slope_div_300_6 - slope_div_600_6', 'M10_raw_10min_slope_div_300_6 - slope_div_600_9', 'M10_raw_10min_slope_div_300_6 - slope_div_900_3', 'M10_raw_10min_slope_div_300_6 - slope_div_900_6', 'M10_raw_10min_slope_div_300_6 - slope_div_900_9', 'M10_raw_10min_slope_div_300_9 - slope_div_600_3', 'M10_raw_10min_slope_div_300_9 - slope_div_600_6', 'M10_raw_10min_slope_div_300_9 - slope_div_600_9', 'M10_raw_10min_slope_div_300_9 - slope_div_900_3', 'M10_raw_10min_slope_div_300_9 - slope_div_900_6', 'M10_raw_10min_slope_div_300_9 - slope_div_900_9', 'M10_raw_10min_slope_div_600_3 - slope_div_600_6', 'M10_raw_10min_slope_div_600_3 - slope_div_600_9', 'M10_raw_10min_slope_div_600_3 - slope_div_900_3', 'M10_raw_10min_slope_div_600_3 - slope_div_900_6', 'M10_raw_10min_slope_div_600_3 - slope_div_900_9', 'M10_raw_10min_slope_div_600_6 - slope_div_600_9', 'M10_raw_10min_slope_div_600_6 - slope_div_900_3', 'M10_raw_10min_slope_div_600_6 - slope_div_900_6', 'M10_raw_10min_slope_div_600_6 - slope_div_900_9', 'M10_raw_10min_slope_div_600_9 - slope_div_900_3', 'M10_raw_10min_slope_div_600_9 - slope_div_900_6', 'M10_raw_10min_slope_div_600_9 - slope_div_900_9', 'M10_raw_10min_slope_div_900_3 - slope_div_900_6', 'M10_raw_10min_slope_div_900_3 - slope_div_900_9', 'M10_raw_10min_slope_div_900_6 - slope_div_900_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_MACD_12_26_9', 'M10_scale_10min_MACD_12_26_9_diff', 'M10_scale_10min_MACD_signal_12_26_9', 'M10_scale_10min_MACD_signal_12_26_9_diff', 'M10_scale_10min_MACD_hist_12_26_9', 'M10_scale_10min_MACD_hist_12_26_9_diff', 'M10_scale_10min_RSI_basic_14', 'M10_scale_10min_RSI_basic_14_diff', 'M10_scale_10min_BB_upper_20', 'M10_scale_10min_BB_upper_20_diff', 'M10_scale_10min_BB_middle_20', 'M10_scale_10min_BB_middle_20_diff', 'M10_scale_10min_BB_lower_20', 'M10_scale_10min_BB_lower_20_diff', 'M10_scale_10min_ATR_14', 'M10_scale_10min_ATR_14_diff', 'M10_scale_10min_OBV_basic', 'M10_scale_10min_OBV_basic_diff', 'M10_scale_10min_VWAP_basic', 'M10_scale_10min_VWAP_basic_diff', 'M10_scale_10min_Momentum_10', 'M10_scale_10min_Momentum_10_diff', 'M10_scale_10min_ROC_10', 'M10_scale_10min_ROC_10_diff', 'M10_scale_10min_Stoch_K_14_3_3', 'M10_scale_10min_Stoch_K_14_3_3_diff', 'M10_scale_10min_Stoch_D_14_3_3', 'M10_scale_10min_Stoch_D_14_3_3_diff', 'M10_scale_10min_CCI_20', 'M10_scale_10min_CCI_20_diff', 'M10_scale_10min_MFI_basic_14', 'M10_scale_10min_MFI_basic_14_diff', 'M10_scale_10min_ADX_14', 'M10_scale_10min_ADX_14_diff', 'M10_scale_10min_WilliamsR_14', 'M10_scale_10min_WilliamsR_14_diff', 'M10_scale_10min_CMF', 'M10_scale_10min_CMF_diff', 'M10_scale_10min_TMF', 'M10_scale_10min_TMF_diff', 'M10_scale_10min_MFI_14_volume', 'M10_scale_10min_MFI_14_volume_diff', 'M10_scale_10min_KO', 'M10_scale_10min_KO_diff', 'M10_scale_10min_EFI', 'M10_scale_10min_EFI_diff', 'M10_scale_10min_EOM', 'M10_scale_10min_EOM_diff', 'M10_scale_10min_VPT', 'M10_scale_10min_VPT_diff', 'M10_scale_10min_NVI', 'M10_scale_10min_NVI_diff', 'M10_scale_10min_PVI', 'M10_scale_10min_PVI_diff', 'M10_scale_10min_VFI', 'M10_scale_10min_VFI_diff', 'M10_scale_10min_VWAP', 'M10_scale_10min_VWAP_diff', 'M10_scale_10min_Market_Facilitation_Index', 'M10_scale_10min_Market_Facilitation_Index_diff', 'M10_scale_10min_AD_Line', 'M10_scale_10min_AD_Line_diff', 'M10_scale_10min_WAD', 'M10_scale_10min_WAD_diff', 'M10_scale_10min_EMA_15', 'M10_scale_10min_EMA_15_diff', 'M10_scale_10min_Close_minus_EMA_15', 'M10_scale_10min_EMA_21', 'M10_scale_10min_EMA_21_diff', 'M10_scale_10min_Close_minus_EMA_21', 'M10_scale_10min_EMA_50', 'M10_scale_10min_EMA_50_diff', 'M10_scale_10min_Close_minus_EMA_50', 'M10_scale_10min_EMA_100', 'M10_scale_10min_EMA_100_diff', 'M10_scale_10min_Close_minus_EMA_100', 'M10_scale_10min_EMA_200', 'M10_scale_10min_EMA_200_diff', 'M10_scale_10min_Close_minus_EMA_200', 'M10_scale_10min_EMA_15_above_EMA_21', 'M10_scale_10min_EMA_15_above_EMA_50', 'M10_scale_10min_EMA_15_above_EMA_100', 'M10_scale_10min_EMA_15_above_EMA_200', 'M10_scale_10min_EMA_21_above_EMA_50', 'M10_scale_10min_EMA_21_above_EMA_100', 'M10_scale_10min_EMA_21_above_EMA_200', 'M10_scale_10min_EMA_50_above_EMA_100', 'M10_scale_10min_EMA_50_above_EMA_200', 'M10_scale_10min_EMA_100_above_EMA_200', 'M10_scale_10min_OBV', 'M10_scale_10min_RSI_3', 'M10_scale_10min_MFI_3', 'M10_scale_10min_RSI_7', 'M10_scale_10min_MFI_7', 'M10_scale_10min_RSI_14', 'M10_scale_10min_MFI_14', 'M10_scale_10min_RSI_3_diff', 'M10_scale_10min_RSI_7_diff', 'M10_scale_10min_RSI_14_diff', 'M10_scale_10min_RSI_3 - RSI_7', 'M10_scale_10min_RSI_3 - RSI_14', 'M10_scale_10min_RSI_7 - RSI_14', 'M10_scale_10min_MFI_3_diff', 'M10_scale_10min_MFI_7_diff', 'M10_scale_10min_MFI_14_diff', 'M10_scale_10min_MFI_3 - MFI_7', 'M10_scale_10min_MFI_3 - MFI_14', 'M10_scale_10min_MFI_7 - MFI_14', 'M10_scale_10min_OBV_diff', 'M10_scale_10min_Kal_300', 'M10_scale_10min_Close_Kal_300', 'M10_scale_10min_Kal_change_300', 'M10_scale_10min_Kal_prev_minus_now_300', 'M10_scale_10min_Kal_prev2_minus_now_300', 'M10_scale_10min_Kal_change2_300', 'M10_scale_10min_Kal_600', 'M10_scale_10min_Close_Kal_600', 'M10_scale_10min_Kal_change_600', 'M10_scale_10min_Kal_prev_minus_now_600', 'M10_scale_10min_Kal_prev2_minus_now_600', 'M10_scale_10min_Kal_change2_600', 'M10_scale_10min_Kal_900', 'M10_scale_10min_Close_Kal_900', 'M10_scale_10min_Kal_change_900', 'M10_scale_10min_Kal_prev_minus_now_900', 'M10_scale_10min_Kal_prev2_minus_now_900', 'M10_scale_10min_Kal_change2_900', 'M10_scale_10min_Kal_300_minus_Kal_600', 'M10_scale_10min_Kal_300_minus_Kal_900', 'M10_scale_10min_Kal_600_minus_Kal_900', 'M10_scale_10min_slope_div_300_3', 'M10_scale_10min_slope_div_300_3_diff', 'M10_scale_10min_slope_signal_300_3', 'M10_scale_10min_slope_signal_300_3_diff', 'M10_scale_10min_slope_angle_300_3', 'M10_scale_10min_slope_angle_300_3_diff', 'M10_scale_10min_slope_angle_signal_300_3', 'M10_scale_10min_slope_angle_signal_300_3_diff', 'M10_scale_10min_slope_lin_reg_300_3', 'M10_scale_10min_slope_lin_reg_300_3_diff', 'M10_scale_10min_slope_lin_reg_signal_300_3', 'M10_scale_10min_slope_lin_reg_signal_300_3_diff', 'M10_scale_10min_slope_div_300_6', 'M10_scale_10min_slope_div_300_6_diff', 'M10_scale_10min_slope_signal_300_6', 'M10_scale_10min_slope_signal_300_6_diff', 'M10_scale_10min_slope_angle_300_6', 'M10_scale_10min_slope_angle_300_6_diff', 'M10_scale_10min_slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_6_diff', 'M10_scale_10min_slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_6_diff', 'M10_scale_10min_slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_6_diff', 'M10_scale_10min_slope_div_300_9', 'M10_scale_10min_slope_div_300_9_diff', 'M10_scale_10min_slope_signal_300_9', 'M10_scale_10min_slope_signal_300_9_diff', 'M10_scale_10min_slope_angle_300_9', 'M10_scale_10min_slope_angle_300_9_diff', 'M10_scale_10min_slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_9_diff', 'M10_scale_10min_slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_9_diff', 'M10_scale_10min_slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_9_diff', 'M10_scale_10min_slope_div_600_3', 'M10_scale_10min_slope_div_600_3_diff', 'M10_scale_10min_slope_signal_600_3', 'M10_scale_10min_slope_signal_600_3_diff', 'M10_scale_10min_slope_angle_600_3', 'M10_scale_10min_slope_angle_600_3_diff', 'M10_scale_10min_slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_600_3_diff', 'M10_scale_10min_slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_600_3_diff', 'M10_scale_10min_slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_600_3_diff', 'M10_scale_10min_slope_div_600_6', 'M10_scale_10min_slope_div_600_6_diff', 'M10_scale_10min_slope_signal_600_6', 'M10_scale_10min_slope_signal_600_6_diff', 'M10_scale_10min_slope_angle_600_6', 'M10_scale_10min_slope_angle_600_6_diff', 'M10_scale_10min_slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_6_diff', 'M10_scale_10min_slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_6_diff', 'M10_scale_10min_slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_6_diff', 'M10_scale_10min_slope_div_600_9', 'M10_scale_10min_slope_div_600_9_diff', 'M10_scale_10min_slope_signal_600_9', 'M10_scale_10min_slope_signal_600_9_diff', 'M10_scale_10min_slope_angle_600_9', 'M10_scale_10min_slope_angle_600_9_diff', 'M10_scale_10min_slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_9_diff', 'M10_scale_10min_slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_9_diff', 'M10_scale_10min_slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_9_diff', 'M10_scale_10min_slope_div_900_3', 'M10_scale_10min_slope_div_900_3_diff', 'M10_scale_10min_slope_signal_900_3', 'M10_scale_10min_slope_signal_900_3_diff', 'M10_scale_10min_slope_angle_900_3', 'M10_scale_10min_slope_angle_900_3_diff', 'M10_scale_10min_slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_900_3_diff', 'M10_scale_10min_slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_900_3_diff', 'M10_scale_10min_slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_900_3_diff', 'M10_scale_10min_slope_div_900_6', 'M10_scale_10min_slope_div_900_6_diff', 'M10_scale_10min_slope_signal_900_6', 'M10_scale_10min_slope_signal_900_6_diff', 'M10_scale_10min_slope_angle_900_6', 'M10_scale_10min_slope_angle_900_6_diff', 'M10_scale_10min_slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_6_diff', 'M10_scale_10min_slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_6_diff', 'M10_scale_10min_slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_6_diff', 'M10_scale_10min_slope_div_900_9', 'M10_scale_10min_slope_div_900_9_diff', 'M10_scale_10min_slope_signal_900_9', 'M10_scale_10min_slope_signal_900_9_diff', 'M10_scale_10min_slope_angle_900_9', 'M10_scale_10min_slope_angle_900_9_diff', 'M10_scale_10min_slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_9_diff', 'M10_scale_10min_slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_9_diff', 'M10_scale_10min_slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_9_diff', 'M10_scale_10min_slope_div_300_3 - slope_div_300_6', 'M10_scale_10min_slope_div_300_3 - slope_div_300_9', 'M10_scale_10min_slope_div_300_3 - slope_div_600_3', 'M10_scale_10min_slope_div_300_3 - slope_div_600_6', 'M10_scale_10min_slope_div_300_3 - slope_div_600_9', 'M10_scale_10min_slope_div_300_3 - slope_div_900_3', 'M10_scale_10min_slope_div_300_3 - slope_div_900_6', 'M10_scale_10min_slope_div_300_3 - slope_div_900_9', 'M10_scale_10min_slope_div_300_6 - slope_div_300_9', 'M10_scale_10min_slope_div_300_6 - slope_div_600_3', 'M10_scale_10min_slope_div_300_6 - slope_div_600_6', 'M10_scale_10min_slope_div_300_6 - slope_div_600_9', 'M10_scale_10min_slope_div_300_6 - slope_div_900_3', 'M10_scale_10min_slope_div_300_6 - slope_div_900_6', 'M10_scale_10min_slope_div_300_6 - slope_div_900_9', 'M10_scale_10min_slope_div_300_9 - slope_div_600_3', 'M10_scale_10min_slope_div_300_9 - slope_div_600_6', 'M10_scale_10min_slope_div_300_9 - slope_div_600_9', 'M10_scale_10min_slope_div_300_9 - slope_div_900_3', 'M10_scale_10min_slope_div_300_9 - slope_div_900_6', 'M10_scale_10min_slope_div_300_9 - slope_div_900_9', 'M10_scale_10min_slope_div_600_3 - slope_div_600_6', 'M10_scale_10min_slope_div_600_3 - slope_div_600_9', 'M10_scale_10min_slope_div_600_3 - slope_div_900_3', 'M10_scale_10min_slope_div_600_3 - slope_div_900_6', 'M10_scale_10min_slope_div_600_3 - slope_div_900_9', 'M10_scale_10min_slope_div_600_6 - slope_div_600_9', 'M10_scale_10min_slope_div_600_6 - slope_div_900_3', 'M10_scale_10min_slope_div_600_6 - slope_div_900_6', 'M10_scale_10min_slope_div_600_6 - slope_div_900_9', 'M10_scale_10min_slope_div_600_9 - slope_div_900_3', 'M10_scale_10min_slope_div_600_9 - slope_div_900_6', 'M10_scale_10min_slope_div_600_9 - slope_div_900_9', 'M10_scale_10min_slope_div_900_3 - slope_div_900_6', 'M10_scale_10min_slope_div_900_3 - slope_div_900_9', 'M10_scale_10min_slope_div_900_6 - slope_div_900_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_MACD_12_26_9', 'M15_raw_15min_MACD_12_26_9_diff', 'M15_raw_15min_MACD_signal_12_26_9', 'M15_raw_15min_MACD_signal_12_26_9_diff', 'M15_raw_15min_MACD_hist_12_26_9', 'M15_raw_15min_MACD_hist_12_26_9_diff', 'M15_raw_15min_RSI_basic_14', 'M15_raw_15min_RSI_basic_14_diff', 'M15_raw_15min_BB_upper_20', 'M15_raw_15min_BB_upper_20_diff', 'M15_raw_15min_BB_middle_20', 'M15_raw_15min_BB_middle_20_diff', 'M15_raw_15min_BB_lower_20', 'M15_raw_15min_BB_lower_20_diff', 'M15_raw_15min_ATR_14', 'M15_raw_15min_ATR_14_diff', 'M15_raw_15min_OBV_basic', 'M15_raw_15min_OBV_basic_diff', 'M15_raw_15min_VWAP_basic', 'M15_raw_15min_VWAP_basic_diff', 'M15_raw_15min_Momentum_10', 'M15_raw_15min_Momentum_10_diff', 'M15_raw_15min_ROC_10', 'M15_raw_15min_ROC_10_diff', 'M15_raw_15min_Stoch_K_14_3_3', 'M15_raw_15min_Stoch_K_14_3_3_diff', 'M15_raw_15min_Stoch_D_14_3_3', 'M15_raw_15min_Stoch_D_14_3_3_diff', 'M15_raw_15min_CCI_20', 'M15_raw_15min_CCI_20_diff', 'M15_raw_15min_MFI_basic_14', 'M15_raw_15min_MFI_basic_14_diff', 'M15_raw_15min_ADX_14', 'M15_raw_15min_ADX_14_diff', 'M15_raw_15min_WilliamsR_14', 'M15_raw_15min_WilliamsR_14_diff', 'M15_raw_15min_CMF', 'M15_raw_15min_CMF_diff', 'M15_raw_15min_TMF', 'M15_raw_15min_TMF_diff', 'M15_raw_15min_MFI_14_volume', 'M15_raw_15min_MFI_14_volume_diff', 'M15_raw_15min_KO', 'M15_raw_15min_KO_diff', 'M15_raw_15min_EFI', 'M15_raw_15min_EFI_diff', 'M15_raw_15min_EOM', 'M15_raw_15min_EOM_diff', 'M15_raw_15min_VPT', 'M15_raw_15min_VPT_diff', 'M15_raw_15min_NVI', 'M15_raw_15min_NVI_diff', 'M15_raw_15min_PVI', 'M15_raw_15min_PVI_diff', 'M15_raw_15min_VFI', 'M15_raw_15min_VFI_diff', 'M15_raw_15min_VWAP', 'M15_raw_15min_VWAP_diff', 'M15_raw_15min_Market_Facilitation_Index', 'M15_raw_15min_Market_Facilitation_Index_diff', 'M15_raw_15min_AD_Line', 'M15_raw_15min_AD_Line_diff', 'M15_raw_15min_WAD', 'M15_raw_15min_WAD_diff', 'M15_raw_15min_EMA_15', 'M15_raw_15min_EMA_15_diff', 'M15_raw_15min_Close_minus_EMA_15', 'M15_raw_15min_EMA_21', 'M15_raw_15min_EMA_21_diff', 'M15_raw_15min_Close_minus_EMA_21', 'M15_raw_15min_EMA_50', 'M15_raw_15min_EMA_50_diff', 'M15_raw_15min_Close_minus_EMA_50', 'M15_raw_15min_EMA_100', 'M15_raw_15min_EMA_100_diff', 'M15_raw_15min_Close_minus_EMA_100', 'M15_raw_15min_EMA_200', 'M15_raw_15min_EMA_200_diff', 'M15_raw_15min_Close_minus_EMA_200', 'M15_raw_15min_EMA_15_above_EMA_21', 'M15_raw_15min_EMA_15_above_EMA_50', 'M15_raw_15min_EMA_15_above_EMA_100', 'M15_raw_15min_EMA_15_above_EMA_200', 'M15_raw_15min_EMA_21_above_EMA_50', 'M15_raw_15min_EMA_21_above_EMA_100', 'M15_raw_15min_EMA_21_above_EMA_200', 'M15_raw_15min_EMA_50_above_EMA_100', 'M15_raw_15min_EMA_50_above_EMA_200', 'M15_raw_15min_EMA_100_above_EMA_200', 'M15_raw_15min_OBV', 'M15_raw_15min_RSI_3', 'M15_raw_15min_MFI_3', 'M15_raw_15min_RSI_7', 'M15_raw_15min_MFI_7', 'M15_raw_15min_RSI_14', 'M15_raw_15min_MFI_14', 'M15_raw_15min_RSI_3_diff', 'M15_raw_15min_RSI_7_diff', 'M15_raw_15min_RSI_14_diff', 'M15_raw_15min_RSI_3 - RSI_7', 'M15_raw_15min_RSI_3 - RSI_14', 'M15_raw_15min_RSI_7 - RSI_14', 'M15_raw_15min_MFI_3_diff', 'M15_raw_15min_MFI_7_diff', 'M15_raw_15min_MFI_14_diff', 'M15_raw_15min_MFI_3 - MFI_7', 'M15_raw_15min_MFI_3 - MFI_14', 'M15_raw_15min_MFI_7 - MFI_14', 'M15_raw_15min_OBV_diff', 'M15_raw_15min_Kal_300', 'M15_raw_15min_Close_Kal_300', 'M15_raw_15min_Kal_change_300', 'M15_raw_15min_Kal_prev_minus_now_300', 'M15_raw_15min_Kal_prev2_minus_now_300', 'M15_raw_15min_Kal_change2_300', 'M15_raw_15min_Kal_600', 'M15_raw_15min_Close_Kal_600', 'M15_raw_15min_Kal_change_600', 'M15_raw_15min_Kal_prev_minus_now_600', 'M15_raw_15min_Kal_prev2_minus_now_600', 'M15_raw_15min_Kal_change2_600', 'M15_raw_15min_Kal_900', 'M15_raw_15min_Close_Kal_900', 'M15_raw_15min_Kal_change_900', 'M15_raw_15min_Kal_prev_minus_now_900', 'M15_raw_15min_Kal_prev2_minus_now_900', 'M15_raw_15min_Kal_change2_900', 'M15_raw_15min_Kal_300_minus_Kal_600', 'M15_raw_15min_Kal_300_minus_Kal_900', 'M15_raw_15min_Kal_600_minus_Kal_900', 'M15_raw_15min_slope_div_300_3', 'M15_raw_15min_slope_div_300_3_diff', 'M15_raw_15min_slope_signal_300_3', 'M15_raw_15min_slope_signal_300_3_diff', 'M15_raw_15min_slope_angle_300_3', 'M15_raw_15min_slope_angle_300_3_diff', 'M15_raw_15min_slope_angle_signal_300_3', 'M15_raw_15min_slope_angle_signal_300_3_diff', 'M15_raw_15min_slope_lin_reg_300_3', 'M15_raw_15min_slope_lin_reg_300_3_diff', 'M15_raw_15min_slope_lin_reg_signal_300_3', 'M15_raw_15min_slope_lin_reg_signal_300_3_diff', 'M15_raw_15min_slope_div_300_6', 'M15_raw_15min_slope_div_300_6_diff', 'M15_raw_15min_slope_signal_300_6', 'M15_raw_15min_slope_signal_300_6_diff', 'M15_raw_15min_slope_angle_300_6', 'M15_raw_15min_slope_angle_300_6_diff', 'M15_raw_15min_slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_6_diff', 'M15_raw_15min_slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_6_diff', 'M15_raw_15min_slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_6_diff', 'M15_raw_15min_slope_div_300_9', 'M15_raw_15min_slope_div_300_9_diff', 'M15_raw_15min_slope_signal_300_9', 'M15_raw_15min_slope_signal_300_9_diff', 'M15_raw_15min_slope_angle_300_9', 'M15_raw_15min_slope_angle_300_9_diff', 'M15_raw_15min_slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_9_diff', 'M15_raw_15min_slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_9_diff', 'M15_raw_15min_slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_9_diff', 'M15_raw_15min_slope_div_600_3', 'M15_raw_15min_slope_div_600_3_diff', 'M15_raw_15min_slope_signal_600_3', 'M15_raw_15min_slope_signal_600_3_diff', 'M15_raw_15min_slope_angle_600_3', 'M15_raw_15min_slope_angle_600_3_diff', 'M15_raw_15min_slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_600_3_diff', 'M15_raw_15min_slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_600_3_diff', 'M15_raw_15min_slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_600_3_diff', 'M15_raw_15min_slope_div_600_6', 'M15_raw_15min_slope_div_600_6_diff', 'M15_raw_15min_slope_signal_600_6', 'M15_raw_15min_slope_signal_600_6_diff', 'M15_raw_15min_slope_angle_600_6', 'M15_raw_15min_slope_angle_600_6_diff', 'M15_raw_15min_slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_6_diff', 'M15_raw_15min_slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_6_diff', 'M15_raw_15min_slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_6_diff', 'M15_raw_15min_slope_div_600_9', 'M15_raw_15min_slope_div_600_9_diff', 'M15_raw_15min_slope_signal_600_9', 'M15_raw_15min_slope_signal_600_9_diff', 'M15_raw_15min_slope_angle_600_9', 'M15_raw_15min_slope_angle_600_9_diff', 'M15_raw_15min_slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_9_diff', 'M15_raw_15min_slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_9_diff', 'M15_raw_15min_slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_9_diff', 'M15_raw_15min_slope_div_900_3', 'M15_raw_15min_slope_div_900_3_diff', 'M15_raw_15min_slope_signal_900_3', 'M15_raw_15min_slope_signal_900_3_diff', 'M15_raw_15min_slope_angle_900_3', 'M15_raw_15min_slope_angle_900_3_diff', 'M15_raw_15min_slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_900_3_diff', 'M15_raw_15min_slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_900_3_diff', 'M15_raw_15min_slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_900_3_diff', 'M15_raw_15min_slope_div_900_6', 'M15_raw_15min_slope_div_900_6_diff', 'M15_raw_15min_slope_signal_900_6', 'M15_raw_15min_slope_signal_900_6_diff', 'M15_raw_15min_slope_angle_900_6', 'M15_raw_15min_slope_angle_900_6_diff', 'M15_raw_15min_slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_6_diff', 'M15_raw_15min_slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_6_diff', 'M15_raw_15min_slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_6_diff', 'M15_raw_15min_slope_div_900_9', 'M15_raw_15min_slope_div_900_9_diff', 'M15_raw_15min_slope_signal_900_9', 'M15_raw_15min_slope_signal_900_9_diff', 'M15_raw_15min_slope_angle_900_9', 'M15_raw_15min_slope_angle_900_9_diff', 'M15_raw_15min_slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_9_diff', 'M15_raw_15min_slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_9_diff', 'M15_raw_15min_slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_9_diff', 'M15_raw_15min_slope_div_300_3 - slope_div_300_6', 'M15_raw_15min_slope_div_300_3 - slope_div_300_9', 'M15_raw_15min_slope_div_300_3 - slope_div_600_3', 'M15_raw_15min_slope_div_300_3 - slope_div_600_6', 'M15_raw_15min_slope_div_300_3 - slope_div_600_9', 'M15_raw_15min_slope_div_300_3 - slope_div_900_3', 'M15_raw_15min_slope_div_300_3 - slope_div_900_6', 'M15_raw_15min_slope_div_300_3 - slope_div_900_9', 'M15_raw_15min_slope_div_300_6 - slope_div_300_9', 'M15_raw_15min_slope_div_300_6 - slope_div_600_3', 'M15_raw_15min_slope_div_300_6 - slope_div_600_6', 'M15_raw_15min_slope_div_300_6 - slope_div_600_9', 'M15_raw_15min_slope_div_300_6 - slope_div_900_3', 'M15_raw_15min_slope_div_300_6 - slope_div_900_6', 'M15_raw_15min_slope_div_300_6 - slope_div_900_9', 'M15_raw_15min_slope_div_300_9 - slope_div_600_3', 'M15_raw_15min_slope_div_300_9 - slope_div_600_6', 'M15_raw_15min_slope_div_300_9 - slope_div_600_9', 'M15_raw_15min_slope_div_300_9 - slope_div_900_3', 'M15_raw_15min_slope_div_300_9 - slope_div_900_6', 'M15_raw_15min_slope_div_300_9 - slope_div_900_9', 'M15_raw_15min_slope_div_600_3 - slope_div_600_6', 'M15_raw_15min_slope_div_600_3 - slope_div_600_9', 'M15_raw_15min_slope_div_600_3 - slope_div_900_3', 'M15_raw_15min_slope_div_600_3 - slope_div_900_6', 'M15_raw_15min_slope_div_600_3 - slope_div_900_9', 'M15_raw_15min_slope_div_600_6 - slope_div_600_9', 'M15_raw_15min_slope_div_600_6 - slope_div_900_3', 'M15_raw_15min_slope_div_600_6 - slope_div_900_6', 'M15_raw_15min_slope_div_600_6 - slope_div_900_9', 'M15_raw_15min_slope_div_600_9 - slope_div_900_3', 'M15_raw_15min_slope_div_600_9 - slope_div_900_6', 'M15_raw_15min_slope_div_600_9 - slope_div_900_9', 'M15_raw_15min_slope_div_900_3 - slope_div_900_6', 'M15_raw_15min_slope_div_900_3 - slope_div_900_9', 'M15_raw_15min_slope_div_900_6 - slope_div_900_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_MACD_12_26_9', 'M15_scale_15min_MACD_12_26_9_diff', 'M15_scale_15min_MACD_signal_12_26_9', 'M15_scale_15min_MACD_signal_12_26_9_diff', 'M15_scale_15min_MACD_hist_12_26_9', 'M15_scale_15min_MACD_hist_12_26_9_diff', 'M15_scale_15min_RSI_basic_14', 'M15_scale_15min_RSI_basic_14_diff', 'M15_scale_15min_BB_upper_20', 'M15_scale_15min_BB_upper_20_diff', 'M15_scale_15min_BB_middle_20', 'M15_scale_15min_BB_middle_20_diff', 'M15_scale_15min_BB_lower_20', 'M15_scale_15min_BB_lower_20_diff', 'M15_scale_15min_ATR_14', 'M15_scale_15min_ATR_14_diff', 'M15_scale_15min_OBV_basic', 'M15_scale_15min_OBV_basic_diff', 'M15_scale_15min_VWAP_basic', 'M15_scale_15min_VWAP_basic_diff', 'M15_scale_15min_Momentum_10', 'M15_scale_15min_Momentum_10_diff', 'M15_scale_15min_ROC_10', 'M15_scale_15min_ROC_10_diff', 'M15_scale_15min_Stoch_K_14_3_3', 'M15_scale_15min_Stoch_K_14_3_3_diff', 'M15_scale_15min_Stoch_D_14_3_3', 'M15_scale_15min_Stoch_D_14_3_3_diff', 'M15_scale_15min_CCI_20', 'M15_scale_15min_CCI_20_diff', 'M15_scale_15min_MFI_basic_14', 'M15_scale_15min_MFI_basic_14_diff', 'M15_scale_15min_ADX_14', 'M15_scale_15min_ADX_14_diff', 'M15_scale_15min_WilliamsR_14', 'M15_scale_15min_WilliamsR_14_diff', 'M15_scale_15min_CMF', 'M15_scale_15min_CMF_diff', 'M15_scale_15min_TMF', 'M15_scale_15min_TMF_diff', 'M15_scale_15min_MFI_14_volume', 'M15_scale_15min_MFI_14_volume_diff', 'M15_scale_15min_KO', 'M15_scale_15min_KO_diff', 'M15_scale_15min_EFI', 'M15_scale_15min_EFI_diff', 'M15_scale_15min_EOM', 'M15_scale_15min_EOM_diff', 'M15_scale_15min_VPT', 'M15_scale_15min_VPT_diff', 'M15_scale_15min_NVI', 'M15_scale_15min_NVI_diff', 'M15_scale_15min_PVI', 'M15_scale_15min_PVI_diff', 'M15_scale_15min_VFI', 'M15_scale_15min_VFI_diff', 'M15_scale_15min_VWAP', 'M15_scale_15min_VWAP_diff', 'M15_scale_15min_Market_Facilitation_Index', 'M15_scale_15min_Market_Facilitation_Index_diff', 'M15_scale_15min_AD_Line', 'M15_scale_15min_AD_Line_diff', 'M15_scale_15min_WAD', 'M15_scale_15min_WAD_diff', 'M15_scale_15min_EMA_15', 'M15_scale_15min_EMA_15_diff', 'M15_scale_15min_Close_minus_EMA_15', 'M15_scale_15min_EMA_21', 'M15_scale_15min_EMA_21_diff', 'M15_scale_15min_Close_minus_EMA_21', 'M15_scale_15min_EMA_50', 'M15_scale_15min_EMA_50_diff', 'M15_scale_15min_Close_minus_EMA_50', 'M15_scale_15min_EMA_100', 'M15_scale_15min_EMA_100_diff', 'M15_scale_15min_Close_minus_EMA_100', 'M15_scale_15min_EMA_200', 'M15_scale_15min_EMA_200_diff', 'M15_scale_15min_Close_minus_EMA_200', 'M15_scale_15min_EMA_15_above_EMA_21', 'M15_scale_15min_EMA_15_above_EMA_50', 'M15_scale_15min_EMA_15_above_EMA_100', 'M15_scale_15min_EMA_15_above_EMA_200', 'M15_scale_15min_EMA_21_above_EMA_50', 'M15_scale_15min_EMA_21_above_EMA_100', 'M15_scale_15min_EMA_21_above_EMA_200', 'M15_scale_15min_EMA_50_above_EMA_100', 'M15_scale_15min_EMA_50_above_EMA_200', 'M15_scale_15min_EMA_100_above_EMA_200', 'M15_scale_15min_OBV', 'M15_scale_15min_RSI_3', 'M15_scale_15min_MFI_3', 'M15_scale_15min_RSI_7', 'M15_scale_15min_MFI_7', 'M15_scale_15min_RSI_14', 'M15_scale_15min_MFI_14', 'M15_scale_15min_RSI_3_diff', 'M15_scale_15min_RSI_7_diff', 'M15_scale_15min_RSI_14_diff', 'M15_scale_15min_RSI_3 - RSI_7', 'M15_scale_15min_RSI_3 - RSI_14', 'M15_scale_15min_RSI_7 - RSI_14', 'M15_scale_15min_MFI_3_diff', 'M15_scale_15min_MFI_7_diff', 'M15_scale_15min_MFI_14_diff', 'M15_scale_15min_MFI_3 - MFI_7', 'M15_scale_15min_MFI_3 - MFI_14', 'M15_scale_15min_MFI_7 - MFI_14', 'M15_scale_15min_OBV_diff', 'M15_scale_15min_Kal_300', 'M15_scale_15min_Close_Kal_300', 'M15_scale_15min_Kal_change_300', 'M15_scale_15min_Kal_prev_minus_now_300', 'M15_scale_15min_Kal_prev2_minus_now_300', 'M15_scale_15min_Kal_change2_300', 'M15_scale_15min_Kal_600', 'M15_scale_15min_Close_Kal_600', 'M15_scale_15min_Kal_change_600', 'M15_scale_15min_Kal_prev_minus_now_600', 'M15_scale_15min_Kal_prev2_minus_now_600', 'M15_scale_15min_Kal_change2_600', 'M15_scale_15min_Kal_900', 'M15_scale_15min_Close_Kal_900', 'M15_scale_15min_Kal_change_900', 'M15_scale_15min_Kal_prev_minus_now_900', 'M15_scale_15min_Kal_prev2_minus_now_900', 'M15_scale_15min_Kal_change2_900', 'M15_scale_15min_Kal_300_minus_Kal_600', 'M15_scale_15min_Kal_300_minus_Kal_900', 'M15_scale_15min_Kal_600_minus_Kal_900', 'M15_scale_15min_slope_div_300_3', 'M15_scale_15min_slope_div_300_3_diff', 'M15_scale_15min_slope_signal_300_3', 'M15_scale_15min_slope_signal_300_3_diff', 'M15_scale_15min_slope_angle_300_3', 'M15_scale_15min_slope_angle_300_3_diff', 'M15_scale_15min_slope_angle_signal_300_3', 'M15_scale_15min_slope_angle_signal_300_3_diff', 'M15_scale_15min_slope_lin_reg_300_3', 'M15_scale_15min_slope_lin_reg_300_3_diff', 'M15_scale_15min_slope_lin_reg_signal_300_3', 'M15_scale_15min_slope_lin_reg_signal_300_3_diff', 'M15_scale_15min_slope_div_300_6', 'M15_scale_15min_slope_div_300_6_diff', 'M15_scale_15min_slope_signal_300_6', 'M15_scale_15min_slope_signal_300_6_diff', 'M15_scale_15min_slope_angle_300_6', 'M15_scale_15min_slope_angle_300_6_diff', 'M15_scale_15min_slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_6_diff', 'M15_scale_15min_slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_6_diff', 'M15_scale_15min_slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_6_diff', 'M15_scale_15min_slope_div_300_9', 'M15_scale_15min_slope_div_300_9_diff', 'M15_scale_15min_slope_signal_300_9', 'M15_scale_15min_slope_signal_300_9_diff', 'M15_scale_15min_slope_angle_300_9', 'M15_scale_15min_slope_angle_300_9_diff', 'M15_scale_15min_slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_9_diff', 'M15_scale_15min_slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_9_diff', 'M15_scale_15min_slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_9_diff', 'M15_scale_15min_slope_div_600_3', 'M15_scale_15min_slope_div_600_3_diff', 'M15_scale_15min_slope_signal_600_3', 'M15_scale_15min_slope_signal_600_3_diff', 'M15_scale_15min_slope_angle_600_3', 'M15_scale_15min_slope_angle_600_3_diff', 'M15_scale_15min_slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_600_3_diff', 'M15_scale_15min_slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_600_3_diff', 'M15_scale_15min_slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_600_3_diff', 'M15_scale_15min_slope_div_600_6', 'M15_scale_15min_slope_div_600_6_diff', 'M15_scale_15min_slope_signal_600_6', 'M15_scale_15min_slope_signal_600_6_diff', 'M15_scale_15min_slope_angle_600_6', 'M15_scale_15min_slope_angle_600_6_diff', 'M15_scale_15min_slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_6_diff', 'M15_scale_15min_slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_6_diff', 'M15_scale_15min_slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_6_diff', 'M15_scale_15min_slope_div_600_9', 'M15_scale_15min_slope_div_600_9_diff', 'M15_scale_15min_slope_signal_600_9', 'M15_scale_15min_slope_signal_600_9_diff', 'M15_scale_15min_slope_angle_600_9', 'M15_scale_15min_slope_angle_600_9_diff', 'M15_scale_15min_slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_9_diff', 'M15_scale_15min_slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_9_diff', 'M15_scale_15min_slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_9_diff', 'M15_scale_15min_slope_div_900_3', 'M15_scale_15min_slope_div_900_3_diff', 'M15_scale_15min_slope_signal_900_3', 'M15_scale_15min_slope_signal_900_3_diff', 'M15_scale_15min_slope_angle_900_3', 'M15_scale_15min_slope_angle_900_3_diff', 'M15_scale_15min_slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_900_3_diff', 'M15_scale_15min_slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_900_3_diff', 'M15_scale_15min_slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_900_3_diff', 'M15_scale_15min_slope_div_900_6', 'M15_scale_15min_slope_div_900_6_diff', 'M15_scale_15min_slope_signal_900_6', 'M15_scale_15min_slope_signal_900_6_diff', 'M15_scale_15min_slope_angle_900_6', 'M15_scale_15min_slope_angle_900_6_diff', 'M15_scale_15min_slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_6_diff', 'M15_scale_15min_slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_6_diff', 'M15_scale_15min_slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_6_diff', 'M15_scale_15min_slope_div_900_9', 'M15_scale_15min_slope_div_900_9_diff', 'M15_scale_15min_slope_signal_900_9', 'M15_scale_15min_slope_signal_900_9_diff', 'M15_scale_15min_slope_angle_900_9', 'M15_scale_15min_slope_angle_900_9_diff', 'M15_scale_15min_slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_9_diff', 'M15_scale_15min_slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_9_diff', 'M15_scale_15min_slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_9_diff', 'M15_scale_15min_slope_div_300_3 - slope_div_300_6', 'M15_scale_15min_slope_div_300_3 - slope_div_300_9', 'M15_scale_15min_slope_div_300_3 - slope_div_600_3', 'M15_scale_15min_slope_div_300_3 - slope_div_600_6', 'M15_scale_15min_slope_div_300_3 - slope_div_600_9', 'M15_scale_15min_slope_div_300_3 - slope_div_900_3', 'M15_scale_15min_slope_div_300_3 - slope_div_900_6', 'M15_scale_15min_slope_div_300_3 - slope_div_900_9', 'M15_scale_15min_slope_div_300_6 - slope_div_300_9', 'M15_scale_15min_slope_div_300_6 - slope_div_600_3', 'M15_scale_15min_slope_div_300_6 - slope_div_600_6', 'M15_scale_15min_slope_div_300_6 - slope_div_600_9', 'M15_scale_15min_slope_div_300_6 - slope_div_900_3', 'M15_scale_15min_slope_div_300_6 - slope_div_900_6', 'M15_scale_15min_slope_div_300_6 - slope_div_900_9', 'M15_scale_15min_slope_div_300_9 - slope_div_600_3', 'M15_scale_15min_slope_div_300_9 - slope_div_600_6', 'M15_scale_15min_slope_div_300_9 - slope_div_600_9', 'M15_scale_15min_slope_div_300_9 - slope_div_900_3', 'M15_scale_15min_slope_div_300_9 - slope_div_900_6', 'M15_scale_15min_slope_div_300_9 - slope_div_900_9', 'M15_scale_15min_slope_div_600_3 - slope_div_600_6', 'M15_scale_15min_slope_div_600_3 - slope_div_600_9', 'M15_scale_15min_slope_div_600_3 - slope_div_900_3', 'M15_scale_15min_slope_div_600_3 - slope_div_900_6', 'M15_scale_15min_slope_div_600_3 - slope_div_900_9', 'M15_scale_15min_slope_div_600_6 - slope_div_600_9', 'M15_scale_15min_slope_div_600_6 - slope_div_900_3', 'M15_scale_15min_slope_div_600_6 - slope_div_900_6', 'M15_scale_15min_slope_div_600_6 - slope_div_900_9', 'M15_scale_15min_slope_div_600_9 - slope_div_900_3', 'M15_scale_15min_slope_div_600_9 - slope_div_900_6', 'M15_scale_15min_slope_div_600_9 - slope_div_900_9', 'M15_scale_15min_slope_div_900_3 - slope_div_900_6', 'M15_scale_15min_slope_div_900_3 - slope_div_900_9', 'M15_scale_15min_slope_div_900_6 - slope_div_900_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
-            "\n",
-            "NaN counts per column (sorted):\n",
-            "M10_scale_10min_EMA_100_above_EMA_200                                      104\n",
-            "M15_scale_15min_EMA_100_above_EMA_200                                      104\n",
-            "M10_scale_10min_EMA_50_above_EMA_200                                        95\n",
-            "M15_scale_15min_EMA_50_above_EMA_200                                        95\n",
-            "M5_scale_slope_angle_signal_300_6                                           49\n",
-            "                                                                          ... \n",
-            "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6      0\n",
-            "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3      0\n",
-            "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9      0\n",
-            "Open_Trade                                                                   0\n",
-            "label                                                                        0\n",
-            "Length: 2727, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(df.shape,'\\n')\n",
-        "print('Label_Counts : ',df.label.value_counts(),'\\n')\n",
-        "print(list(df.columns), '\\n')\n",
-        "\n",
-        "# Add NaN count per column, sorted\n",
-        "print(\"NaN counts per column (sorted):\")\n",
-        "print(df.isnull().sum().sort_values(ascending=False), '\\n')\n",
-        "\n",
-        "#df.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "Suezit_quoZ1",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Suezit_quoZ1",
-        "outputId": "56d5d737-42db-4360-a0c8-6fede9c16a7e"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "DataFrame with difference features:\n",
-            "(67770, 1922) \n",
-            "\n",
-            "Label_Counts :  label\n",
-            "1    34223\n",
-            "0    33547\n",
-            "Name: count, dtype: int64 \n",
-            "\n",
-            "['Date', 'label', 'M5_raw_MACD_12_26_9_diff', 'M5_raw_MACD_signal_12_26_9_diff', 'M5_raw_MACD_hist_12_26_9_diff', 'M5_raw_RSI_basic_14_diff', 'M5_raw_BB_upper_20_diff', 'M5_raw_BB_middle_20_diff', 'M5_raw_BB_lower_20_diff', 'M5_raw_ATR_14_diff', 'M5_raw_OBV_basic_diff', 'M5_raw_VWAP_basic_diff', 'M5_raw_Momentum_10_diff', 'M5_raw_ROC_10_diff', 'M5_raw_Stoch_K_14_3_3_diff', 'M5_raw_Stoch_D_14_3_3_diff', 'M5_raw_CCI_20_diff', 'M5_raw_MFI_basic_14_diff', 'M5_raw_ADX_14_diff', 'M5_raw_WilliamsR_14_diff', 'M5_raw_CMF_diff', 'M5_raw_TMF_diff', 'M5_raw_MFI_14_volume_diff', 'M5_raw_KO_diff', 'M5_raw_EFI_diff', 'M5_raw_EOM_diff', 'M5_raw_VPT_diff', 'M5_raw_NVI_diff', 'M5_raw_PVI_diff', 'M5_raw_VFI_diff', 'M5_raw_VWAP_diff', 'M5_raw_Market_Facilitation_Index_diff', 'M5_raw_AD_Line_diff', 'M5_raw_WAD_diff', 'M5_raw_EMA_15_diff', 'M5_raw_EMA_21_diff', 'M5_raw_EMA_50_diff', 'M5_raw_EMA_100_diff', 'M5_raw_EMA_200_diff', 'M5_raw_RSI_3_diff', 'M5_raw_RSI_7_diff', 'M5_raw_RSI_14_diff', 'M5_raw_RSI_3 - RSI_7', 'M5_raw_RSI_3 - RSI_14', 'M5_raw_RSI_7 - RSI_14', 'M5_raw_MFI_3_diff', 'M5_raw_MFI_7_diff', 'M5_raw_MFI_14_diff', 'M5_raw_MFI_3 - MFI_7', 'M5_raw_MFI_3 - MFI_14', 'M5_raw_MFI_7 - MFI_14', 'M5_raw_OBV_diff', 'M5_raw_slope_div_300_3_diff', 'M5_raw_slope_signal_300_3_diff', 'M5_raw_slope_angle_300_3_diff', 'M5_raw_slope_angle_signal_300_3_diff', 'M5_raw_slope_lin_reg_300_3_diff', 'M5_raw_slope_lin_reg_signal_300_3_diff', 'M5_raw_slope_div_300_6_diff', 'M5_raw_slope_signal_300_6_diff', 'M5_raw_slope_angle_300_6_diff', 'M5_raw_slope_angle_signal_300_6_diff', 'M5_raw_slope_lin_reg_300_6_diff', 'M5_raw_slope_lin_reg_signal_300_6_diff', 'M5_raw_slope_div_300_9_diff', 'M5_raw_slope_signal_300_9_diff', 'M5_raw_slope_angle_300_9_diff', 'M5_raw_slope_angle_signal_300_9_diff', 'M5_raw_slope_lin_reg_300_9_diff', 'M5_raw_slope_lin_reg_signal_300_9_diff', 'M5_raw_slope_div_600_3_diff', 'M5_raw_slope_signal_600_3_diff', 'M5_raw_slope_angle_600_3_diff', 'M5_raw_slope_angle_signal_600_3_diff', 'M5_raw_slope_lin_reg_600_3_diff', 'M5_raw_slope_lin_reg_signal_600_3_diff', 'M5_raw_slope_div_600_6_diff', 'M5_raw_slope_signal_600_6_diff', 'M5_raw_slope_angle_600_6_diff', 'M5_raw_slope_angle_signal_600_6_diff', 'M5_raw_slope_lin_reg_600_6_diff', 'M5_raw_slope_lin_reg_signal_600_6_diff', 'M5_raw_slope_div_600_9_diff', 'M5_raw_slope_signal_600_9_diff', 'M5_raw_slope_angle_600_9_diff', 'M5_raw_slope_angle_signal_600_9_diff', 'M5_raw_slope_lin_reg_600_9_diff', 'M5_raw_slope_lin_reg_signal_600_9_diff', 'M5_raw_slope_div_900_3_diff', 'M5_raw_slope_signal_900_3_diff', 'M5_raw_slope_angle_900_3_diff', 'M5_raw_slope_angle_signal_900_3_diff', 'M5_raw_slope_lin_reg_900_3_diff', 'M5_raw_slope_lin_reg_signal_900_3_diff', 'M5_raw_slope_div_900_6_diff', 'M5_raw_slope_signal_900_6_diff', 'M5_raw_slope_angle_900_6_diff', 'M5_raw_slope_angle_signal_900_6_diff', 'M5_raw_slope_lin_reg_900_6_diff', 'M5_raw_slope_lin_reg_signal_900_6_diff', 'M5_raw_slope_div_900_9_diff', 'M5_raw_slope_signal_900_9_diff', 'M5_raw_slope_angle_900_9_diff', 'M5_raw_slope_angle_signal_900_9_diff', 'M5_raw_slope_lin_reg_900_9_diff', 'M5_raw_slope_lin_reg_signal_900_9_diff', 'M5_raw_slope_div_300_3 - slope_div_300_6', 'M5_raw_slope_div_300_3 - slope_div_300_9', 'M5_raw_slope_div_300_3 - slope_div_600_3', 'M5_raw_slope_div_300_3 - slope_div_600_6', 'M5_raw_slope_div_300_3 - slope_div_600_9', 'M5_raw_slope_div_300_3 - slope_div_900_3', 'M5_raw_slope_div_300_3 - slope_div_900_6', 'M5_raw_slope_div_300_3 - slope_div_900_9', 'M5_raw_slope_div_300_6 - slope_div_300_9', 'M5_raw_slope_div_300_6 - slope_div_600_3', 'M5_raw_slope_div_300_6 - slope_div_600_6', 'M5_raw_slope_div_300_6 - slope_div_600_9', 'M5_raw_slope_div_300_6 - slope_div_900_3', 'M5_raw_slope_div_300_6 - slope_div_900_6', 'M5_raw_slope_div_300_6 - slope_div_900_9', 'M5_raw_slope_div_300_9 - slope_div_600_3', 'M5_raw_slope_div_300_9 - slope_div_600_6', 'M5_raw_slope_div_300_9 - slope_div_600_9', 'M5_raw_slope_div_300_9 - slope_div_900_3', 'M5_raw_slope_div_300_9 - slope_div_900_6', 'M5_raw_slope_div_300_9 - slope_div_900_9', 'M5_raw_slope_div_600_3 - slope_div_600_6', 'M5_raw_slope_div_600_3 - slope_div_600_9', 'M5_raw_slope_div_600_3 - slope_div_900_3', 'M5_raw_slope_div_600_3 - slope_div_900_6', 'M5_raw_slope_div_600_3 - slope_div_900_9', 'M5_raw_slope_div_600_6 - slope_div_600_9', 'M5_raw_slope_div_600_6 - slope_div_900_3', 'M5_raw_slope_div_600_6 - slope_div_900_6', 'M5_raw_slope_div_600_6 - slope_div_900_9', 'M5_raw_slope_div_600_9 - slope_div_900_3', 'M5_raw_slope_div_600_9 - slope_div_900_6', 'M5_raw_slope_div_600_9 - slope_div_900_9', 'M5_raw_slope_div_900_3 - slope_div_900_6', 'M5_raw_slope_div_900_3 - slope_div_900_9', 'M5_raw_slope_div_900_6 - slope_div_900_9', 'M5_raw_slope_signal_300_3 - slope_signal_300_6', 'M5_raw_slope_signal_300_3 - slope_signal_300_9', 'M5_raw_slope_signal_300_3 - slope_signal_600_3', 'M5_raw_slope_signal_300_3 - slope_signal_600_6', 'M5_raw_slope_signal_300_3 - slope_signal_600_9', 'M5_raw_slope_signal_300_3 - slope_signal_900_3', 'M5_raw_slope_signal_300_3 - slope_signal_900_6', 'M5_raw_slope_signal_300_3 - slope_signal_900_9', 'M5_raw_slope_signal_300_6 - slope_signal_300_9', 'M5_raw_slope_signal_300_6 - slope_signal_600_3', 'M5_raw_slope_signal_300_6 - slope_signal_600_6', 'M5_raw_slope_signal_300_6 - slope_signal_600_9', 'M5_raw_slope_signal_300_6 - slope_signal_900_3', 'M5_raw_slope_signal_300_6 - slope_signal_900_6', 'M5_raw_slope_signal_300_6 - slope_signal_900_9', 'M5_raw_slope_signal_300_9 - slope_signal_600_3', 'M5_raw_slope_signal_300_9 - slope_signal_600_6', 'M5_raw_slope_signal_300_9 - slope_signal_600_9', 'M5_raw_slope_signal_300_9 - slope_signal_900_3', 'M5_raw_slope_signal_300_9 - slope_signal_900_6', 'M5_raw_slope_signal_300_9 - slope_signal_900_9', 'M5_raw_slope_signal_600_3 - slope_signal_600_6', 'M5_raw_slope_signal_600_3 - slope_signal_600_9', 'M5_raw_slope_signal_600_3 - slope_signal_900_3', 'M5_raw_slope_signal_600_3 - slope_signal_900_6', 'M5_raw_slope_signal_600_3 - slope_signal_900_9', 'M5_raw_slope_signal_600_6 - slope_signal_600_9', 'M5_raw_slope_signal_600_6 - slope_signal_900_3', 'M5_raw_slope_signal_600_6 - slope_signal_900_6', 'M5_raw_slope_signal_600_6 - slope_signal_900_9', 'M5_raw_slope_signal_600_9 - slope_signal_900_3', 'M5_raw_slope_signal_600_9 - slope_signal_900_6', 'M5_raw_slope_signal_600_9 - slope_signal_900_9', 'M5_raw_slope_signal_900_3 - slope_signal_900_6', 'M5_raw_slope_signal_900_3 - slope_signal_900_9', 'M5_raw_slope_signal_900_6 - slope_signal_900_9', 'M5_raw_slope_angle_300_3 - slope_angle_300_6', 'M5_raw_slope_angle_300_3 - slope_angle_300_9', 'M5_raw_slope_angle_300_3 - slope_angle_600_3', 'M5_raw_slope_angle_300_3 - slope_angle_600_6', 'M5_raw_slope_angle_300_3 - slope_angle_600_9', 'M5_raw_slope_angle_300_3 - slope_angle_900_3', 'M5_raw_slope_angle_300_3 - slope_angle_900_6', 'M5_raw_slope_angle_300_3 - slope_angle_900_9', 'M5_raw_slope_angle_300_6 - slope_angle_300_9', 'M5_raw_slope_angle_300_6 - slope_angle_600_3', 'M5_raw_slope_angle_300_6 - slope_angle_600_6', 'M5_raw_slope_angle_300_6 - slope_angle_600_9', 'M5_raw_slope_angle_300_6 - slope_angle_900_3', 'M5_raw_slope_angle_300_6 - slope_angle_900_6', 'M5_raw_slope_angle_300_6 - slope_angle_900_9', 'M5_raw_slope_angle_300_9 - slope_angle_600_3', 'M5_raw_slope_angle_300_9 - slope_angle_600_6', 'M5_raw_slope_angle_300_9 - slope_angle_600_9', 'M5_raw_slope_angle_300_9 - slope_angle_900_3', 'M5_raw_slope_angle_300_9 - slope_angle_900_6', 'M5_raw_slope_angle_300_9 - slope_angle_900_9', 'M5_raw_slope_angle_600_3 - slope_angle_600_6', 'M5_raw_slope_angle_600_3 - slope_angle_600_9', 'M5_raw_slope_angle_600_3 - slope_angle_900_3', 'M5_raw_slope_angle_600_3 - slope_angle_900_6', 'M5_raw_slope_angle_600_3 - slope_angle_900_9', 'M5_raw_slope_angle_600_6 - slope_angle_600_9', 'M5_raw_slope_angle_600_6 - slope_angle_900_3', 'M5_raw_slope_angle_600_6 - slope_angle_900_6', 'M5_raw_slope_angle_600_6 - slope_angle_900_9', 'M5_raw_slope_angle_600_9 - slope_angle_900_3', 'M5_raw_slope_angle_600_9 - slope_angle_900_6', 'M5_raw_slope_angle_600_9 - slope_angle_900_9', 'M5_raw_slope_angle_900_3 - slope_angle_900_6', 'M5_raw_slope_angle_900_3 - slope_angle_900_9', 'M5_raw_slope_angle_900_6 - slope_angle_900_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M5_scale_MACD_12_26_9_diff', 'M5_scale_MACD_signal_12_26_9_diff', 'M5_scale_MACD_hist_12_26_9_diff', 'M5_scale_RSI_basic_14_diff', 'M5_scale_BB_upper_20_diff', 'M5_scale_BB_middle_20_diff', 'M5_scale_BB_lower_20_diff', 'M5_scale_ATR_14_diff', 'M5_scale_OBV_basic_diff', 'M5_scale_VWAP_basic_diff', 'M5_scale_Momentum_10_diff', 'M5_scale_ROC_10_diff', 'M5_scale_Stoch_K_14_3_3_diff', 'M5_scale_Stoch_D_14_3_3_diff', 'M5_scale_CCI_20_diff', 'M5_scale_MFI_basic_14_diff', 'M5_scale_ADX_14_diff', 'M5_scale_WilliamsR_14_diff', 'M5_scale_CMF_diff', 'M5_scale_TMF_diff', 'M5_scale_MFI_14_volume_diff', 'M5_scale_KO_diff', 'M5_scale_EFI_diff', 'M5_scale_EOM_diff', 'M5_scale_VPT_diff', 'M5_scale_NVI_diff', 'M5_scale_PVI_diff', 'M5_scale_VFI_diff', 'M5_scale_VWAP_diff', 'M5_scale_Market_Facilitation_Index_diff', 'M5_scale_AD_Line_diff', 'M5_scale_WAD_diff', 'M5_scale_EMA_15_diff', 'M5_scale_EMA_21_diff', 'M5_scale_EMA_50_diff', 'M5_scale_EMA_100_diff', 'M5_scale_EMA_200_diff', 'M5_scale_RSI_3_diff', 'M5_scale_RSI_7_diff', 'M5_scale_RSI_14_diff', 'M5_scale_RSI_3 - RSI_7', 'M5_scale_RSI_3 - RSI_14', 'M5_scale_RSI_7 - RSI_14', 'M5_scale_MFI_3_diff', 'M5_scale_MFI_7_diff', 'M5_scale_MFI_14_diff', 'M5_scale_MFI_3 - MFI_7', 'M5_scale_MFI_3 - MFI_14', 'M5_scale_MFI_7 - MFI_14', 'M5_scale_OBV_diff', 'M5_scale_slope_div_300_3_diff', 'M5_scale_slope_signal_300_3_diff', 'M5_scale_slope_angle_300_3_diff', 'M5_scale_slope_angle_signal_300_3_diff', 'M5_scale_slope_lin_reg_300_3_diff', 'M5_scale_slope_lin_reg_signal_300_3_diff', 'M5_scale_slope_div_300_6_diff', 'M5_scale_slope_signal_300_6_diff', 'M5_scale_slope_angle_300_6_diff', 'M5_scale_slope_angle_signal_300_6_diff', 'M5_scale_slope_lin_reg_300_6_diff', 'M5_scale_slope_lin_reg_signal_300_6_diff', 'M5_scale_slope_div_300_9_diff', 'M5_scale_slope_signal_300_9_diff', 'M5_scale_slope_angle_300_9_diff', 'M5_scale_slope_angle_signal_300_9_diff', 'M5_scale_slope_lin_reg_300_9_diff', 'M5_scale_slope_lin_reg_signal_300_9_diff', 'M5_scale_slope_div_600_3_diff', 'M5_scale_slope_signal_600_3_diff', 'M5_scale_slope_angle_600_3_diff', 'M5_scale_slope_angle_signal_600_3_diff', 'M5_scale_slope_lin_reg_600_3_diff', 'M5_scale_slope_lin_reg_signal_600_3_diff', 'M5_scale_slope_div_600_6_diff', 'M5_scale_slope_signal_600_6_diff', 'M5_scale_slope_angle_600_6_diff', 'M5_scale_slope_angle_signal_600_6_diff', 'M5_scale_slope_lin_reg_600_6_diff', 'M5_scale_slope_lin_reg_signal_600_6_diff', 'M5_scale_slope_div_600_9_diff', 'M5_scale_slope_signal_600_9_diff', 'M5_scale_slope_angle_600_9_diff', 'M5_scale_slope_angle_signal_600_9_diff', 'M5_scale_slope_lin_reg_600_9_diff', 'M5_scale_slope_lin_reg_signal_600_9_diff', 'M5_scale_slope_div_900_3_diff', 'M5_scale_slope_signal_900_3_diff', 'M5_scale_slope_angle_900_3_diff', 'M5_scale_slope_angle_signal_900_3_diff', 'M5_scale_slope_lin_reg_900_3_diff', 'M5_scale_slope_lin_reg_signal_900_3_diff', 'M5_scale_slope_div_900_6_diff', 'M5_scale_slope_signal_900_6_diff', 'M5_scale_slope_angle_900_6_diff', 'M5_scale_slope_angle_signal_900_6_diff', 'M5_scale_slope_lin_reg_900_6_diff', 'M5_scale_slope_lin_reg_signal_900_6_diff', 'M5_scale_slope_div_900_9_diff', 'M5_scale_slope_signal_900_9_diff', 'M5_scale_slope_angle_900_9_diff', 'M5_scale_slope_angle_signal_900_9_diff', 'M5_scale_slope_lin_reg_900_9_diff', 'M5_scale_slope_lin_reg_signal_900_9_diff', 'M5_scale_slope_div_300_3 - slope_div_300_6', 'M5_scale_slope_div_300_3 - slope_div_300_9', 'M5_scale_slope_div_300_3 - slope_div_600_3', 'M5_scale_slope_div_300_3 - slope_div_600_6', 'M5_scale_slope_div_300_3 - slope_div_600_9', 'M5_scale_slope_div_300_3 - slope_div_900_3', 'M5_scale_slope_div_300_3 - slope_div_900_6', 'M5_scale_slope_div_300_3 - slope_div_900_9', 'M5_scale_slope_div_300_6 - slope_div_300_9', 'M5_scale_slope_div_300_6 - slope_div_600_3', 'M5_scale_slope_div_300_6 - slope_div_600_6', 'M5_scale_slope_div_300_6 - slope_div_600_9', 'M5_scale_slope_div_300_6 - slope_div_900_3', 'M5_scale_slope_div_300_6 - slope_div_900_6', 'M5_scale_slope_div_300_6 - slope_div_900_9', 'M5_scale_slope_div_300_9 - slope_div_600_3', 'M5_scale_slope_div_300_9 - slope_div_600_6', 'M5_scale_slope_div_300_9 - slope_div_600_9', 'M5_scale_slope_div_300_9 - slope_div_900_3', 'M5_scale_slope_div_300_9 - slope_div_900_6', 'M5_scale_slope_div_300_9 - slope_div_900_9', 'M5_scale_slope_div_600_3 - slope_div_600_6', 'M5_scale_slope_div_600_3 - slope_div_600_9', 'M5_scale_slope_div_600_3 - slope_div_900_3', 'M5_scale_slope_div_600_3 - slope_div_900_6', 'M5_scale_slope_div_600_3 - slope_div_900_9', 'M5_scale_slope_div_600_6 - slope_div_600_9', 'M5_scale_slope_div_600_6 - slope_div_900_3', 'M5_scale_slope_div_600_6 - slope_div_900_6', 'M5_scale_slope_div_600_6 - slope_div_900_9', 'M5_scale_slope_div_600_9 - slope_div_900_3', 'M5_scale_slope_div_600_9 - slope_div_900_6', 'M5_scale_slope_div_600_9 - slope_div_900_9', 'M5_scale_slope_div_900_3 - slope_div_900_6', 'M5_scale_slope_div_900_3 - slope_div_900_9', 'M5_scale_slope_div_900_6 - slope_div_900_9', 'M5_scale_slope_signal_300_3 - slope_signal_300_6', 'M5_scale_slope_signal_300_3 - slope_signal_300_9', 'M5_scale_slope_signal_300_3 - slope_signal_600_3', 'M5_scale_slope_signal_300_3 - slope_signal_600_6', 'M5_scale_slope_signal_300_3 - slope_signal_600_9', 'M5_scale_slope_signal_300_3 - slope_signal_900_3', 'M5_scale_slope_signal_300_3 - slope_signal_900_6', 'M5_scale_slope_signal_300_3 - slope_signal_900_9', 'M5_scale_slope_signal_300_6 - slope_signal_300_9', 'M5_scale_slope_signal_300_6 - slope_signal_600_3', 'M5_scale_slope_signal_300_6 - slope_signal_600_6', 'M5_scale_slope_signal_300_6 - slope_signal_600_9', 'M5_scale_slope_signal_300_6 - slope_signal_900_3', 'M5_scale_slope_signal_300_6 - slope_signal_900_6', 'M5_scale_slope_signal_300_6 - slope_signal_900_9', 'M5_scale_slope_signal_300_9 - slope_signal_600_3', 'M5_scale_slope_signal_300_9 - slope_signal_600_6', 'M5_scale_slope_signal_300_9 - slope_signal_600_9', 'M5_scale_slope_signal_300_9 - slope_signal_900_3', 'M5_scale_slope_signal_300_9 - slope_signal_900_6', 'M5_scale_slope_signal_300_9 - slope_signal_900_9', 'M5_scale_slope_signal_600_3 - slope_signal_600_6', 'M5_scale_slope_signal_600_3 - slope_signal_600_9', 'M5_scale_slope_signal_600_3 - slope_signal_900_3', 'M5_scale_slope_signal_600_3 - slope_signal_900_6', 'M5_scale_slope_signal_600_3 - slope_signal_900_9', 'M5_scale_slope_signal_600_6 - slope_signal_600_9', 'M5_scale_slope_signal_600_6 - slope_signal_900_3', 'M5_scale_slope_signal_600_6 - slope_signal_900_6', 'M5_scale_slope_signal_600_6 - slope_signal_900_9', 'M5_scale_slope_signal_600_9 - slope_signal_900_3', 'M5_scale_slope_signal_600_9 - slope_signal_900_6', 'M5_scale_slope_signal_600_9 - slope_signal_900_9', 'M5_scale_slope_signal_900_3 - slope_signal_900_6', 'M5_scale_slope_signal_900_3 - slope_signal_900_9', 'M5_scale_slope_signal_900_6 - slope_signal_900_9', 'M5_scale_slope_angle_300_3 - slope_angle_300_6', 'M5_scale_slope_angle_300_3 - slope_angle_300_9', 'M5_scale_slope_angle_300_3 - slope_angle_600_3', 'M5_scale_slope_angle_300_3 - slope_angle_600_6', 'M5_scale_slope_angle_300_3 - slope_angle_600_9', 'M5_scale_slope_angle_300_3 - slope_angle_900_3', 'M5_scale_slope_angle_300_3 - slope_angle_900_6', 'M5_scale_slope_angle_300_3 - slope_angle_900_9', 'M5_scale_slope_angle_300_6 - slope_angle_300_9', 'M5_scale_slope_angle_300_6 - slope_angle_600_3', 'M5_scale_slope_angle_300_6 - slope_angle_600_6', 'M5_scale_slope_angle_300_6 - slope_angle_600_9', 'M5_scale_slope_angle_300_6 - slope_angle_900_3', 'M5_scale_slope_angle_300_6 - slope_angle_900_6', 'M5_scale_slope_angle_300_6 - slope_angle_900_9', 'M5_scale_slope_angle_300_9 - slope_angle_600_3', 'M5_scale_slope_angle_300_9 - slope_angle_600_6', 'M5_scale_slope_angle_300_9 - slope_angle_600_9', 'M5_scale_slope_angle_300_9 - slope_angle_900_3', 'M5_scale_slope_angle_300_9 - slope_angle_900_6', 'M5_scale_slope_angle_300_9 - slope_angle_900_9', 'M5_scale_slope_angle_600_3 - slope_angle_600_6', 'M5_scale_slope_angle_600_3 - slope_angle_600_9', 'M5_scale_slope_angle_600_3 - slope_angle_900_3', 'M5_scale_slope_angle_600_3 - slope_angle_900_6', 'M5_scale_slope_angle_600_3 - slope_angle_900_9', 'M5_scale_slope_angle_600_6 - slope_angle_600_9', 'M5_scale_slope_angle_600_6 - slope_angle_900_3', 'M5_scale_slope_angle_600_6 - slope_angle_900_6', 'M5_scale_slope_angle_600_6 - slope_angle_900_9', 'M5_scale_slope_angle_600_9 - slope_angle_900_3', 'M5_scale_slope_angle_600_9 - slope_angle_900_6', 'M5_scale_slope_angle_600_9 - slope_angle_900_9', 'M5_scale_slope_angle_900_3 - slope_angle_900_6', 'M5_scale_slope_angle_900_3 - slope_angle_900_9', 'M5_scale_slope_angle_900_6 - slope_angle_900_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_MACD_12_26_9_diff', 'M10_raw_10min_MACD_signal_12_26_9_diff', 'M10_raw_10min_MACD_hist_12_26_9_diff', 'M10_raw_10min_RSI_basic_14_diff', 'M10_raw_10min_BB_upper_20_diff', 'M10_raw_10min_BB_middle_20_diff', 'M10_raw_10min_BB_lower_20_diff', 'M10_raw_10min_ATR_14_diff', 'M10_raw_10min_OBV_basic_diff', 'M10_raw_10min_VWAP_basic_diff', 'M10_raw_10min_Momentum_10_diff', 'M10_raw_10min_ROC_10_diff', 'M10_raw_10min_Stoch_K_14_3_3_diff', 'M10_raw_10min_Stoch_D_14_3_3_diff', 'M10_raw_10min_CCI_20_diff', 'M10_raw_10min_MFI_basic_14_diff', 'M10_raw_10min_ADX_14_diff', 'M10_raw_10min_WilliamsR_14_diff', 'M10_raw_10min_CMF_diff', 'M10_raw_10min_TMF_diff', 'M10_raw_10min_MFI_14_volume_diff', 'M10_raw_10min_KO_diff', 'M10_raw_10min_EFI_diff', 'M10_raw_10min_EOM_diff', 'M10_raw_10min_VPT_diff', 'M10_raw_10min_NVI_diff', 'M10_raw_10min_PVI_diff', 'M10_raw_10min_VFI_diff', 'M10_raw_10min_VWAP_diff', 'M10_raw_10min_Market_Facilitation_Index_diff', 'M10_raw_10min_AD_Line_diff', 'M10_raw_10min_WAD_diff', 'M10_raw_10min_EMA_15_diff', 'M10_raw_10min_EMA_21_diff', 'M10_raw_10min_EMA_50_diff', 'M10_raw_10min_EMA_100_diff', 'M10_raw_10min_EMA_200_diff', 'M10_raw_10min_RSI_3_diff', 'M10_raw_10min_RSI_7_diff', 'M10_raw_10min_RSI_14_diff', 'M10_raw_10min_RSI_3 - RSI_7', 'M10_raw_10min_RSI_3 - RSI_14', 'M10_raw_10min_RSI_7 - RSI_14', 'M10_raw_10min_MFI_3_diff', 'M10_raw_10min_MFI_7_diff', 'M10_raw_10min_MFI_14_diff', 'M10_raw_10min_MFI_3 - MFI_7', 'M10_raw_10min_MFI_3 - MFI_14', 'M10_raw_10min_MFI_7 - MFI_14', 'M10_raw_10min_OBV_diff', 'M10_raw_10min_slope_div_300_3_diff', 'M10_raw_10min_slope_signal_300_3_diff', 'M10_raw_10min_slope_angle_300_3_diff', 'M10_raw_10min_slope_angle_signal_300_3_diff', 'M10_raw_10min_slope_lin_reg_300_3_diff', 'M10_raw_10min_slope_lin_reg_signal_300_3_diff', 'M10_raw_10min_slope_div_300_6_diff', 'M10_raw_10min_slope_signal_300_6_diff', 'M10_raw_10min_slope_angle_300_6_diff', 'M10_raw_10min_slope_angle_signal_300_6_diff', 'M10_raw_10min_slope_lin_reg_300_6_diff', 'M10_raw_10min_slope_lin_reg_signal_300_6_diff', 'M10_raw_10min_slope_div_300_9_diff', 'M10_raw_10min_slope_signal_300_9_diff', 'M10_raw_10min_slope_angle_300_9_diff', 'M10_raw_10min_slope_angle_signal_300_9_diff', 'M10_raw_10min_slope_lin_reg_300_9_diff', 'M10_raw_10min_slope_lin_reg_signal_300_9_diff', 'M10_raw_10min_slope_div_600_3_diff', 'M10_raw_10min_slope_signal_600_3_diff', 'M10_raw_10min_slope_angle_600_3_diff', 'M10_raw_10min_slope_angle_signal_600_3_diff', 'M10_raw_10min_slope_lin_reg_600_3_diff', 'M10_raw_10min_slope_lin_reg_signal_600_3_diff', 'M10_raw_10min_slope_div_600_6_diff', 'M10_raw_10min_slope_signal_600_6_diff', 'M10_raw_10min_slope_angle_600_6_diff', 'M10_raw_10min_slope_angle_signal_600_6_diff', 'M10_raw_10min_slope_lin_reg_600_6_diff', 'M10_raw_10min_slope_lin_reg_signal_600_6_diff', 'M10_raw_10min_slope_div_600_9_diff', 'M10_raw_10min_slope_signal_600_9_diff', 'M10_raw_10min_slope_angle_600_9_diff', 'M10_raw_10min_slope_angle_signal_600_9_diff', 'M10_raw_10min_slope_lin_reg_600_9_diff', 'M10_raw_10min_slope_lin_reg_signal_600_9_diff', 'M10_raw_10min_slope_div_900_3_diff', 'M10_raw_10min_slope_signal_900_3_diff', 'M10_raw_10min_slope_angle_900_3_diff', 'M10_raw_10min_slope_angle_signal_900_3_diff', 'M10_raw_10min_slope_lin_reg_900_3_diff', 'M10_raw_10min_slope_lin_reg_signal_900_3_diff', 'M10_raw_10min_slope_div_900_6_diff', 'M10_raw_10min_slope_signal_900_6_diff', 'M10_raw_10min_slope_angle_900_6_diff', 'M10_raw_10min_slope_angle_signal_900_6_diff', 'M10_raw_10min_slope_lin_reg_900_6_diff', 'M10_raw_10min_slope_lin_reg_signal_900_6_diff', 'M10_raw_10min_slope_div_900_9_diff', 'M10_raw_10min_slope_signal_900_9_diff', 'M10_raw_10min_slope_angle_900_9_diff', 'M10_raw_10min_slope_angle_signal_900_9_diff', 'M10_raw_10min_slope_lin_reg_900_9_diff', 'M10_raw_10min_slope_lin_reg_signal_900_9_diff', 'M10_raw_10min_slope_div_300_3 - slope_div_300_6', 'M10_raw_10min_slope_div_300_3 - slope_div_300_9', 'M10_raw_10min_slope_div_300_3 - slope_div_600_3', 'M10_raw_10min_slope_div_300_3 - slope_div_600_6', 'M10_raw_10min_slope_div_300_3 - slope_div_600_9', 'M10_raw_10min_slope_div_300_3 - slope_div_900_3', 'M10_raw_10min_slope_div_300_3 - slope_div_900_6', 'M10_raw_10min_slope_div_300_3 - slope_div_900_9', 'M10_raw_10min_slope_div_300_6 - slope_div_300_9', 'M10_raw_10min_slope_div_300_6 - slope_div_600_3', 'M10_raw_10min_slope_div_300_6 - slope_div_600_6', 'M10_raw_10min_slope_div_300_6 - slope_div_600_9', 'M10_raw_10min_slope_div_300_6 - slope_div_900_3', 'M10_raw_10min_slope_div_300_6 - slope_div_900_6', 'M10_raw_10min_slope_div_300_6 - slope_div_900_9', 'M10_raw_10min_slope_div_300_9 - slope_div_600_3', 'M10_raw_10min_slope_div_300_9 - slope_div_600_6', 'M10_raw_10min_slope_div_300_9 - slope_div_600_9', 'M10_raw_10min_slope_div_300_9 - slope_div_900_3', 'M10_raw_10min_slope_div_300_9 - slope_div_900_6', 'M10_raw_10min_slope_div_300_9 - slope_div_900_9', 'M10_raw_10min_slope_div_600_3 - slope_div_600_6', 'M10_raw_10min_slope_div_600_3 - slope_div_600_9', 'M10_raw_10min_slope_div_600_3 - slope_div_900_3', 'M10_raw_10min_slope_div_600_3 - slope_div_900_6', 'M10_raw_10min_slope_div_600_3 - slope_div_900_9', 'M10_raw_10min_slope_div_600_6 - slope_div_600_9', 'M10_raw_10min_slope_div_600_6 - slope_div_900_3', 'M10_raw_10min_slope_div_600_6 - slope_div_900_6', 'M10_raw_10min_slope_div_600_6 - slope_div_900_9', 'M10_raw_10min_slope_div_600_9 - slope_div_900_3', 'M10_raw_10min_slope_div_600_9 - slope_div_900_6', 'M10_raw_10min_slope_div_600_9 - slope_div_900_9', 'M10_raw_10min_slope_div_900_3 - slope_div_900_6', 'M10_raw_10min_slope_div_900_3 - slope_div_900_9', 'M10_raw_10min_slope_div_900_6 - slope_div_900_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_MACD_12_26_9_diff', 'M10_scale_10min_MACD_signal_12_26_9_diff', 'M10_scale_10min_MACD_hist_12_26_9_diff', 'M10_scale_10min_RSI_basic_14_diff', 'M10_scale_10min_BB_upper_20_diff', 'M10_scale_10min_BB_middle_20_diff', 'M10_scale_10min_BB_lower_20_diff', 'M10_scale_10min_ATR_14_diff', 'M10_scale_10min_OBV_basic_diff', 'M10_scale_10min_VWAP_basic_diff', 'M10_scale_10min_Momentum_10_diff', 'M10_scale_10min_ROC_10_diff', 'M10_scale_10min_Stoch_K_14_3_3_diff', 'M10_scale_10min_Stoch_D_14_3_3_diff', 'M10_scale_10min_CCI_20_diff', 'M10_scale_10min_MFI_basic_14_diff', 'M10_scale_10min_ADX_14_diff', 'M10_scale_10min_WilliamsR_14_diff', 'M10_scale_10min_CMF_diff', 'M10_scale_10min_TMF_diff', 'M10_scale_10min_MFI_14_volume_diff', 'M10_scale_10min_KO_diff', 'M10_scale_10min_EFI_diff', 'M10_scale_10min_EOM_diff', 'M10_scale_10min_VPT_diff', 'M10_scale_10min_NVI_diff', 'M10_scale_10min_PVI_diff', 'M10_scale_10min_VFI_diff', 'M10_scale_10min_VWAP_diff', 'M10_scale_10min_Market_Facilitation_Index_diff', 'M10_scale_10min_AD_Line_diff', 'M10_scale_10min_WAD_diff', 'M10_scale_10min_EMA_15_diff', 'M10_scale_10min_EMA_21_diff', 'M10_scale_10min_EMA_50_diff', 'M10_scale_10min_EMA_100_diff', 'M10_scale_10min_EMA_200_diff', 'M10_scale_10min_RSI_3_diff', 'M10_scale_10min_RSI_7_diff', 'M10_scale_10min_RSI_14_diff', 'M10_scale_10min_RSI_3 - RSI_7', 'M10_scale_10min_RSI_3 - RSI_14', 'M10_scale_10min_RSI_7 - RSI_14', 'M10_scale_10min_MFI_3_diff', 'M10_scale_10min_MFI_7_diff', 'M10_scale_10min_MFI_14_diff', 'M10_scale_10min_MFI_3 - MFI_7', 'M10_scale_10min_MFI_3 - MFI_14', 'M10_scale_10min_MFI_7 - MFI_14', 'M10_scale_10min_OBV_diff', 'M10_scale_10min_slope_div_300_3_diff', 'M10_scale_10min_slope_signal_300_3_diff', 'M10_scale_10min_slope_angle_300_3_diff', 'M10_scale_10min_slope_angle_signal_300_3_diff', 'M10_scale_10min_slope_lin_reg_300_3_diff', 'M10_scale_10min_slope_lin_reg_signal_300_3_diff', 'M10_scale_10min_slope_div_300_6_diff', 'M10_scale_10min_slope_signal_300_6_diff', 'M10_scale_10min_slope_angle_300_6_diff', 'M10_scale_10min_slope_angle_signal_300_6_diff', 'M10_scale_10min_slope_lin_reg_300_6_diff', 'M10_scale_10min_slope_lin_reg_signal_300_6_diff', 'M10_scale_10min_slope_div_300_9_diff', 'M10_scale_10min_slope_signal_300_9_diff', 'M10_scale_10min_slope_angle_300_9_diff', 'M10_scale_10min_slope_angle_signal_300_9_diff', 'M10_scale_10min_slope_lin_reg_300_9_diff', 'M10_scale_10min_slope_lin_reg_signal_300_9_diff', 'M10_scale_10min_slope_div_600_3_diff', 'M10_scale_10min_slope_signal_600_3_diff', 'M10_scale_10min_slope_angle_600_3_diff', 'M10_scale_10min_slope_angle_signal_600_3_diff', 'M10_scale_10min_slope_lin_reg_600_3_diff', 'M10_scale_10min_slope_lin_reg_signal_600_3_diff', 'M10_scale_10min_slope_div_600_6_diff', 'M10_scale_10min_slope_signal_600_6_diff', 'M10_scale_10min_slope_angle_600_6_diff', 'M10_scale_10min_slope_angle_signal_600_6_diff', 'M10_scale_10min_slope_lin_reg_600_6_diff', 'M10_scale_10min_slope_lin_reg_signal_600_6_diff', 'M10_scale_10min_slope_div_600_9_diff', 'M10_scale_10min_slope_signal_600_9_diff', 'M10_scale_10min_slope_angle_600_9_diff', 'M10_scale_10min_slope_angle_signal_600_9_diff', 'M10_scale_10min_slope_lin_reg_600_9_diff', 'M10_scale_10min_slope_lin_reg_signal_600_9_diff', 'M10_scale_10min_slope_div_900_3_diff', 'M10_scale_10min_slope_signal_900_3_diff', 'M10_scale_10min_slope_angle_900_3_diff', 'M10_scale_10min_slope_angle_signal_900_3_diff', 'M10_scale_10min_slope_lin_reg_900_3_diff', 'M10_scale_10min_slope_lin_reg_signal_900_3_diff', 'M10_scale_10min_slope_div_900_6_diff', 'M10_scale_10min_slope_signal_900_6_diff', 'M10_scale_10min_slope_angle_900_6_diff', 'M10_scale_10min_slope_angle_signal_900_6_diff', 'M10_scale_10min_slope_lin_reg_900_6_diff', 'M10_scale_10min_slope_lin_reg_signal_900_6_diff', 'M10_scale_10min_slope_div_900_9_diff', 'M10_scale_10min_slope_signal_900_9_diff', 'M10_scale_10min_slope_angle_900_9_diff', 'M10_scale_10min_slope_angle_signal_900_9_diff', 'M10_scale_10min_slope_lin_reg_900_9_diff', 'M10_scale_10min_slope_lin_reg_signal_900_9_diff', 'M10_scale_10min_slope_div_300_3 - slope_div_300_6', 'M10_scale_10min_slope_div_300_3 - slope_div_300_9', 'M10_scale_10min_slope_div_300_3 - slope_div_600_3', 'M10_scale_10min_slope_div_300_3 - slope_div_600_6', 'M10_scale_10min_slope_div_300_3 - slope_div_600_9', 'M10_scale_10min_slope_div_300_3 - slope_div_900_3', 'M10_scale_10min_slope_div_300_3 - slope_div_900_6', 'M10_scale_10min_slope_div_300_3 - slope_div_900_9', 'M10_scale_10min_slope_div_300_6 - slope_div_300_9', 'M10_scale_10min_slope_div_300_6 - slope_div_600_3', 'M10_scale_10min_slope_div_300_6 - slope_div_600_6', 'M10_scale_10min_slope_div_300_6 - slope_div_600_9', 'M10_scale_10min_slope_div_300_6 - slope_div_900_3', 'M10_scale_10min_slope_div_300_6 - slope_div_900_6', 'M10_scale_10min_slope_div_300_6 - slope_div_900_9', 'M10_scale_10min_slope_div_300_9 - slope_div_600_3', 'M10_scale_10min_slope_div_300_9 - slope_div_600_6', 'M10_scale_10min_slope_div_300_9 - slope_div_600_9', 'M10_scale_10min_slope_div_300_9 - slope_div_900_3', 'M10_scale_10min_slope_div_300_9 - slope_div_900_6', 'M10_scale_10min_slope_div_300_9 - slope_div_900_9', 'M10_scale_10min_slope_div_600_3 - slope_div_600_6', 'M10_scale_10min_slope_div_600_3 - slope_div_600_9', 'M10_scale_10min_slope_div_600_3 - slope_div_900_3', 'M10_scale_10min_slope_div_600_3 - slope_div_900_6', 'M10_scale_10min_slope_div_600_3 - slope_div_900_9', 'M10_scale_10min_slope_div_600_6 - slope_div_600_9', 'M10_scale_10min_slope_div_600_6 - slope_div_900_3', 'M10_scale_10min_slope_div_600_6 - slope_div_900_6', 'M10_scale_10min_slope_div_600_6 - slope_div_900_9', 'M10_scale_10min_slope_div_600_9 - slope_div_900_3', 'M10_scale_10min_slope_div_600_9 - slope_div_900_6', 'M10_scale_10min_slope_div_600_9 - slope_div_900_9', 'M10_scale_10min_slope_div_900_3 - slope_div_900_6', 'M10_scale_10min_slope_div_900_3 - slope_div_900_9', 'M10_scale_10min_slope_div_900_6 - slope_div_900_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_MACD_12_26_9_diff', 'M15_raw_15min_MACD_signal_12_26_9_diff', 'M15_raw_15min_MACD_hist_12_26_9_diff', 'M15_raw_15min_RSI_basic_14_diff', 'M15_raw_15min_BB_upper_20_diff', 'M15_raw_15min_BB_middle_20_diff', 'M15_raw_15min_BB_lower_20_diff', 'M15_raw_15min_ATR_14_diff', 'M15_raw_15min_OBV_basic_diff', 'M15_raw_15min_VWAP_basic_diff', 'M15_raw_15min_Momentum_10_diff', 'M15_raw_15min_ROC_10_diff', 'M15_raw_15min_Stoch_K_14_3_3_diff', 'M15_raw_15min_Stoch_D_14_3_3_diff', 'M15_raw_15min_CCI_20_diff', 'M15_raw_15min_MFI_basic_14_diff', 'M15_raw_15min_ADX_14_diff', 'M15_raw_15min_WilliamsR_14_diff', 'M15_raw_15min_CMF_diff', 'M15_raw_15min_TMF_diff', 'M15_raw_15min_MFI_14_volume_diff', 'M15_raw_15min_KO_diff', 'M15_raw_15min_EFI_diff', 'M15_raw_15min_EOM_diff', 'M15_raw_15min_VPT_diff', 'M15_raw_15min_NVI_diff', 'M15_raw_15min_PVI_diff', 'M15_raw_15min_VFI_diff', 'M15_raw_15min_VWAP_diff', 'M15_raw_15min_Market_Facilitation_Index_diff', 'M15_raw_15min_AD_Line_diff', 'M15_raw_15min_WAD_diff', 'M15_raw_15min_EMA_15_diff', 'M15_raw_15min_EMA_21_diff', 'M15_raw_15min_EMA_50_diff', 'M15_raw_15min_EMA_100_diff', 'M15_raw_15min_EMA_200_diff', 'M15_raw_15min_RSI_3_diff', 'M15_raw_15min_RSI_7_diff', 'M15_raw_15min_RSI_14_diff', 'M15_raw_15min_RSI_3 - RSI_7', 'M15_raw_15min_RSI_3 - RSI_14', 'M15_raw_15min_RSI_7 - RSI_14', 'M15_raw_15min_MFI_3_diff', 'M15_raw_15min_MFI_7_diff', 'M15_raw_15min_MFI_14_diff', 'M15_raw_15min_MFI_3 - MFI_7', 'M15_raw_15min_MFI_3 - MFI_14', 'M15_raw_15min_MFI_7 - MFI_14', 'M15_raw_15min_OBV_diff', 'M15_raw_15min_slope_div_300_3_diff', 'M15_raw_15min_slope_signal_300_3_diff', 'M15_raw_15min_slope_angle_300_3_diff', 'M15_raw_15min_slope_angle_signal_300_3_diff', 'M15_raw_15min_slope_lin_reg_300_3_diff', 'M15_raw_15min_slope_lin_reg_signal_300_3_diff', 'M15_raw_15min_slope_div_300_6_diff', 'M15_raw_15min_slope_signal_300_6_diff', 'M15_raw_15min_slope_angle_300_6_diff', 'M15_raw_15min_slope_angle_signal_300_6_diff', 'M15_raw_15min_slope_lin_reg_300_6_diff', 'M15_raw_15min_slope_lin_reg_signal_300_6_diff', 'M15_raw_15min_slope_div_300_9_diff', 'M15_raw_15min_slope_signal_300_9_diff', 'M15_raw_15min_slope_angle_300_9_diff', 'M15_raw_15min_slope_angle_signal_300_9_diff', 'M15_raw_15min_slope_lin_reg_300_9_diff', 'M15_raw_15min_slope_lin_reg_signal_300_9_diff', 'M15_raw_15min_slope_div_600_3_diff', 'M15_raw_15min_slope_signal_600_3_diff', 'M15_raw_15min_slope_angle_600_3_diff', 'M15_raw_15min_slope_angle_signal_600_3_diff', 'M15_raw_15min_slope_lin_reg_600_3_diff', 'M15_raw_15min_slope_lin_reg_signal_600_3_diff', 'M15_raw_15min_slope_div_600_6_diff', 'M15_raw_15min_slope_signal_600_6_diff', 'M15_raw_15min_slope_angle_600_6_diff', 'M15_raw_15min_slope_angle_signal_600_6_diff', 'M15_raw_15min_slope_lin_reg_600_6_diff', 'M15_raw_15min_slope_lin_reg_signal_600_6_diff', 'M15_raw_15min_slope_div_600_9_diff', 'M15_raw_15min_slope_signal_600_9_diff', 'M15_raw_15min_slope_angle_600_9_diff', 'M15_raw_15min_slope_angle_signal_600_9_diff', 'M15_raw_15min_slope_lin_reg_600_9_diff', 'M15_raw_15min_slope_lin_reg_signal_600_9_diff', 'M15_raw_15min_slope_div_900_3_diff', 'M15_raw_15min_slope_signal_900_3_diff', 'M15_raw_15min_slope_angle_900_3_diff', 'M15_raw_15min_slope_angle_signal_900_3_diff', 'M15_raw_15min_slope_lin_reg_900_3_diff', 'M15_raw_15min_slope_lin_reg_signal_900_3_diff', 'M15_raw_15min_slope_div_900_6_diff', 'M15_raw_15min_slope_signal_900_6_diff', 'M15_raw_15min_slope_angle_900_6_diff', 'M15_raw_15min_slope_angle_signal_900_6_diff', 'M15_raw_15min_slope_lin_reg_900_6_diff', 'M15_raw_15min_slope_lin_reg_signal_900_6_diff', 'M15_raw_15min_slope_div_900_9_diff', 'M15_raw_15min_slope_signal_900_9_diff', 'M15_raw_15min_slope_angle_900_9_diff', 'M15_raw_15min_slope_angle_signal_900_9_diff', 'M15_raw_15min_slope_lin_reg_900_9_diff', 'M15_raw_15min_slope_lin_reg_signal_900_9_diff', 'M15_raw_15min_slope_div_300_3 - slope_div_300_6', 'M15_raw_15min_slope_div_300_3 - slope_div_300_9', 'M15_raw_15min_slope_div_300_3 - slope_div_600_3', 'M15_raw_15min_slope_div_300_3 - slope_div_600_6', 'M15_raw_15min_slope_div_300_3 - slope_div_600_9', 'M15_raw_15min_slope_div_300_3 - slope_div_900_3', 'M15_raw_15min_slope_div_300_3 - slope_div_900_6', 'M15_raw_15min_slope_div_300_3 - slope_div_900_9', 'M15_raw_15min_slope_div_300_6 - slope_div_300_9', 'M15_raw_15min_slope_div_300_6 - slope_div_600_3', 'M15_raw_15min_slope_div_300_6 - slope_div_600_6', 'M15_raw_15min_slope_div_300_6 - slope_div_600_9', 'M15_raw_15min_slope_div_300_6 - slope_div_900_3', 'M15_raw_15min_slope_div_300_6 - slope_div_900_6', 'M15_raw_15min_slope_div_300_6 - slope_div_900_9', 'M15_raw_15min_slope_div_300_9 - slope_div_600_3', 'M15_raw_15min_slope_div_300_9 - slope_div_600_6', 'M15_raw_15min_slope_div_300_9 - slope_div_600_9', 'M15_raw_15min_slope_div_300_9 - slope_div_900_3', 'M15_raw_15min_slope_div_300_9 - slope_div_900_6', 'M15_raw_15min_slope_div_300_9 - slope_div_900_9', 'M15_raw_15min_slope_div_600_3 - slope_div_600_6', 'M15_raw_15min_slope_div_600_3 - slope_div_600_9', 'M15_raw_15min_slope_div_600_3 - slope_div_900_3', 'M15_raw_15min_slope_div_600_3 - slope_div_900_6', 'M15_raw_15min_slope_div_600_3 - slope_div_900_9', 'M15_raw_15min_slope_div_600_6 - slope_div_600_9', 'M15_raw_15min_slope_div_600_6 - slope_div_900_3', 'M15_raw_15min_slope_div_600_6 - slope_div_900_6', 'M15_raw_15min_slope_div_600_6 - slope_div_900_9', 'M15_raw_15min_slope_div_600_9 - slope_div_900_3', 'M15_raw_15min_slope_div_600_9 - slope_div_900_6', 'M15_raw_15min_slope_div_600_9 - slope_div_900_9', 'M15_raw_15min_slope_div_900_3 - slope_div_900_6', 'M15_raw_15min_slope_div_900_3 - slope_div_900_9', 'M15_raw_15min_slope_div_900_6 - slope_div_900_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_MACD_12_26_9_diff', 'M15_scale_15min_MACD_signal_12_26_9_diff', 'M15_scale_15min_MACD_hist_12_26_9_diff', 'M15_scale_15min_RSI_basic_14_diff', 'M15_scale_15min_BB_upper_20_diff', 'M15_scale_15min_BB_middle_20_diff', 'M15_scale_15min_BB_lower_20_diff', 'M15_scale_15min_ATR_14_diff', 'M15_scale_15min_OBV_basic_diff', 'M15_scale_15min_VWAP_basic_diff', 'M15_scale_15min_Momentum_10_diff', 'M15_scale_15min_ROC_10_diff', 'M15_scale_15min_Stoch_K_14_3_3_diff', 'M15_scale_15min_Stoch_D_14_3_3_diff', 'M15_scale_15min_CCI_20_diff', 'M15_scale_15min_MFI_basic_14_diff', 'M15_scale_15min_ADX_14_diff', 'M15_scale_15min_WilliamsR_14_diff', 'M15_scale_15min_CMF_diff', 'M15_scale_15min_TMF_diff', 'M15_scale_15min_MFI_14_volume_diff', 'M15_scale_15min_KO_diff', 'M15_scale_15min_EFI_diff', 'M15_scale_15min_EOM_diff', 'M15_scale_15min_VPT_diff', 'M15_scale_15min_NVI_diff', 'M15_scale_15min_PVI_diff', 'M15_scale_15min_VFI_diff', 'M15_scale_15min_VWAP_diff', 'M15_scale_15min_Market_Facilitation_Index_diff', 'M15_scale_15min_AD_Line_diff', 'M15_scale_15min_WAD_diff', 'M15_scale_15min_EMA_15_diff', 'M15_scale_15min_EMA_21_diff', 'M15_scale_15min_EMA_50_diff', 'M15_scale_15min_EMA_100_diff', 'M15_scale_15min_EMA_200_diff', 'M15_scale_15min_RSI_3_diff', 'M15_scale_15min_RSI_7_diff', 'M15_scale_15min_RSI_14_diff', 'M15_scale_15min_RSI_3 - RSI_7', 'M15_scale_15min_RSI_3 - RSI_14', 'M15_scale_15min_RSI_7 - RSI_14', 'M15_scale_15min_MFI_3_diff', 'M15_scale_15min_MFI_7_diff', 'M15_scale_15min_MFI_14_diff', 'M15_scale_15min_MFI_3 - MFI_7', 'M15_scale_15min_MFI_3 - MFI_14', 'M15_scale_15min_MFI_7 - MFI_14', 'M15_scale_15min_OBV_diff', 'M15_scale_15min_slope_div_300_3_diff', 'M15_scale_15min_slope_signal_300_3_diff', 'M15_scale_15min_slope_angle_300_3_diff', 'M15_scale_15min_slope_angle_signal_300_3_diff', 'M15_scale_15min_slope_lin_reg_300_3_diff', 'M15_scale_15min_slope_lin_reg_signal_300_3_diff', 'M15_scale_15min_slope_div_300_6_diff', 'M15_scale_15min_slope_signal_300_6_diff', 'M15_scale_15min_slope_angle_300_6_diff', 'M15_scale_15min_slope_angle_signal_300_6_diff', 'M15_scale_15min_slope_lin_reg_300_6_diff', 'M15_scale_15min_slope_lin_reg_signal_300_6_diff', 'M15_scale_15min_slope_div_300_9_diff', 'M15_scale_15min_slope_signal_300_9_diff', 'M15_scale_15min_slope_angle_300_9_diff', 'M15_scale_15min_slope_angle_signal_300_9_diff', 'M15_scale_15min_slope_lin_reg_300_9_diff', 'M15_scale_15min_slope_lin_reg_signal_300_9_diff', 'M15_scale_15min_slope_div_600_3_diff', 'M15_scale_15min_slope_signal_600_3_diff', 'M15_scale_15min_slope_angle_600_3_diff', 'M15_scale_15min_slope_angle_signal_600_3_diff', 'M15_scale_15min_slope_lin_reg_600_3_diff', 'M15_scale_15min_slope_lin_reg_signal_600_3_diff', 'M15_scale_15min_slope_div_600_6_diff', 'M15_scale_15min_slope_signal_600_6_diff', 'M15_scale_15min_slope_angle_600_6_diff', 'M15_scale_15min_slope_angle_signal_600_6_diff', 'M15_scale_15min_slope_lin_reg_600_6_diff', 'M15_scale_15min_slope_lin_reg_signal_600_6_diff', 'M15_scale_15min_slope_div_600_9_diff', 'M15_scale_15min_slope_signal_600_9_diff', 'M15_scale_15min_slope_angle_600_9_diff', 'M15_scale_15min_slope_angle_signal_600_9_diff', 'M15_scale_15min_slope_lin_reg_600_9_diff', 'M15_scale_15min_slope_lin_reg_signal_600_9_diff', 'M15_scale_15min_slope_div_900_3_diff', 'M15_scale_15min_slope_signal_900_3_diff', 'M15_scale_15min_slope_angle_900_3_diff', 'M15_scale_15min_slope_angle_signal_900_3_diff', 'M15_scale_15min_slope_lin_reg_900_3_diff', 'M15_scale_15min_slope_lin_reg_signal_900_3_diff', 'M15_scale_15min_slope_div_900_6_diff', 'M15_scale_15min_slope_signal_900_6_diff', 'M15_scale_15min_slope_angle_900_6_diff', 'M15_scale_15min_slope_angle_signal_900_6_diff', 'M15_scale_15min_slope_lin_reg_900_6_diff', 'M15_scale_15min_slope_lin_reg_signal_900_6_diff', 'M15_scale_15min_slope_div_900_9_diff', 'M15_scale_15min_slope_signal_900_9_diff', 'M15_scale_15min_slope_angle_900_9_diff', 'M15_scale_15min_slope_angle_signal_900_9_diff', 'M15_scale_15min_slope_lin_reg_900_9_diff', 'M15_scale_15min_slope_lin_reg_signal_900_9_diff', 'M15_scale_15min_slope_div_300_3 - slope_div_300_6', 'M15_scale_15min_slope_div_300_3 - slope_div_300_9', 'M15_scale_15min_slope_div_300_3 - slope_div_600_3', 'M15_scale_15min_slope_div_300_3 - slope_div_600_6', 'M15_scale_15min_slope_div_300_3 - slope_div_600_9', 'M15_scale_15min_slope_div_300_3 - slope_div_900_3', 'M15_scale_15min_slope_div_300_3 - slope_div_900_6', 'M15_scale_15min_slope_div_300_3 - slope_div_900_9', 'M15_scale_15min_slope_div_300_6 - slope_div_300_9', 'M15_scale_15min_slope_div_300_6 - slope_div_600_3', 'M15_scale_15min_slope_div_300_6 - slope_div_600_6', 'M15_scale_15min_slope_div_300_6 - slope_div_600_9', 'M15_scale_15min_slope_div_300_6 - slope_div_900_3', 'M15_scale_15min_slope_div_300_6 - slope_div_900_6', 'M15_scale_15min_slope_div_300_6 - slope_div_900_9', 'M15_scale_15min_slope_div_300_9 - slope_div_600_3', 'M15_scale_15min_slope_div_300_9 - slope_div_600_6', 'M15_scale_15min_slope_div_300_9 - slope_div_600_9', 'M15_scale_15min_slope_div_300_9 - slope_div_900_3', 'M15_scale_15min_slope_div_300_9 - slope_div_900_6', 'M15_scale_15min_slope_div_300_9 - slope_div_900_9', 'M15_scale_15min_slope_div_600_3 - slope_div_600_6', 'M15_scale_15min_slope_div_600_3 - slope_div_600_9', 'M15_scale_15min_slope_div_600_3 - slope_div_900_3', 'M15_scale_15min_slope_div_600_3 - slope_div_900_6', 'M15_scale_15min_slope_div_600_3 - slope_div_900_9', 'M15_scale_15min_slope_div_600_6 - slope_div_600_9', 'M15_scale_15min_slope_div_600_6 - slope_div_900_3', 'M15_scale_15min_slope_div_600_6 - slope_div_900_6', 'M15_scale_15min_slope_div_600_6 - slope_div_900_9', 'M15_scale_15min_slope_div_600_9 - slope_div_900_3', 'M15_scale_15min_slope_div_600_9 - slope_div_900_6', 'M15_scale_15min_slope_div_600_9 - slope_div_900_9', 'M15_scale_15min_slope_div_900_3 - slope_div_900_6', 'M15_scale_15min_slope_div_900_3 - slope_div_900_9', 'M15_scale_15min_slope_div_900_6 - slope_div_900_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
-            "\n",
-            "NaN counts per column (sorted):\n",
-            "M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9           49\n",
-            "M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9           49\n",
-            "M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9           49\n",
-            "M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6           49\n",
-            "M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9           49\n",
-            "                                                                           ..\n",
-            "M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9     0\n",
-            "M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6     0\n",
-            "M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9     0\n",
-            "label                                                                       0\n",
-            "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9     0\n",
-            "Length: 1922, dtype: int64 \n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "### Select features containing 'diff' or '-' in their names\n",
-        "#diff_features = df.filter(regex='diff|-')\n",
-        "\n",
-        "### Create a new dataframe with the Date column, label and the selected features\n",
-        "#df_diff = pd.concat([df[['Date', 'label']], diff_features], axis=1)\n",
-        "\n",
-        "#print(\"DataFrame with difference features:\")\n",
-        "#print(df_diff.shape,'\\n')\n",
-        "#print('Label_Counts : ',df_diff.label.value_counts(),'\\n')\n",
-        "#print(list(df_diff.columns), '\\n')\n",
-        "\n",
-        "# Add NaN count per column, sorted\n",
-        "#print(\"NaN counts per column (sorted):\")\n",
-        "#print(df_diff.isnull().sum().sort_values(ascending=False), '\\n')\n",
-        "\n",
-        "#df_diff.head(5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4TPpba7UChUY",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4TPpba7UChUY",
-        "outputId": "97597da2-64f7-4d48-9f53-22766d4e9fdc"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Flipped 33857 rows with Open_Trade = -1.\n"
-          ]
-        }
-      ],
-      "source": [
-        "### Align feature directions so that shorts mirror longs\n",
-        "#if 'Open_Trade' not in df.columns:\n",
-        " #   raise KeyError(\"'Open_Trade' column is required in df to flip feature signs.\")\n",
-        "\n",
-        "### Attach the trade direction to the diff dataframe (kept for reference).\n",
-        "#df_diff = df_diff.merge(df[['Date', 'Open_Trade']], on='Date', how='left')\n",
-        "\n",
-        "### Identify feature columns to flip (exclude identifiers/targets).\n",
-        "#feature_cols = [col for col in df_diff.columns if col not in ['Date', 'label', 'Open_Trade']]\n",
-        "#short_mask = df_diff['Open_Trade'] == -1\n",
-        "\n",
-        "#if short_mask.any():\n",
-        "#    df_diff.loc[short_mask, feature_cols] = df_diff.loc[short_mask, feature_cols] * -1\n",
-        "#    print(f\"Flipped {short_mask.sum()} rows with Open_Trade = -1.\")\n",
-        "#else:\n",
-        "#    print(\"No rows with Open_Trade = -1 were found.\")\n",
-        "\n",
-        "### Reorder columns so Open_Trade stays next to the label for downstream steps.\n",
-        "#ordered_cols = ['Date', 'label', 'Open_Trade'] + [col for col in feature_cols]\n",
-        "#df_diff = df_diff[ordered_cols]\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "pQa8_4GpvRRf",
-      "metadata": {
-        "id": "pQa8_4GpvRRf"
-      },
-      "outputs": [],
-      "source": [
-        "#df = df_diff.copy()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "lBtQecOO08zB",
-      "metadata": {
-        "id": "lBtQecOO08zB"
-      },
-      "source": [
-        "## ML"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8rlkmypd9DJj",
-      "metadata": {
-        "id": "8rlkmypd9DJj"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 1. ENTRENAR Y OBTENER IMPORTANCIAS =====================\n",
-        "def compute_xgb_importance(\n",
-        "    X: pd.DataFrame,\n",
-        "    y: pd.Series,\n",
-        "    task: str = \"classification\",\n",
-        "    random_state: int = 42,\n",
-        "    **xgb_params: Any\n",
-        ") -> Tuple[pd.DataFrame, Any]:\n",
-        "    \"\"\"\n",
-        "    Entrena un modelo XGBoost y devuelve:\n",
-        "      - imp_df: DataFrame con 'feature', 'importance' y 'cum_importance'.\n",
-        "      - model : modelo ya entrenado.\n",
-        "\n",
-        "    Soporta:\n",
-        "      • Clasificación binaria o multiclase (detecta nº de clases).\n",
-        "      • Regresión (si task != 'classification').\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X : pd.DataFrame\n",
-        "        Matriz de características (sin la columna objetivo).\n",
-        "    y : pd.Series\n",
-        "        Etiquetas objetivo. Puede ser binaria (0/1) o multiclase (0..K-1).\n",
-        "    task : str, opcional\n",
-        "        \"classification\" (default) o \"regression\".\n",
-        "    random_state : int, opcional\n",
-        "        Semilla para reproducibilidad.\n",
-        "    **xgb_params : dict\n",
-        "        Parámetros adicionales para el estimador de XGBoost.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (imp_df, model)\n",
-        "        imp_df : DataFrame con importancias y su acumulado.\n",
-        "        model  : instancia entrenada de XGBClassifier / XGBRegressor.\n",
-        "    \"\"\"\n",
-        "    default_params: Dict[str, Any] = dict(\n",
-        "        n_estimators=500,\n",
-        "        max_depth=6,\n",
-        "        learning_rate=0.05,\n",
-        "        subsample=0.8,\n",
-        "        colsample_bytree=0.8,\n",
-        "        random_state=random_state,\n",
-        "        n_jobs=-1,\n",
-        "        tree_method=\"hist\",\n",
-        "    )\n",
-        "    default_params.update(xgb_params)\n",
-        "\n",
-        "    if task == \"classification\":\n",
-        "        # Detectar nº de clases\n",
-        "        classes = np.unique(y)\n",
-        "        n_classes = len(classes)\n",
-        "\n",
-        "        # XGBClassifier ajusta objetivo automáticamente, pero lo explicitamos:\n",
-        "        if n_classes > 2:\n",
-        "            default_params.setdefault(\"objective\", \"multi:softprob\")\n",
-        "            default_params.setdefault(\"num_class\", n_classes)\n",
-        "            eval_metric = \"mlogloss\"\n",
-        "        else:\n",
-        "            default_params.setdefault(\"objective\", \"binary:logistic\")\n",
-        "            eval_metric = \"logloss\"\n",
-        "\n",
-        "        model = XGBClassifier(eval_metric=eval_metric, **default_params)\n",
-        "\n",
-        "    else:\n",
-        "        model = XGBRegressor(**default_params)\n",
-        "\n",
-        "    model.fit(X, y)\n",
-        "\n",
-        "    imp_df = (\n",
-        "        pd.DataFrame({\n",
-        "            \"feature\": X.columns,\n",
-        "            \"importance\": model.feature_importances_\n",
-        "        })\n",
-        "        .sort_values(\"importance\", ascending=False)\n",
-        "        .reset_index(drop=True)\n",
-        "    )\n",
-        "    total_imp = imp_df[\"importance\"].sum()\n",
-        "    if total_imp == 0:\n",
-        "        # Evitar división por cero si el modelo devuelve todo cero (raro, pero posible)\n",
-        "        imp_df[\"cum_importance\"] = 0.0\n",
-        "    else:\n",
-        "        imp_df[\"cum_importance\"] = imp_df[\"importance\"].cumsum() / total_imp\n",
-        "\n",
-        "    return imp_df, model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3r9Di4Xx9DOU",
-      "metadata": {
-        "id": "3r9Di4Xx9DOU"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 2. SELECCIÓN DE FEATURES =====================\n",
-        "def select_features_with_importance(\n",
-        "    X: pd.DataFrame,\n",
-        "    imp_df: pd.DataFrame,\n",
-        "    top_n: Optional[int] = None,\n",
-        "    threshold: Optional[str | float] = None,\n",
-        "    cum_threshold: Optional[float] = 0.8\n",
-        ") -> Tuple[pd.DataFrame, List[str]]:\n",
-        "    \"\"\"\n",
-        "    Selección flexible de variables a partir de importancias de XGBoost.\n",
-        "\n",
-        "    Reglas:\n",
-        "      - Si top_n no es None           => usa el top_n.\n",
-        "      - Else si cum_threshold no None => usa importancia acumulada (p.ej. 0.8 = 80%).\n",
-        "      - Else usa threshold ('median', 'mean' o valor numérico).\n",
-        "\n",
-        "    Devuelve (X_reducido, lista_de_features).\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X : pd.DataFrame\n",
-        "        Matriz de características original.\n",
-        "    imp_df : pd.DataFrame\n",
-        "        DataFrame devuelto por compute_xgb_importance.\n",
-        "    top_n : int | None\n",
-        "        Número fijo de variables a conservar.\n",
-        "    threshold : str | float | None\n",
-        "        Umbral de importancia. Si str, usar 'median' o 'mean'.\n",
-        "    cum_threshold : float | None\n",
-        "        Porcentaje acumulado de importancia (0-1). Si None, se ignora.\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (X_sel, keep)\n",
-        "        X_sel : subset de X con columnas seleccionadas.\n",
-        "        keep  : lista de nombres de columnas seleccionadas.\n",
-        "    \"\"\"\n",
-        "    if top_n is not None:\n",
-        "        keep = imp_df.head(top_n)[\"feature\"].tolist()\n",
-        "\n",
-        "    elif cum_threshold is not None:\n",
-        "        keep_mask = imp_df[\"cum_importance\"] <= float(cum_threshold)\n",
-        "        keep = imp_df.loc[keep_mask, \"feature\"].tolist()\n",
-        "        # asegurar que haya al menos una más para no quedarnos exactamente en el corte\n",
-        "        if len(keep) < len(imp_df):\n",
-        "            keep.append(imp_df.iloc[len(keep)][\"feature\"])\n",
-        "\n",
-        "    else:\n",
-        "        if threshold is None:\n",
-        "            threshold = \"median\"\n",
-        "        if isinstance(threshold, str):\n",
-        "            thr_val = imp_df[\"importance\"].agg(threshold)\n",
-        "        else:\n",
-        "            thr_val = float(threshold)\n",
-        "        keep = imp_df.loc[imp_df[\"importance\"] >= thr_val, \"feature\"].tolist()\n",
-        "\n",
-        "    return X[keep], keep"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "tCDZCTz2_v9z",
-      "metadata": {
-        "id": "tCDZCTz2_v9z"
-      },
-      "outputs": [],
-      "source": [
-        "# ===================== 3. BÚSQUEDA DEL MEJOR UMBRAL ACUMULADO =====================\n",
-        "def find_best_cum_threshold(\n",
-        "    X_train: pd.DataFrame,\n",
-        "    y_train: pd.Series,\n",
-        "    X_valid: pd.DataFrame,\n",
-        "    y_valid: pd.Series,\n",
-        "    task: str = \"classification\",\n",
-        "    thresholds: Tuple[float, ...] = (0.6, 0.7, 0.8, 0.9),\n",
-        "    random_state: int = 42,\n",
-        "    metric: str = \"auto\",\n",
-        "    **xgb_params: Any\n",
-        ") -> Tuple[float, pd.DataFrame, pd.DataFrame]:\n",
-        "    \"\"\"\n",
-        "    Entrena un XGB en train, calcula importancias y prueba varios umbrales\n",
-        "    acumulados para ver cuál da la mejor métrica en valid.\n",
-        "\n",
-        "    Para CLASIFICACIÓN:\n",
-        "        - Detecta nº de clases.\n",
-        "        - Métrica por defecto (metric=\"auto\"):\n",
-        "            • Binaria: ROC-AUC (probabilidades de la clase positiva).\n",
-        "            • Multiclase: ROC-AUC macro OVR (usa predict_proba).\n",
-        "          Alternativas: metric=\"f1_macro\", \"accuracy\", \"logloss\" (se MINIMIZA).\n",
-        "    Para REGRESIÓN:\n",
-        "        - Usa R^2.\n",
-        "\n",
-        "    Devuelve:\n",
-        "        best_thr, res_df_ordenado_por_score_desc, imp_df\n",
-        "\n",
-        "    Parámetros\n",
-        "    ----------\n",
-        "    X_train, y_train, X_valid, y_valid : pd.DataFrame / pd.Series\n",
-        "        Particiones de entrenamiento y validación.\n",
-        "    task : str\n",
-        "        \"classification\" (default) o \"regression\".\n",
-        "    thresholds : tuple[float, ...]\n",
-        "        Valores de umbral de importancia acumulada a evaluar (0-1).\n",
-        "    random_state : int\n",
-        "        Semilla para reproducibilidad.\n",
-        "    metric : str\n",
-        "        \"auto\" (default), \"roc_auc\", \"f1_macro\", \"accuracy\", \"logloss\" (clasif) o \"r2\" (regresión).\n",
-        "    **xgb_params : dict\n",
-        "        Parámetros extra para el estimador de XGBoost (pasan a compute y a los modelos internos).\n",
-        "\n",
-        "    Returns\n",
-        "    -------\n",
-        "    (best_thr, res_df, imp_df)\n",
-        "        best_thr : float\n",
-        "            Umbral con mejor score (o menor logloss si metric='logloss').\n",
-        "        res_df : pd.DataFrame\n",
-        "            Tabla con resultados por umbral (n_features, score).\n",
-        "        imp_df : pd.DataFrame\n",
-        "            Importancias calculadas en X_train / y_train.\n",
-        "    \"\"\"\n",
-        "    imp_df, _ = compute_xgb_importance(\n",
-        "        X_train, y_train, task=task, random_state=random_state, **xgb_params\n",
-        "    )\n",
-        "\n",
-        "    results = []\n",
-        "\n",
-        "    # Detectar nº de clases si es clasificación\n",
-        "    if task == \"classification\":\n",
-        "        classes = np.unique(y_train)\n",
-        "        n_classes = len(classes)\n",
-        "        if metric == \"auto\":\n",
-        "            metric_to_use = \"roc_auc\" if n_classes == 2 else \"roc_auc\"\n",
-        "        else:\n",
-        "            metric_to_use = metric\n",
-        "    else:\n",
-        "        metric_to_use = \"r2\" if metric == \"auto\" else metric\n",
-        "\n",
-        "    for thr in thresholds:\n",
-        "        X_tr_sel, cols = select_features_with_importance(\n",
-        "            X_train, imp_df, cum_threshold=thr, top_n=None, threshold=None\n",
-        "        )\n",
-        "        X_va_sel = X_valid[cols]\n",
-        "\n",
-        "        if task == \"classification\":\n",
-        "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
-        "            params.update(xgb_params)\n",
-        "\n",
-        "            if n_classes > 2:\n",
-        "                params.setdefault(\"objective\", \"multi:softprob\")\n",
-        "                params.setdefault(\"num_class\", n_classes)\n",
-        "                eval_metric = \"mlogloss\"\n",
-        "            else:\n",
-        "                params.setdefault(\"objective\", \"binary:logistic\")\n",
-        "                eval_metric = \"logloss\"\n",
-        "\n",
-        "            model_sel = XGBClassifier(eval_metric=eval_metric, **params)\n",
-        "            model_sel.fit(X_tr_sel, y_train)\n",
-        "\n",
-        "            # Probabilidades y predicciones\n",
-        "            proba = model_sel.predict_proba(X_va_sel)\n",
-        "            pred  = np.argmax(proba, axis=1) if n_classes > 2 else (proba[:, 1] >= 0.5).astype(int)\n",
-        "\n",
-        "            # Calcular métrica\n",
-        "            if metric_to_use == \"roc_auc\":\n",
-        "                if n_classes == 2:\n",
-        "                    score = roc_auc_score(y_valid, proba[:, 1])\n",
-        "                else:\n",
-        "                    # AUC macro One-vs-Rest\n",
-        "                    score = roc_auc_score(y_valid, proba, multi_class=\"ovr\", average=\"macro\")\n",
-        "            elif metric_to_use == \"f1_macro\":\n",
-        "                score = f1_score(y_valid, pred, average=\"macro\")\n",
-        "            elif metric_to_use == \"accuracy\":\n",
-        "                score = accuracy_score(y_valid, pred)\n",
-        "            elif metric_to_use == \"logloss\":\n",
-        "                # En este caso, menor es mejor. Guardamos negativo para mantener criterio \"mayor mejor\".\n",
-        "                score = -log_loss(y_valid, proba, labels=np.unique(y_train))\n",
-        "            else:\n",
-        "                raise ValueError(f\"Métrica no soportada: {metric_to_use}\")\n",
-        "\n",
-        "        else:\n",
-        "            # REGRESIÓN\n",
-        "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
-        "            params.update(xgb_params)\n",
-        "            model_sel = XGBRegressor(**params)\n",
-        "            model_sel.fit(X_tr_sel, y_train)\n",
-        "            pred = model_sel.predict(X_va_sel)\n",
-        "\n",
-        "            if metric_to_use == \"r2\":\n",
-        "                score = r2_score(y_valid, pred)\n",
-        "            else:\n",
-        "                raise ValueError(f\"Métrica de regresión no soportada: {metric_to_use}\")\n",
-        "\n",
-        "        results.append({\"cum_threshold\": thr, \"n_features\": len(cols), \"score\": score})\n",
-        "\n",
-        "    # Ordenar (si usamos logloss negado, mayor sigue siendo mejor)\n",
-        "    res_df = pd.DataFrame(results).sort_values(\"score\", ascending=False).reset_index(drop=True)\n",
-        "    best_thr = float(res_df.iloc[0][\"cum_threshold\"])\n",
-        "    return best_thr, res_df, imp_df"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "R0Dm8ZPGcBr7",
-      "metadata": {
-        "id": "R0Dm8ZPGcBr7"
-      },
-      "outputs": [],
-      "source": [
-        "def remove_highly_correlated_features(df, threshold=0.9):\n",
-        "\n",
-        "    # Solo numéricos para evitar errores y acelerar\n",
-        "    corr_matrix = df.corr(numeric_only=True).abs()\n",
-        "    upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape, dtype=bool), k=1))\n",
-        "\n",
-        "    to_drop = []\n",
-        "    for col in tqdm(upper.columns, desc=f\"Pruning corr > {threshold}\", unit=\"col\", leave=False):\n",
-        "        if (upper[col] > threshold).any():\n",
-        "            to_drop.append(col)\n",
-        "\n",
-        "    return df.drop(columns=to_drop, errors=\"ignore\"), to_drop\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "WodcQEBJ_wAW",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 468,
-          "referenced_widgets": [
-            "5f836c62734d451386fd09b07cbbd5a5",
-            "63909e59276d48c6be533cb7ac6a4b51",
-            "56d0aa2bebd947769b766a99c7ab6c0e",
-            "e1af085ad9934b8599f3bb34509f3814",
-            "8786987a3a2448d5a696addc8f1ff179",
-            "2ec69da230984633b2c5bfc059c8d2c1",
-            "241af7b314f34423b4af560bcefc7007",
-            "42626100e2084ac79f1521e8d84b11b7",
-            "1f07ba6bb7864d4981aeba397cf633aa",
-            "152adcea029b4abdace26402ef4bd98d",
-            "e1d8854e112e4f608037b5080d7614e1"
-          ]
-        },
-        "id": "WodcQEBJ_wAW",
-        "outputId": "5805d7bc-9ec4-4c1c-c942-e5c1bcdaf4c7"
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "Pruning corr > 0.9:   0%|          | 0/2725 [00:00<?, ?col/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "5f836c62734d451386fd09b07cbbd5a5"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Logistic regression CV accuracy: 0.5461760141875416\n",
-            "=== Importancias XGBoost ===\n",
-            "                                     feature  importance  cum_importance\n",
-            "0            M10_raw_10min_RSI_basic_14_diff    0.016185        0.016185\n",
-            "1                M10_scale_10min_ATR_14_diff    0.010048        0.026233\n",
-            "2                                 Open_Trade    0.009153        0.035386\n",
-            "3                 M5_scale_MACD_12_26_9_diff    0.005679        0.041065\n",
-            "4                        M10_raw_10min_RSI_3    0.005639        0.046704\n",
-            "5                      M5_raw_Kal_change_300    0.005598        0.052302\n",
-            "6   M10_raw_10min_slope_lin_reg_signal_900_3    0.005403        0.057705\n",
-            "7                  M10_raw_10min_CCI_20_diff    0.005398        0.063103\n",
-            "8                   M5_raw_MACD_12_26_9_diff    0.005299        0.068401\n",
-            "9           M10_raw_10min_slope_signal_900_3    0.005195        0.073596\n",
-            "10  M10_raw_10min_slope_lin_reg_signal_900_6    0.004901        0.078497\n",
-            "11  M10_raw_10min_slope_lin_reg_signal_600_6    0.004397        0.082895\n",
-            "12                 M5_raw_slope_signal_900_9    0.004084        0.086979\n",
-            "13                      M5_scale_ATR_14_diff    0.003975        0.090954\n",
-            "14                  M5_raw_RSI_basic_14_diff    0.003938        0.094892\n",
-            "15               M10_raw_10min_RSI_3 - RSI_7    0.003851        0.098743\n",
-            "16                    M10_raw_10min_TMF_diff    0.003577        0.102319\n",
-            "17                M5_raw_Stoch_K_14_3_3_diff    0.003375        0.105694\n",
-            "18                        M5_raw_EMA_15_diff    0.003321        0.109015\n",
-            "19                     M10_raw_10min_KO_diff    0.003318        0.112333\n",
-            "Total features: 486\n",
-            "Features seleccionadas: 340\n",
-            "XGBoost CV accuracy: 0.6015960984260695\n"
-          ]
-        }
-      ],
-      "source": [
-        "# ===================== 3. PIPELINE PRINCIPAL =====================\n",
-        "df = df.dropna()\n",
-        "y = df['label']\n",
-        "X = df.iloc[:, 2:]\n",
-        "\n",
-        "# --- 3.3 Split temporal (ejemplo simple 80/20) ---\n",
-        "split_idx = int(len(X) * 0.8)\n",
-        "X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]\n",
-        "y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]\n",
-        "\n",
-        "# --- 3.4 Remove correlated features ---\n",
-        "X_train_filtered, dropped_features = remove_highly_correlated_features(X_train, threshold=0.9)\n",
-        "X_test_filtered = X_test.drop(columns=dropped_features)\n",
-        "\n",
-        "# Baseline logistic regression with time-series CV\n",
-        "scaler = StandardScaler()\n",
-        "X_scaled = scaler.fit_transform(X_train_filtered)\n",
-        "tscv = TimeSeriesSplit(n_splits=5)\n",
-        "baseline = cross_val_score(LogisticRegression(max_iter=1000), X_scaled, y_train, cv=tscv).mean()\n",
-        "print('Logistic regression CV accuracy:', baseline)\n",
-        "\n",
-        "# --- 3.5 Importancias con XGBoost ---\n",
-        "imp_df, xgb_model = compute_xgb_importance(X_train_filtered, y_train, task='classification')\n",
-        "\n",
-        "print('=== Importancias XGBoost ===')\n",
-        "print(imp_df.head(20))\n",
-        "print(f'Total features: {len(imp_df)}')\n",
-        "\n",
-        "# --- 3.6 Selección (elige una opción) ---\n",
-        "X_train_sel, keep_cols = select_features_with_importance(X_train_filtered, imp_df, cum_threshold=0.8)\n",
-        "X_test_sel = X_test_filtered[keep_cols]\n",
-        "\n",
-        "print(f'Features seleccionadas: {len(keep_cols)}')\n",
-        "importance_map = imp_df.set_index(\"feature\")[\"importance\"]\n",
-        "selected_importances = pd.DataFrame({\n",
-        "    \"feature\": keep_cols,\n",
-        "    \"importance\": importance_map.reindex(keep_cols).values\n",
-        "})\n",
-        "selected_importances.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_ImportantCols.csv', index=False)\n",
-        "\n",
-        "# Save dataset with selected features\n",
-        "df_selected = df[['Date', 'label'] + keep_cols]\n",
-        "df_selected.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_Features.csv', index=False)\n",
-        "\n",
-        "# Time-series cross-validation with XGBoost\n",
-        "xgb_cv = XGBClassifier(eval_metric='logloss', n_estimators=500, max_depth=6, learning_rate=0.05, subsample=0.8, colsample_bytree=0.8, random_state=42, n_jobs=-1, tree_method='hist')\n",
-        "xgb_scores = cross_val_score(xgb_cv, X_train_sel, y_train, cv=tscv, scoring='accuracy')\n",
-        "print('XGBoost CV accuracy:', xgb_scores.mean())\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [
-        "Ysa-7eLvEMpE",
-        "m8CIB8vltFfH",
-        "y6QRdBKwrX98",
-        "zhTndYVi1TEV",
-        "jh9-mi26wsya",
-        "Hv5bsrpc03z7",
-        "2RFfhHT2AwAJ"
-      ],
-      "gpuType": "T4",
-      "machine_shape": "hm",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.5"
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "5f836c62734d451386fd09b07cbbd5a5": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_63909e59276d48c6be533cb7ac6a4b51",
-              "IPY_MODEL_56d0aa2bebd947769b766a99c7ab6c0e",
-              "IPY_MODEL_e1af085ad9934b8599f3bb34509f3814"
-            ],
-            "layout": "IPY_MODEL_8786987a3a2448d5a696addc8f1ff179"
-          }
-        },
-        "63909e59276d48c6be533cb7ac6a4b51": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_2ec69da230984633b2c5bfc059c8d2c1",
-            "placeholder": "​",
-            "style": "IPY_MODEL_241af7b314f34423b4af560bcefc7007",
-            "value": "Pruning corr &gt; 0.9:  93%"
-          }
-        },
-        "56d0aa2bebd947769b766a99c7ab6c0e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_42626100e2084ac79f1521e8d84b11b7",
-            "max": 2725,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_1f07ba6bb7864d4981aeba397cf633aa",
-            "value": 2725
-          }
-        },
-        "e1af085ad9934b8599f3bb34509f3814": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_152adcea029b4abdace26402ef4bd98d",
-            "placeholder": "​",
-            "style": "IPY_MODEL_e1d8854e112e4f608037b5080d7614e1",
-            "value": " 2536/2725 [00:00&lt;00:00, 8538.79col/s]"
-          }
-        },
-        "8786987a3a2448d5a696addc8f1ff179": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": "hidden",
-            "width": null
-          }
-        },
-        "2ec69da230984633b2c5bfc059c8d2c1": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "241af7b314f34423b4af560bcefc7007": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "42626100e2084ac79f1521e8d84b11b7": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "1f07ba6bb7864d4981aeba397cf633aa": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "152adcea029b4abdace26402ef4bd98d": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "e1d8854e112e4f608037b5080d7614e1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bf83164c",
+   "metadata": {
+    "id": "bf83164c"
+   },
+   "source": [
+    "# Pendientes\n",
+    "\n",
+    "Nada"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "Ysa-7eLvEMpE",
+   "metadata": {
+    "id": "Ysa-7eLvEMpE"
+   },
+   "source": [
+    "# Gpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9GJAW8qAEM8f",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "9GJAW8qAEM8f",
+    "outputId": "a399319e-f240-48c9-c725-16a0184f2476"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Thu Sep 25 21:45:43 2025       \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |\n",
+      "|-----------------------------------------+------------------------+----------------------+\n",
+      "| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |\n",
+      "| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |\n",
+      "|                                         |                        |               MIG M. |\n",
+      "|=========================================+========================+======================|\n",
+      "|   0  Tesla T4                       Off |   00000000:00:04.0 Off |                    0 |\n",
+      "| N/A   35C    P8             11W /   70W |       0MiB /  15360MiB |      0%      Default |\n",
+      "|                                         |                        |                  N/A |\n",
+      "+-----------------------------------------+------------------------+----------------------+\n",
+      "                                                                                         \n",
+      "+-----------------------------------------------------------------------------------------+\n",
+      "| Processes:                                                                              |\n",
+      "|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |\n",
+      "|        ID   ID                                                               Usage      |\n",
+      "|=========================================================================================|\n",
+      "|  No running processes found                                                             |\n",
+      "+-----------------------------------------------------------------------------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "FcIdAmrNERw-",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "FcIdAmrNERw-",
+    "outputId": "97294001-26cf-4c92-851d-7fc055f6cfaf"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "tf.config.list_physical_devices('GPU')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m8CIB8vltFfH",
+   "metadata": {
+    "id": "m8CIB8vltFfH"
+   },
+   "source": [
+    "# Set_Up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "EB5RqjoAtFwl",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "EB5RqjoAtFwl",
+    "outputId": "0890d842-0745-4541-9601-3af632e44a70"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/content/drive/MyDrive/Course Folder/Forex/XAUUSD/\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "root_data = f'/content/drive/MyDrive/Course Folder/Forex/XAUUSD/'\n",
+    "print(root_data)\n",
+    "\n",
+    "direction = 'Short'\n",
+    "direction_number = -1\n",
+    "\n",
+    "symbol = 'XAUUSD'\n",
+    "strategy = 'Kalman'\n",
+    "time_frame = 'M5'\n",
+    "\n",
+    "trade_evolution = 'st_Max'\n",
+    "result_field = 'st_PnL'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "y6QRdBKwrX98",
+   "metadata": {
+    "id": "y6QRdBKwrX98"
+   },
+   "source": [
+    "# Libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "R9bTNmBwK_Up",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "R9bTNmBwK_Up",
+    "outputId": "b86df12c-9494-4628-861b-4feae0317865"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting ta-lib\n",
+      "  Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (24 kB)\n",
+      "Requirement already satisfied: build in /usr/local/lib/python3.12/dist-packages (from ta-lib) (1.3.0)\n",
+      "Requirement already satisfied: cython in /usr/local/lib/python3.12/dist-packages (from ta-lib) (3.0.12)\n",
+      "Requirement already satisfied: numpy in /usr/local/lib/python3.12/dist-packages (from ta-lib) (2.0.2)\n",
+      "Requirement already satisfied: packaging>=19.1 in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (25.0)\n",
+      "Requirement already satisfied: pyproject_hooks in /usr/local/lib/python3.12/dist-packages (from build->ta-lib) (1.2.0)\n",
+      "Downloading ta_lib-0.6.7-cp312-cp312-manylinux_2_28_x86_64.whl (4.1 MB)\n",
+      "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/4.1 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[91m╸\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m227.0 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.1/4.1 MB\u001b[0m \u001b[31m115.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: ta-lib\n",
+      "Successfully installed ta-lib-0.6.7\n",
+      "0.6.7\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install ta-lib\n",
+    "import talib as ta\n",
+    "print(ta.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bda1a01c",
+   "metadata": {
+    "id": "bda1a01c"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import joblib\n",
+    "import math\n",
+    "import time\n",
+    "\n",
+    "from itertools import combinations, product\n",
+    "\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import Dense\n",
+    "\n",
+    "from sklearn.cluster import KMeans\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.feature_selection import RFECV\n",
+    "from sklearn.model_selection import StratifiedKFold\n",
+    "from sklearn.feature_selection import SelectFromModel\n",
+    "from sklearn.metrics import roc_auc_score, r2_score\n",
+    "from sklearn.model_selection import TimeSeriesSplit\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "\n",
+    "from scipy.cluster.hierarchy import linkage, fcluster\n",
+    "from scipy.spatial.distance import squareform\n",
+    "\n",
+    "from xgboost import XGBClassifier, XGBRegressor\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "from __future__ import annotations\n",
+    "from typing import Tuple, List, Optional, Dict, Any, Union\n",
+    "\n",
+    "from xgboost import XGBClassifier, XGBRegressor\n",
+    "from sklearn.metrics import (roc_auc_score, f1_score, accuracy_score, log_loss, r2_score)\n",
+    "\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7JweuZy755ym",
+   "metadata": {
+    "id": "7JweuZy755ym"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "plt.style.use(\"seaborn-v0_8-darkgrid\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "KFfn45ty82qv",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "KFfn45ty82qv",
+    "outputId": "c553119e-49e8-4345-a6ed-6bd4e69be76a"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mounted at /content/drive\n"
+     ]
+    }
+   ],
+   "source": [
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9aa65d54",
+   "metadata": {
+    "id": "9aa65d54"
+   },
+   "source": [
+    "# Calculate_Features\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "I23127P7lBq_",
+   "metadata": {
+    "id": "I23127P7lBq_"
+   },
+   "source": [
+    "## Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "kp4yJdGAjoeA",
+   "metadata": {
+    "id": "kp4yJdGAjoeA"
+   },
+   "outputs": [],
+   "source": [
+    "def kalman_line(source, kalman_length: int, smooth: int):\n",
+    "    \"\"\"\n",
+    "    Pine -> Python (solo 'kalman_line'), replicando la EMA de TradingView con\n",
+    "    *semilla SMA* (como ta.ema) sobre el núcleo Kalman kf_c.\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    source : pd.Series o array-like de floats (precio crudo, sin diff/returns)\n",
+    "    kalman_length : int   (equivale a length_kal en Pine)\n",
+    "    smooth : int          (equivale a smooth_kal en Pine -> ta.ema(kf_c, smooth))\n",
+    "\n",
+    "    Retorna\n",
+    "    -------\n",
+    "    Mismo tipo que `source`: pd.Series o np.ndarray con la línea Kalman suavizada.\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    # normalizamos tipos\n",
+    "    is_series = hasattr(source, \"index\")\n",
+    "    idx = source.index if is_series else None\n",
+    "    x = np.asarray(source, dtype=np.float64)\n",
+    "    n = x.shape[0]\n",
+    "    if n == 0:\n",
+    "        return source\n",
+    "\n",
+    "    # ---------- núcleo Kalman idéntico al Pine ----------\n",
+    "    sqrt_term   = np.sqrt((kalman_length / 10000.0) * 2.0)\n",
+    "    length_term = kalman_length / 10000.0\n",
+    "\n",
+    "    kf_c   = np.empty(n, dtype=np.float64)\n",
+    "    velo_c = np.empty(n, dtype=np.float64)\n",
+    "\n",
+    "    # bar 0 (nz(kf_c[1], source) y nz(velo_c[1], 0))\n",
+    "    kf_c[0] = x[0]\n",
+    "    velo_c[0] = 0.0\n",
+    "\n",
+    "    for i in range(1, n):\n",
+    "        prev_kf = kf_c[i - 1]\n",
+    "        dk_c = x[i] - prev_kf\n",
+    "        smooth_c = prev_kf + dk_c * sqrt_term\n",
+    "        velo_c[i] = velo_c[i - 1] + length_term * dk_c\n",
+    "        kf_c[i] = smooth_c + velo_c[i]\n",
+    "\n",
+    "    # ---------- EMA con semilla SMA (comportamiento ta.ema de TV) ----------\n",
+    "    L = int(max(1, smooth))\n",
+    "    alpha = 2.0 / (L + 1.0)\n",
+    "    ema = np.full(n, np.nan, dtype=np.float64)\n",
+    "\n",
+    "    if n < L:\n",
+    "        # con pocas barras, igualamos al promedio simple disponible\n",
+    "        ema[-1] = np.nanmean(kf_c)\n",
+    "    else:\n",
+    "        # seed = SMA de las primeras L barras\n",
+    "        seed = np.mean(kf_c[:L])\n",
+    "        ema[L - 1] = seed\n",
+    "        for i in range(L, n):\n",
+    "            ema[i] = alpha * kf_c[i] + (1.0 - alpha) * ema[i - 1]\n",
+    "\n",
+    "    return (pd.Series(ema, index=idx) if is_series else ema)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e07e51fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_features(\n",
+    "    stock_data: pd.DataFrame,\n",
+    "    return_components: bool = False\n",
+    ") -> Union[pd.DataFrame, Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]]:\n",
+    "\n",
+    "    periods        = [3, 7, 14]\n",
+    "    kalman_periods = [300, 600, 900]\n",
+    "\n",
+    "    component_frames: Dict[str, pd.DataFrame] = {}\n",
+    "\n",
+    "    def _unique_pairwise(columns: List[str]) -> List[Tuple[str, str]]:\n",
+    "        \"\"\"Return ordered unique column pairs without self-pairings.\"\"\"\n",
+    "        unique_columns = list(dict.fromkeys(columns))\n",
+    "        return list(combinations(unique_columns, 2))\n",
+    "\n",
+    "    # ───────────────────────── Kalman y derivados ───────────────────────\n",
+    "    t0 = time.time()\n",
+    "    kal_cols = []\n",
+    "    kalman_features = pd.DataFrame(index=stock_data.index)\n",
+    "    kalman_900_series: Optional[pd.Series] = None\n",
+    "    for period in tqdm(kalman_periods, desc=\"Kalman & Derivatives\"):\n",
+    "        kal = pd.Series(\n",
+    "            kalman_line(stock_data['Close'], kalman_length=period, smooth=3),\n",
+    "            index=stock_data.index\n",
+    "        )\n",
+    "        kname = f'Kal_{period}'\n",
+    "        kal_cols.append(kname)\n",
+    "\n",
+    "        kalman_features[kname] = kal\n",
+    "        if period == 900:\n",
+    "            kalman_900_series = kal\n",
+    "\n",
+    "        kalman_features[f'Close_Kal_{period}']  = stock_data['Close'] - kal\n",
+    "        kalman_features[f'Kal_change_{period}'] = kal.diff(1)\n",
+    "\n",
+    "    kal_pairs = _unique_pairwise(kal_cols)\n",
+    "    for c1, c2 in tqdm(kal_pairs, desc=\"Kalman pairwise\"):\n",
+    "        kalman_features[f'{c1}_minus_{c2}'] = kalman_features[c1] - kalman_features[c2]\n",
+    "\n",
+    "    tqdm.write(f\"[Timing] Kalman block: {time.time()-t0:.2f}s\")\n",
+    "    component_frames['Kalman'] = kalman_features.copy()\n",
+    "    features = kalman_features.copy()\n",
+    "\n",
+    "    # ───────────────────────── RSI (Close & Kalman_900) ────────────────────\n",
+    "    t0 = time.time()\n",
+    "    rsi_features = pd.DataFrame(index=stock_data.index)\n",
+    "    rsi_sources: Dict[str, pd.Series] = {'Close': stock_data['Close']}\n",
+    "    if kalman_900_series is not None:\n",
+    "        rsi_sources['Kalman_900'] = kalman_900_series\n",
+    "\n",
+    "    for source_name, series in rsi_sources.items():\n",
+    "        rsi_cols: List[str] = []\n",
+    "        for period in tqdm(periods, desc=f\"RSI ({source_name})\", leave=False):\n",
+    "            if source_name == 'Close':\n",
+    "                col_name = f'RSI_{period}'\n",
+    "            else:\n",
+    "                col_name = f'RSI_{source_name}_{period}'\n",
+    "            rsi_features[col_name] = ta.RSI(series, timeperiod=period)\n",
+    "            rsi_cols.append(col_name)\n",
+    "\n",
+    "        for col in tqdm(rsi_cols, desc=f\"RSI ({source_name}) diffs\", leave=False):\n",
+    "            rsi_features[f'{col}_diff'] = rsi_features[col].diff()\n",
+    "\n",
+    "        for col1, col2 in tqdm(_unique_pairwise(rsi_cols), desc=f\"RSI ({source_name}) pairwise\", leave=False):\n",
+    "            rsi_features[f'{col1} - {col2}'] = rsi_features[col1] - rsi_features[col2]\n",
+    "\n",
+    "    tqdm.write(f\"[Timing] RSI block: {time.time()-t0:.2f}s\")\n",
+    "    component_frames['RSI'] = rsi_features.copy()\n",
+    "    features = pd.concat([features, rsi_features], axis=1)\n",
+    "\n",
+    "    if return_components:\n",
+    "        component_frames['Create_Features'] = features.copy()\n",
+    "        return features, component_frames\n",
+    "\n",
+    "    return features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "1e0c0f79",
+   "metadata": {
+    "id": "1e0c0f79"
+   },
+   "outputs": [],
+   "source": [
+    "def scale_feature_block(features: pd.DataFrame, window: int = 200) -> pd.DataFrame:\n",
+    "    \"\"\"Scale features using a rolling window standardization.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    features : pd.DataFrame\n",
+    "        Feature block to scale.\n",
+    "    window : int, optional\n",
+    "        Rolling window size, by default 200.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pd.DataFrame\n",
+    "        Scaled feature block preserving the original index.\n",
+    "    \"\"\"\n",
+    "    if features.empty:\n",
+    "        return features.copy()\n",
+    "\n",
+    "    scaled = features.copy()\n",
+    "    rolling = scaled.rolling(window)\n",
+    "    scaled = (scaled - rolling.mean()) / rolling.std()\n",
+    "    return scaled\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DoqqPJxPxnBF",
+   "metadata": {
+    "id": "DoqqPJxPxnBF"
+   },
+   "source": [
+    "## 5_min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d7l7vt7QxvyC",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 324
+    },
+    "id": "d7l7vt7QxvyC",
+    "outputId": "6631bd4e-4408-411e-fed4-d3fe055b5f4d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min_Date :  2024-11-08 21:20:00\n",
+      "Min_Date :  2025-07-25 23:55:00\n",
+      "Number_Rows =  50000\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.google.colaboratory.intrinsic+json": {
+       "summary": "{\n  \"name\": \"df_5min\",\n  \"rows\": 5,\n  \"fields\": [\n    {\n      \"column\": \"Date\",\n      \"properties\": {\n        \"dtype\": \"date\",\n        \"min\": \"2025-07-25 23:35:00\",\n        \"max\": \"2025-07-25 23:55:00\",\n        \"num_unique_values\": 5,\n        \"samples\": [\n          \"2025-07-25 23:40:00\",\n          \"2025-07-25 23:55:00\",\n          \"2025-07-25 23:45:00\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Open\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1397894542414626,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.81,\n          3336.52,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"High\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.132263220280441,\n        \"min\": 3336.86,\n        \"max\": 3339.14,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.92,\n          3336.88,\n          3338.69\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Low\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.8069696400732905,\n        \"min\": 3336.12,\n        \"max\": 3338.04,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3337.56,\n          3336.44,\n          3336.64\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Close\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1.1374313166077035,\n        \"min\": 3336.52,\n        \"max\": 3338.81,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          3338.69,\n          3336.8,\n          3336.73\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Volume\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 50,\n        \"min\": 82,\n        \"max\": 197,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          194,\n          82,\n          195\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Spread\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 19,\n        \"min\": 5,\n        \"max\": 40,\n        \"num_unique_values\": 2,\n        \"samples\": [\n          40,\n          5\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
+       "type": "dataframe"
+      },
+      "text/html": [
+       "\n",
+       "  <div id=\"df-27443eb1-e42b-4b98-913f-742dbafd3d8e\" class=\"colab-df-container\">\n",
+       "    <div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Open</th>\n",
+       "      <th>High</th>\n",
+       "      <th>Low</th>\n",
+       "      <th>Close</th>\n",
+       "      <th>Volume</th>\n",
+       "      <th>Spread</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:35:00</th>\n",
+       "      <td>3338.59</td>\n",
+       "      <td>3339.14</td>\n",
+       "      <td>3338.04</td>\n",
+       "      <td>3338.81</td>\n",
+       "      <td>197</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:40:00</th>\n",
+       "      <td>3338.81</td>\n",
+       "      <td>3338.92</td>\n",
+       "      <td>3337.56</td>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>194</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:45:00</th>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>3338.69</td>\n",
+       "      <td>3336.64</td>\n",
+       "      <td>3336.73</td>\n",
+       "      <td>195</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:50:00</th>\n",
+       "      <td>3336.73</td>\n",
+       "      <td>3336.86</td>\n",
+       "      <td>3336.12</td>\n",
+       "      <td>3336.52</td>\n",
+       "      <td>192</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-07-25 23:55:00</th>\n",
+       "      <td>3336.52</td>\n",
+       "      <td>3336.88</td>\n",
+       "      <td>3336.44</td>\n",
+       "      <td>3336.80</td>\n",
+       "      <td>82</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>\n",
+       "    <div class=\"colab-df-buttons\">\n",
+       "\n",
+       "  <div class=\"colab-df-container\">\n",
+       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-27443eb1-e42b-4b98-913f-742dbafd3d8e')\"\n",
+       "            title=\"Convert this dataframe to an interactive table.\"\n",
+       "            style=\"display:none;\">\n",
+       "\n",
+       "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+       "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+       "  </svg>\n",
+       "    </button>\n",
+       "\n",
+       "  <style>\n",
+       "    .colab-df-container {\n",
+       "      display:flex;\n",
+       "      gap: 12px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert {\n",
+       "      background-color: #E8F0FE;\n",
+       "      border: none;\n",
+       "      border-radius: 50%;\n",
+       "      cursor: pointer;\n",
+       "      display: none;\n",
+       "      fill: #1967D2;\n",
+       "      height: 32px;\n",
+       "      padding: 0 0 0 0;\n",
+       "      width: 32px;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-convert:hover {\n",
+       "      background-color: #E2EBFA;\n",
+       "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "      fill: #174EA6;\n",
+       "    }\n",
+       "\n",
+       "    .colab-df-buttons div {\n",
+       "      margin-bottom: 4px;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert {\n",
+       "      background-color: #3B4455;\n",
+       "      fill: #D2E3FC;\n",
+       "    }\n",
+       "\n",
+       "    [theme=dark] .colab-df-convert:hover {\n",
+       "      background-color: #434B5C;\n",
+       "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+       "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+       "      fill: #FFFFFF;\n",
+       "    }\n",
+       "  </style>\n",
+       "\n",
+       "    <script>\n",
+       "      const buttonEl =\n",
+       "        document.querySelector('#df-27443eb1-e42b-4b98-913f-742dbafd3d8e button.colab-df-convert');\n",
+       "      buttonEl.style.display =\n",
+       "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "\n",
+       "      async function convertToInteractive(key) {\n",
+       "        const element = document.querySelector('#df-27443eb1-e42b-4b98-913f-742dbafd3d8e');\n",
+       "        const dataTable =\n",
+       "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+       "                                                    [key], {});\n",
+       "        if (!dataTable) return;\n",
+       "\n",
+       "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+       "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+       "          + ' to learn more about interactive tables.';\n",
+       "        element.innerHTML = '';\n",
+       "        dataTable['output_type'] = 'display_data';\n",
+       "        await google.colab.output.renderOutput(dataTable, element);\n",
+       "        const docLink = document.createElement('div');\n",
+       "        docLink.innerHTML = docLinkHtml;\n",
+       "        element.appendChild(docLink);\n",
+       "      }\n",
+       "    </script>\n",
+       "  </div>\n",
+       "\n",
+       "\n",
+       "    <div id=\"df-557978d1-a72f-4d4e-acd1-1cece514161a\">\n",
+       "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-557978d1-a72f-4d4e-acd1-1cece514161a')\"\n",
+       "                title=\"Suggest charts\"\n",
+       "                style=\"display:none;\">\n",
+       "\n",
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+       "     width=\"24px\">\n",
+       "    <g>\n",
+       "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+       "    </g>\n",
+       "</svg>\n",
+       "      </button>\n",
+       "\n",
+       "<style>\n",
+       "  .colab-df-quickchart {\n",
+       "      --bg-color: #E8F0FE;\n",
+       "      --fill-color: #1967D2;\n",
+       "      --hover-bg-color: #E2EBFA;\n",
+       "      --hover-fill-color: #174EA6;\n",
+       "      --disabled-fill-color: #AAA;\n",
+       "      --disabled-bg-color: #DDD;\n",
+       "  }\n",
+       "\n",
+       "  [theme=dark] .colab-df-quickchart {\n",
+       "      --bg-color: #3B4455;\n",
+       "      --fill-color: #D2E3FC;\n",
+       "      --hover-bg-color: #434B5C;\n",
+       "      --hover-fill-color: #FFFFFF;\n",
+       "      --disabled-bg-color: #3B4455;\n",
+       "      --disabled-fill-color: #666;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart {\n",
+       "    background-color: var(--bg-color);\n",
+       "    border: none;\n",
+       "    border-radius: 50%;\n",
+       "    cursor: pointer;\n",
+       "    display: none;\n",
+       "    fill: var(--fill-color);\n",
+       "    height: 32px;\n",
+       "    padding: 0;\n",
+       "    width: 32px;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart:hover {\n",
+       "    background-color: var(--hover-bg-color);\n",
+       "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+       "    fill: var(--button-hover-fill-color);\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-quickchart-complete:disabled,\n",
+       "  .colab-df-quickchart-complete:disabled:hover {\n",
+       "    background-color: var(--disabled-bg-color);\n",
+       "    fill: var(--disabled-fill-color);\n",
+       "    box-shadow: none;\n",
+       "  }\n",
+       "\n",
+       "  .colab-df-spinner {\n",
+       "    border: 2px solid var(--fill-color);\n",
+       "    border-color: transparent;\n",
+       "    border-bottom-color: var(--fill-color);\n",
+       "    animation:\n",
+       "      spin 1s steps(1) infinite;\n",
+       "  }\n",
+       "\n",
+       "  @keyframes spin {\n",
+       "    0% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "      border-left-color: var(--fill-color);\n",
+       "    }\n",
+       "    20% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    30% {\n",
+       "      border-color: transparent;\n",
+       "      border-left-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    40% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-top-color: var(--fill-color);\n",
+       "    }\n",
+       "    60% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "    }\n",
+       "    80% {\n",
+       "      border-color: transparent;\n",
+       "      border-right-color: var(--fill-color);\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "    90% {\n",
+       "      border-color: transparent;\n",
+       "      border-bottom-color: var(--fill-color);\n",
+       "    }\n",
+       "  }\n",
+       "</style>\n",
+       "\n",
+       "      <script>\n",
+       "        async function quickchart(key) {\n",
+       "          const quickchartButtonEl =\n",
+       "            document.querySelector('#' + key + ' button');\n",
+       "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+       "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+       "          try {\n",
+       "            const charts = await google.colab.kernel.invokeFunction(\n",
+       "                'suggestCharts', [key], {});\n",
+       "          } catch (error) {\n",
+       "            console.error('Error during call to suggestCharts:', error);\n",
+       "          }\n",
+       "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+       "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+       "        }\n",
+       "        (() => {\n",
+       "          let quickchartButtonEl =\n",
+       "            document.querySelector('#df-557978d1-a72f-4d4e-acd1-1cece514161a button');\n",
+       "          quickchartButtonEl.style.display =\n",
+       "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+       "        })();\n",
+       "      </script>\n",
+       "    </div>\n",
+       "\n",
+       "    </div>\n",
+       "  </div>\n"
+      ],
+      "text/plain": [
+       "                        Open     High      Low    Close  Volume  Spread\n",
+       "Date                                                                   \n",
+       "2025-07-25 23:35:00  3338.59  3339.14  3338.04  3338.81     197       5\n",
+       "2025-07-25 23:40:00  3338.81  3338.92  3337.56  3338.69     194       5\n",
+       "2025-07-25 23:45:00  3338.69  3338.69  3336.64  3336.73     195      40\n",
+       "2025-07-25 23:50:00  3336.73  3336.86  3336.12  3336.52     192      40\n",
+       "2025-07-25 23:55:00  3336.52  3336.88  3336.44  3336.80      82      40"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Read the CSV file\n",
+    "df_5min = pd.read_csv(root_data + 'Data/'+symbol+'_M5.csv', index_col=0)\n",
+    "df_5min.index = pd.to_datetime(df_5min.index)\n",
+    "df_5min = df_5min.iloc[-50000:,]\n",
+    "\n",
+    "print('Min_Date : ', df_5min.index.min())\n",
+    "print('Min_Date : ', df_5min.index.max())\n",
+    "print('Number_Rows = ',len(df_5min.index))\n",
+    "print('\\n')\n",
+    "\n",
+    "df_5min.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "HBicVZcDx2CF",
+   "metadata": {
+    "id": "HBicVZcDx2CF"
+   },
+   "source": [
+    "**Features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "XxU4wllsEUcN",
+   "metadata": {
+    "id": "XxU4wllsEUcN"
+   },
+   "outputs": [],
+   "source": [
+    "start_time = time.time()\n",
+    "\n",
+    "features_5min_raw, components_5min = create_features(df_5min, return_components=True)\n",
+    "features_5min_raw = features_5min_raw.dropna()\n",
+    "valid_index_5min = features_5min_raw.index\n",
+    "\n",
+    "# Align every component to the valid index coming from the full feature set\n",
+    "m5_raw_blocks: Dict[str, pd.DataFrame] = {name: frame.loc[valid_index_5min].copy()\n",
+    "                                           for name, frame in components_5min.items()}\n",
+    "m5_raw_blocks['Create_Features'] = features_5min_raw\n",
+    "\n",
+    "m5_scaled_blocks: Dict[str, pd.DataFrame] = {}\n",
+    "m5_raw_paths: Dict[str, str] = {}\n",
+    "m5_scaled_paths: Dict[str, str] = {}\n",
+    "\n",
+    "for name, frame in m5_raw_blocks.items():\n",
+    "    filename_raw = f\"{symbol}_M5_{name}_Raw_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Raw_Features.csv\"\n",
+    "    raw_path = os.path.join(root_data, 'Results', filename_raw)\n",
+    "    frame.to_csv(raw_path)\n",
+    "    m5_raw_paths[name] = raw_path\n",
+    "\n",
+    "    scaled_frame = scale_feature_block(frame)\n",
+    "    m5_scaled_blocks[name] = scaled_frame\n",
+    "    filename_scale = f\"{symbol}_M5_{name}_Scale_Features.csv\" if name != 'Create_Features' else f\"{symbol}_M5_Scale_Features.csv\"\n",
+    "    scale_path = os.path.join(root_data, 'Results', filename_scale)\n",
+    "    scaled_frame.to_csv(scale_path)\n",
+    "    m5_scaled_paths[name] = scale_path\n",
+    "\n",
+    "execution_time = time.time() - start_time\n",
+    "\n",
+    "print(f\"Number of features are: {features_5min_raw.shape[1]}\")\n",
+    "print(features_5min_raw.shape)\n",
+    "print(f\"Execution time: {execution_time:.2f} seconds\")\n",
+    "print(f\"Saved {len(m5_raw_blocks) * 2} DataFrames for the M5 timeframe.\")\n",
+    "features_5min_raw.tail(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "7Vw_2C-ZEO57",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "7Vw_2C-ZEO57",
+    "outputId": "68b5b48f-0948-4a38-c1e6-e1669b0aa9e6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NaN counts per column (sorted):\n",
+      "slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9    0\n",
+      "Kal_300                                                    0\n",
+      "Close_Kal_300                                              0\n",
+      "Kal_change_300                                             0\n",
+      "Kal_prev_minus_now_300                                     0\n",
+      "                                                          ..\n",
+      "Kal_change_900                                             0\n",
+      "Kal_prev_minus_now_900                                     0\n",
+      "Kal_prev2_minus_now_900                                    0\n",
+      "Kal_change2_900                                            0\n",
+      "Kal_300_minus_Kal_600                                      0\n",
+      "Length: 363, dtype: int64 \n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(m5_raw_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "j4AwNJic6icv",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "j4AwNJic6icv",
+    "outputId": "b03aa827-f15c-42a7-804f-a0508c9e998d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved raw feature files:\n",
+      " - Slope: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_M5_Slope_Raw_Features.csv\n",
+      " - Create_Features: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_M5_Raw_Features.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Saved raw feature files:\")\n",
+    "for name, path in m5_raw_paths.items():\n",
+    "    print(f\" - {name}: {path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "71edtpuJ4Y-E",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "71edtpuJ4Y-E",
+    "outputId": "6a15ce4a-64bf-49f4-c081-68d15162dd09"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Kal_300', 'Close_Kal_300', 'Kal_change_300', 'Kal_prev_minus_now_300', 'Kal_prev2_minus_now_300', 'Kal_change2_300', 'Kal_600', 'Close_Kal_600', 'Kal_change_600', 'Kal_prev_minus_now_600', 'Kal_prev2_minus_now_600', 'Kal_change2_600', 'Kal_900', 'Close_Kal_900', 'Kal_change_900', 'Kal_prev_minus_now_900', 'Kal_prev2_minus_now_900', 'Kal_change2_900', 'Kal_300_minus_Kal_600', 'Kal_300_minus_Kal_900', 'Kal_600_minus_Kal_900', 'RSI_3', 'RSI_7', 'RSI_14', 'RSI_3_diff', 'RSI_7_diff', 'RSI_14_diff', 'RSI_3 - RSI_7', 'RSI_3 - RSI_14', 'RSI_7 - RSI_14', 'RSI_Kalman_900_3', 'RSI_Kalman_900_7', 'RSI_Kalman_900_14', 'RSI_Kalman_900_3_diff', 'RSI_Kalman_900_7_diff', 'RSI_Kalman_900_14_diff', 'RSI_Kalman_900_3 - RSI_Kalman_900_7', 'RSI_Kalman_900_3 - RSI_Kalman_900_14', 'RSI_Kalman_900_7 - RSI_Kalman_900_14', 'slope_div_300_3', 'slope_div_300_3_diff', 'slope_signal_300_3', 'slope_signal_300_3_diff', 'slope_angle_300_3', 'slope_angle_300_3_diff', 'slope_angle_signal_300_3', 'slope_angle_signal_300_3_diff', 'slope_lin_reg_300_3', 'slope_lin_reg_300_3_diff', 'slope_lin_reg_signal_300_3', 'slope_lin_reg_signal_300_3_diff', 'slope_div_300_6', 'slope_div_300_6_diff', 'slope_signal_300_6', 'slope_signal_300_6_diff', 'slope_angle_300_6', 'slope_angle_300_6_diff', 'slope_angle_signal_300_6', 'slope_angle_signal_300_6_diff', 'slope_lin_reg_300_6', 'slope_lin_reg_300_6_diff', 'slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_6_diff', 'slope_div_300_9', 'slope_div_300_9_diff', 'slope_signal_300_9', 'slope_signal_300_9_diff', 'slope_angle_300_9', 'slope_angle_300_9_diff', 'slope_angle_signal_300_9', 'slope_angle_signal_300_9_diff', 'slope_lin_reg_300_9', 'slope_lin_reg_300_9_diff', 'slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_9_diff', 'slope_div_600_3', 'slope_div_600_3_diff', 'slope_signal_600_3', 'slope_signal_600_3_diff', 'slope_angle_600_3', 'slope_angle_600_3_diff', 'slope_angle_signal_600_3', 'slope_angle_signal_600_3_diff', 'slope_lin_reg_600_3', 'slope_lin_reg_600_3_diff', 'slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_600_3_diff', 'slope_div_600_6', 'slope_div_600_6_diff', 'slope_signal_600_6', 'slope_signal_600_6_diff', 'slope_angle_600_6', 'slope_angle_600_6_diff', 'slope_angle_signal_600_6', 'slope_angle_signal_600_6_diff', 'slope_lin_reg_600_6', 'slope_lin_reg_600_6_diff', 'slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_6_diff', 'slope_div_600_9', 'slope_div_600_9_diff', 'slope_signal_600_9', 'slope_signal_600_9_diff', 'slope_angle_600_9', 'slope_angle_600_9_diff', 'slope_angle_signal_600_9', 'slope_angle_signal_600_9_diff', 'slope_lin_reg_600_9', 'slope_lin_reg_600_9_diff', 'slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_9_diff', 'slope_div_900_3', 'slope_div_900_3_diff', 'slope_signal_900_3', 'slope_signal_900_3_diff', 'slope_angle_900_3', 'slope_angle_900_3_diff', 'slope_angle_signal_900_3', 'slope_angle_signal_900_3_diff', 'slope_lin_reg_900_3', 'slope_lin_reg_900_3_diff', 'slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_900_3_diff', 'slope_div_900_6', 'slope_div_900_6_diff', 'slope_signal_900_6', 'slope_signal_900_6_diff', 'slope_angle_900_6', 'slope_angle_900_6_diff', 'slope_angle_signal_900_6', 'slope_angle_signal_900_6_diff', 'slope_lin_reg_900_6', 'slope_lin_reg_900_6_diff', 'slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_6_diff', 'slope_div_900_9', 'slope_div_900_9_diff', 'slope_signal_900_9', 'slope_signal_900_9_diff', 'slope_angle_900_9', 'slope_angle_900_9_diff', 'slope_angle_signal_900_9', 'slope_angle_signal_900_9_diff', 'slope_lin_reg_900_9', 'slope_lin_reg_900_9_diff', 'slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_9_diff', 'slope_div_300_3 - slope_div_300_6', 'slope_div_300_3 - slope_div_300_9', 'slope_div_300_3 - slope_div_600_3', 'slope_div_300_3 - slope_div_600_6', 'slope_div_300_3 - slope_div_600_9', 'slope_div_300_3 - slope_div_900_3', 'slope_div_300_3 - slope_div_900_6', 'slope_div_300_3 - slope_div_900_9', 'slope_div_300_6 - slope_div_300_9', 'slope_div_300_6 - slope_div_600_3', 'slope_div_300_6 - slope_div_600_6', 'slope_div_300_6 - slope_div_600_9', 'slope_div_300_6 - slope_div_900_3', 'slope_div_300_6 - slope_div_900_6', 'slope_div_300_6 - slope_div_900_9', 'slope_div_300_9 - slope_div_600_3', 'slope_div_300_9 - slope_div_600_6', 'slope_div_300_9 - slope_div_600_9', 'slope_div_300_9 - slope_div_900_3', 'slope_div_300_9 - slope_div_900_6', 'slope_div_300_9 - slope_div_900_9', 'slope_div_600_3 - slope_div_600_6', 'slope_div_600_3 - slope_div_600_9', 'slope_div_600_3 - slope_div_900_3', 'slope_div_600_3 - slope_div_900_6', 'slope_div_600_3 - slope_div_900_9', 'slope_div_600_6 - slope_div_600_9', 'slope_div_600_6 - slope_div_900_3', 'slope_div_600_6 - slope_div_900_6', 'slope_div_600_6 - slope_div_900_9', 'slope_div_600_9 - slope_div_900_3', 'slope_div_600_9 - slope_div_900_6', 'slope_div_600_9 - slope_div_900_9', 'slope_div_900_3 - slope_div_900_6', 'slope_div_900_3 - slope_div_900_9', 'slope_div_900_6 - slope_div_900_9', 'slope_signal_300_3 - slope_signal_300_6', 'slope_signal_300_3 - slope_signal_300_9', 'slope_signal_300_3 - slope_signal_600_3', 'slope_signal_300_3 - slope_signal_600_6', 'slope_signal_300_3 - slope_signal_600_9', 'slope_signal_300_3 - slope_signal_900_3', 'slope_signal_300_3 - slope_signal_900_6', 'slope_signal_300_3 - slope_signal_900_9', 'slope_signal_300_6 - slope_signal_300_9', 'slope_signal_300_6 - slope_signal_600_3', 'slope_signal_300_6 - slope_signal_600_6', 'slope_signal_300_6 - slope_signal_600_9', 'slope_signal_300_6 - slope_signal_900_3', 'slope_signal_300_6 - slope_signal_900_6', 'slope_signal_300_6 - slope_signal_900_9', 'slope_signal_300_9 - slope_signal_600_3', 'slope_signal_300_9 - slope_signal_600_6', 'slope_signal_300_9 - slope_signal_600_9', 'slope_signal_300_9 - slope_signal_900_3', 'slope_signal_300_9 - slope_signal_900_6', 'slope_signal_300_9 - slope_signal_900_9', 'slope_signal_600_3 - slope_signal_600_6', 'slope_signal_600_3 - slope_signal_600_9', 'slope_signal_600_3 - slope_signal_900_3', 'slope_signal_600_3 - slope_signal_900_6', 'slope_signal_600_3 - slope_signal_900_9', 'slope_signal_600_6 - slope_signal_600_9', 'slope_signal_600_6 - slope_signal_900_3', 'slope_signal_600_6 - slope_signal_900_6', 'slope_signal_600_6 - slope_signal_900_9', 'slope_signal_600_9 - slope_signal_900_3', 'slope_signal_600_9 - slope_signal_900_6', 'slope_signal_600_9 - slope_signal_900_9', 'slope_signal_900_3 - slope_signal_900_6', 'slope_signal_900_3 - slope_signal_900_9', 'slope_signal_900_6 - slope_signal_900_9', 'slope_angle_300_3 - slope_angle_300_6', 'slope_angle_300_3 - slope_angle_300_9', 'slope_angle_300_3 - slope_angle_600_3', 'slope_angle_300_3 - slope_angle_600_6', 'slope_angle_300_3 - slope_angle_600_9', 'slope_angle_300_3 - slope_angle_900_3', 'slope_angle_300_3 - slope_angle_900_6', 'slope_angle_300_3 - slope_angle_900_9', 'slope_angle_300_6 - slope_angle_300_9', 'slope_angle_300_6 - slope_angle_600_3', 'slope_angle_300_6 - slope_angle_600_6', 'slope_angle_300_6 - slope_angle_600_9', 'slope_angle_300_6 - slope_angle_900_3', 'slope_angle_300_6 - slope_angle_900_6', 'slope_angle_300_6 - slope_angle_900_9', 'slope_angle_300_9 - slope_angle_600_3', 'slope_angle_300_9 - slope_angle_600_6', 'slope_angle_300_9 - slope_angle_600_9', 'slope_angle_300_9 - slope_angle_900_3', 'slope_angle_300_9 - slope_angle_900_6', 'slope_angle_300_9 - slope_angle_900_9', 'slope_angle_600_3 - slope_angle_600_6', 'slope_angle_600_3 - slope_angle_600_9', 'slope_angle_600_3 - slope_angle_900_3', 'slope_angle_600_3 - slope_angle_900_6', 'slope_angle_600_3 - slope_angle_900_9', 'slope_angle_600_6 - slope_angle_600_9', 'slope_angle_600_6 - slope_angle_900_3', 'slope_angle_600_6 - slope_angle_900_6', 'slope_angle_600_6 - slope_angle_900_9', 'slope_angle_600_9 - slope_angle_900_3', 'slope_angle_600_9 - slope_angle_900_6', 'slope_angle_600_9 - slope_angle_900_9', 'slope_angle_900_3 - slope_angle_900_6', 'slope_angle_900_3 - slope_angle_900_9', 'slope_angle_900_6 - slope_angle_900_9', 'slope_angle_signal_300_3 - slope_angle_signal_300_6', 'slope_angle_signal_300_3 - slope_angle_signal_300_9', 'slope_angle_signal_300_3 - slope_angle_signal_600_3', 'slope_angle_signal_300_3 - slope_angle_signal_600_6', 'slope_angle_signal_300_3 - slope_angle_signal_600_9', 'slope_angle_signal_300_3 - slope_angle_signal_900_3', 'slope_angle_signal_300_3 - slope_angle_signal_900_6', 'slope_angle_signal_300_3 - slope_angle_signal_900_9', 'slope_angle_signal_300_6 - slope_angle_signal_300_9', 'slope_angle_signal_300_6 - slope_angle_signal_600_3', 'slope_angle_signal_300_6 - slope_angle_signal_600_6', 'slope_angle_signal_300_6 - slope_angle_signal_600_9', 'slope_angle_signal_300_6 - slope_angle_signal_900_3', 'slope_angle_signal_300_6 - slope_angle_signal_900_6', 'slope_angle_signal_300_6 - slope_angle_signal_900_9', 'slope_angle_signal_300_9 - slope_angle_signal_600_3', 'slope_angle_signal_300_9 - slope_angle_signal_600_6', 'slope_angle_signal_300_9 - slope_angle_signal_600_9', 'slope_angle_signal_300_9 - slope_angle_signal_900_3', 'slope_angle_signal_300_9 - slope_angle_signal_900_6', 'slope_angle_signal_300_9 - slope_angle_signal_900_9', 'slope_angle_signal_600_3 - slope_angle_signal_600_6', 'slope_angle_signal_600_3 - slope_angle_signal_600_9', 'slope_angle_signal_600_3 - slope_angle_signal_900_3', 'slope_angle_signal_600_3 - slope_angle_signal_900_6', 'slope_angle_signal_600_3 - slope_angle_signal_900_9', 'slope_angle_signal_600_6 - slope_angle_signal_600_9', 'slope_angle_signal_600_6 - slope_angle_signal_900_3', 'slope_angle_signal_600_6 - slope_angle_signal_900_6', 'slope_angle_signal_600_6 - slope_angle_signal_900_9', 'slope_angle_signal_600_9 - slope_angle_signal_900_3', 'slope_angle_signal_600_9 - slope_angle_signal_900_6', 'slope_angle_signal_600_9 - slope_angle_signal_900_9', 'slope_angle_signal_900_3 - slope_angle_signal_900_6', 'slope_angle_signal_900_3 - slope_angle_signal_900_9', 'slope_angle_signal_900_6 - slope_angle_signal_900_9', 'slope_lin_reg_300_3 - slope_lin_reg_300_6', 'slope_lin_reg_300_3 - slope_lin_reg_300_9', 'slope_lin_reg_300_3 - slope_lin_reg_600_3', 'slope_lin_reg_300_3 - slope_lin_reg_600_6', 'slope_lin_reg_300_3 - slope_lin_reg_600_9', 'slope_lin_reg_300_3 - slope_lin_reg_900_3', 'slope_lin_reg_300_3 - slope_lin_reg_900_6', 'slope_lin_reg_300_3 - slope_lin_reg_900_9', 'slope_lin_reg_300_6 - slope_lin_reg_300_9', 'slope_lin_reg_300_6 - slope_lin_reg_600_3', 'slope_lin_reg_300_6 - slope_lin_reg_600_6', 'slope_lin_reg_300_6 - slope_lin_reg_600_9', 'slope_lin_reg_300_6 - slope_lin_reg_900_3', 'slope_lin_reg_300_6 - slope_lin_reg_900_6', 'slope_lin_reg_300_6 - slope_lin_reg_900_9', 'slope_lin_reg_300_9 - slope_lin_reg_600_3', 'slope_lin_reg_300_9 - slope_lin_reg_600_6', 'slope_lin_reg_300_9 - slope_lin_reg_600_9', 'slope_lin_reg_300_9 - slope_lin_reg_900_3', 'slope_lin_reg_300_9 - slope_lin_reg_900_6', 'slope_lin_reg_300_9 - slope_lin_reg_900_9', 'slope_lin_reg_600_3 - slope_lin_reg_600_6', 'slope_lin_reg_600_3 - slope_lin_reg_600_9', 'slope_lin_reg_600_3 - slope_lin_reg_900_3', 'slope_lin_reg_600_3 - slope_lin_reg_900_6', 'slope_lin_reg_600_3 - slope_lin_reg_900_9', 'slope_lin_reg_600_6 - slope_lin_reg_600_9', 'slope_lin_reg_600_6 - slope_lin_reg_900_3', 'slope_lin_reg_600_6 - slope_lin_reg_900_6', 'slope_lin_reg_600_6 - slope_lin_reg_900_9', 'slope_lin_reg_600_9 - slope_lin_reg_900_3', 'slope_lin_reg_600_9 - slope_lin_reg_900_6', 'slope_lin_reg_600_9 - slope_lin_reg_900_9', 'slope_lin_reg_900_3 - slope_lin_reg_900_6', 'slope_lin_reg_900_3 - slope_lin_reg_900_9', 'slope_lin_reg_900_6 - slope_lin_reg_900_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list(features_5min_raw.columns))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "QX4cSq3Ftqhm",
+   "metadata": {
+    "id": "QX4cSq3Ftqhm"
+   },
+   "source": [
+    "**Scale_features**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1qEb1Cz1vzj6",
+   "metadata": {
+    "id": "1qEb1Cz1vzj6"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Saved scaled feature files:\")\n",
+    "for name, path in m5_scaled_paths.items():\n",
+    "    print(f\" - {name}: {path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eJcGUESttqhm",
+   "metadata": {
+    "id": "eJcGUESttqhm"
+   },
+   "outputs": [],
+   "source": [
+    "m5_scaled_blocks['Create_Features'].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "BFVUCAe3GWFy",
+   "metadata": {
+    "id": "BFVUCAe3GWFy"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"NaN counts per column (scaled, sorted):\")\n",
+    "print(m5_scaled_blocks['Create_Features'].isnull().sum().sort_values(ascending=False), '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aXMGezVftqhn",
+   "metadata": {
+    "id": "aXMGezVftqhn"
+   },
+   "outputs": [],
+   "source": [
+    "print(\"M5 feature blocks:\", list(m5_raw_blocks.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "W1Pk4Hkfjhvt",
+   "metadata": {
+    "id": "W1Pk4Hkfjhvt"
+   },
+   "source": [
+    "**Plots**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67453c9e",
+   "metadata": {
+    "id": "67453c9e"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "last_200_features_15min = m15_scaled_blocks['Create_Features'].tail(200)\n",
+    "last_200_df_15min = df_15min.tail(200)\n",
+    "\n",
+    "indicators_to_plot = ['Close','15min_Kal_300','15min_Kal_600']\n",
+    "\n",
+    "# Separate Close from other indicators\n",
+    "close_to_plot = 'Close' if 'Close' in indicators_to_plot else None\n",
+    "other_indicators_to_plot = [col for col in indicators_to_plot if col != 'Close' and col in last_200_features_15min.columns]\n",
+    "\n",
+    "num_plots = len(other_indicators_to_plot) + (1 if close_to_plot else 0)\n",
+    "\n",
+    "# Plotting\n",
+    "fig, axes = plt.subplots(nrows=num_plots, ncols=1, figsize=(15, 2.5 * num_plots), sharex=True)\n",
+    "\n",
+    "# Ensure axes is an array even if only one plot\n",
+    "if not isinstance(axes, np.ndarray):\n",
+    "    axes = np.array([axes])\n",
+    "\n",
+    "current_plot_index = 0\n",
+    "\n",
+    "# Plot Close price if requested\n",
+    "if close_to_plot:\n",
+    "    axes[current_plot_index].plot(last_200_df_15min.index, last_200_df_15min['Close'])\n",
+    "    axes[current_plot_index].set_title('Close Price')\n",
+    "    axes[current_plot_index].grid(True)\n",
+    "    current_plot_index += 1\n",
+    "\n",
+    "# Plot each selected indicator (excluding 'Close')\n",
+    "for col in other_indicators_to_plot:\n",
+    "    axes[current_plot_index].plot(last_200_features_15min.index, last_200_features_15min[col])\n",
+    "    axes[current_plot_index].set_title(col)\n",
+    "    axes[current_plot_index].grid(True)\n",
+    "    current_plot_index += 1\n",
+    "\n",
+    "#plt.tight_layout()\n",
+    "#plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "A5c__w6s_dtY",
+   "metadata": {
+    "id": "A5c__w6s_dtY"
+   },
+   "source": [
+    "# Feature Importance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4j7J8tk_f3o-",
+   "metadata": {
+    "id": "4j7J8tk_f3o-"
+   },
+   "source": [
+    "## Labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6XOsumPycYz3",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "6XOsumPycYz3",
+    "outputId": "a9e8a2d3-e9b2-41ff-d9f9-1c5e5fe408ac"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Min_Date    :  2019-01-02 01:00:00\n",
+      "Min_Date    :  2025-07-25 23:55:00 \n",
+      "\n",
+      "Number_Rows :  (465718, 29) \n",
+      "\n",
+      "Columns     :  Index(['Date', 'Open', 'High', 'Low', 'Close', 'Volume', 'Spread', 'ATR',\n",
+      "       'kal_1', 'kal_2', 'kal_3', 'kal_4', 'Open_Trade', 'Close_Trade',\n",
+      "       'Entry_Date', 'Type', 'Trade_Number', 'st_Exit_Date', 'trade type',\n",
+      "       'st_Duration', 'st_row_PnL_close', 'st_row_PnL_high', 'st_row_PnL_Low',\n",
+      "       'st_row_PnL_low', 'st_Max', 'st_Min', 'st_PnL', 'st_atr_PnL',\n",
+      "       'st_atr_max_PnL'],\n",
+      "      dtype='object')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Open_Trade</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>33915</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>-1.0</th>\n",
+       "      <td>33858</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div><br><label><b>dtype:</b> int64</label>"
+      ],
+      "text/plain": [
+       "Open_Trade\n",
+       " 1.0    33915\n",
+       "-1.0    33858\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lab = pd.read_csv(root_data + 'Results/'+symbol+'_'+strategy+'_'+time_frame+'_Strategy_Gen_Labels.csv', index_col=0)\n",
+    "lab['Date'] = pd.to_datetime(lab['Date'])\n",
+    "\n",
+    "print('Min_Date    : ',lab['Date'].min())\n",
+    "print('Min_Date    : ',lab['Date'].max(),'\\n')\n",
+    "print('Number_Rows : ',lab.shape,'\\n')\n",
+    "print('Columns     : ',lab.columns)\n",
+    "\n",
+    "lab['Open_Trade'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "apV2tezPsbux",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "apV2tezPsbux",
+    "outputId": "3d49cf8e-7890-472b-d936-66d4a46b4056"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total_Trades = 67,773\n",
+      "\n",
+      "Mean st_atr_max_PnL = 238.39\n",
+      "\n",
+      "Above_Mean = 11,463,914.00\n",
+      "Below_Mean = 4,691,967.00\n",
+      "\n",
+      "<= 0.5 = 33.00\n",
+      "> 0.5 & <= 1 = 801,960.00\n",
+      "> 1 & <= 1.5 = 1,411,119.00\n",
+      "> 1.5 & <= 2 = 1,400,438.00\n",
+      "> 2 = 11,277,394.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "#analyse_column = 'st_atr_max_PnL'\n",
+    "analyse_column = 'st_Max'\n",
+    "\n",
+    "st_max_0  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
+    "st_max_1  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
+    "st_max_2  = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].sum()\n",
+    "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].sum()\n",
+    "\n",
+    "\n",
+    "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 0)),analyse_column].sum()\n",
+    "\n",
+    "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 0.7) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].sum()\n",
+    "\n",
+    "st_max_5 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 1) &\n",
+    "                   (lab['st_atr_max_PnL'] <= 1.5)),analyse_column].sum()\n",
+    "\n",
+    "st_max_6 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 1.5) &\n",
+    "                   (lab['st_atr_max_PnL'] <= 2)),analyse_column].sum()\n",
+    "\n",
+    "st_max_7 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] > 2)),analyse_column].sum()\n",
+    "\n",
+    "\n",
+    "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
+    "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
+    "print(f'Above_Mean = {st_max_2:,.2f}')\n",
+    "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
+    "\n",
+    "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
+    "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
+    "print(f'> 1 & <= 1.5 = {st_max_5:,.2f}')\n",
+    "print(f'> 1.5 & <= 2 = {st_max_6:,.2f}')\n",
+    "print(f'> 2 = {st_max_7:,.2f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "p2fjs4Si792v",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "p2fjs4Si792v",
+    "outputId": "8a038f41-3186-4478-d0f3-c3cb11e10685"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total_Trades = 67,773\n",
+      "\n",
+      "Mean st_atr_max_PnL = 1.89\n",
+      "\n",
+      "Above_Mean = 20,857.00\n",
+      "Below_Mean = 46,913.00\n",
+      "\n",
+      "<= 0.5 = 20,431.00\n",
+      "> 0.5 & <= 1 = 13,116.00\n",
+      "> 1 = 34,223.00\n"
+     ]
+    }
+   ],
+   "source": [
+    "analyse_column = 'st_atr_max_PnL'\n",
+    "\n",
+    "st_max_0 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),:]['Open_Trade'].count()\n",
+    "st_max_1 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)),analyse_column].mean()\n",
+    "st_max_2 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] >= 1.93),analyse_column].count()\n",
+    "st_max_25 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) & (lab['st_atr_max_PnL'] <= 1.93),analyse_column].count()\n",
+    "\n",
+    "st_max_3 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                    (lab['st_atr_max_PnL'] <= 0.5)),analyse_column].count()\n",
+    "\n",
+    "st_max_4 = lab.loc[(((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                     (lab['st_atr_max_PnL'] >= 0.5) & (lab['st_atr_max_PnL'] <= 1)),analyse_column].count()\n",
+    "\n",
+    "st_max_5 = lab.loc[((lab['Open_Trade']==1) |(lab['Open_Trade']==-1)) &\n",
+    "                   (lab['st_atr_max_PnL'] >= 1), analyse_column].count()\n",
+    "\n",
+    "print(f'Total_Trades = {st_max_0:,.0f}\\n')\n",
+    "print(f'Mean st_atr_max_PnL = {st_max_1:,.2f}\\n')\n",
+    "print(f'Above_Mean = {st_max_2:,.2f}')\n",
+    "print(f'Below_Mean = {st_max_25:,.2f}\\n')\n",
+    "\n",
+    "print(f'<= 0.5 = {st_max_3:,.2f}')\n",
+    "print(f'> 0.5 & <= 1 = {st_max_4:,.2f}')\n",
+    "print(f'> 1 = {st_max_5:,.2f}')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85DATjQqZd66",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "85DATjQqZd66",
+    "outputId": "a438b83c-e4f9-406e-d934-d6f79255edcc"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Value counts de label 4/5/6:\n",
+      "label\n",
+      "0    33547\n",
+      "1    34223\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Parámetros / campos\n",
+    "result_field = 'st_atr_max_PnL'\n",
+    "\n",
+    "#valid = (\n",
+    "#    (lab['Type'] == direction) &\n",
+    "#    (lab['Open_Trade'].isin([1, -1])) &\n",
+    "#    (lab[result_field].notna()))\n",
+    "\n",
+    "valid = (\n",
+    "    (lab['Open_Trade'].isin([1, -1])) &\n",
+    "    (lab[result_field].notna()))\n",
+    "\n",
+    "\n",
+    "# --- Etiquetado en la columna \"label\" con valores 4/5/6\n",
+    "lab['label'] = np.nan\n",
+    "lab.loc[valid & (lab[result_field] <= 1), 'label'] = 0\n",
+    "lab.loc[valid & (lab[result_field] >= 1), 'label'] = 1\n",
+    "\n",
+    "\n",
+    "# --- Mantener solo filas válidas y con label\n",
+    "lab = lab.loc[valid & lab['label'].notna()].copy()\n",
+    "lab['label'] = lab['label'].astype('int8')\n",
+    "\n",
+    "# --- Ver distribución de labels 4/5/6\n",
+    "print('\\nValue counts de label 4/5/6:')\n",
+    "print(lab['label'].value_counts(dropna=False).sort_index())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "_BCdqt3Y0Fjm",
+   "metadata": {
+    "id": "_BCdqt3Y0Fjm"
+   },
+   "source": [
+    "## Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "gX04ZTmfz-pK",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "gX04ZTmfz-pK",
+    "outputId": "0a28e505-dec9-4d54-9711-705a904a0050"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(465518, 455)\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Raw_Features.csv')\n",
+    "raw_feat_5min[\"Date\"] = pd.to_datetime(raw_feat_5min[\"Date\"])\n",
+    "print(raw_feat_5min.shape)\n",
+    "#raw_feat_5min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "D5gxf0ke0KUx",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "D5gxf0ke0KUx",
+    "outputId": "da7c18db-8bd4-4865-b8c5-93e5f4adefc8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(465518, 455)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scale_feat_5min = pd.read_csv(root_data+'Results/'+symbol+'_M5_Scale_Features.csv')\n",
+    "#scale_feat_5min = scale_feat_5min.drop('Unnamed: 0', axis=1)\n",
+    "scale_feat_5min[\"Date\"] = pd.to_datetime(scale_feat_5min[\"Date\"])\n",
+    "print(scale_feat_5min.shape)\n",
+    "#scale_feat_5min.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Hv5bsrpc03z7",
+   "metadata": {
+    "id": "Hv5bsrpc03z7"
+   },
+   "source": [
+    "## Merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Mc1y2NbRM_f1",
+   "metadata": {
+    "id": "Mc1y2NbRM_f1"
+   },
+   "outputs": [],
+   "source": [
+    "data_type = 'Scale'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "I0gkNVT60Ka5",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "I0gkNVT60Ka5",
+    "outputId": "dfb633fb-e39e-48fa-e77b-f013b4ffc321"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature blocks merged:\n",
+      " - M5_raw: 454 columns\n",
+      " - M5_scale: 454 columns\n",
+      " - M10_raw: 454 columns\n",
+      " - M10_scale: 454 columns\n",
+      " - M15_raw: 454 columns\n",
+      " - M15_scale: 454 columns\n",
+      "Combined feature dataframe shape: (67770, 2727)\n",
+      "Saved combined feature dataframe to: /content/drive/MyDrive/Course Folder/Forex/XAUUSD/Results/XAUUSD_Short_AllFeatures.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "def prepare_feature_block(frame: pd.DataFrame, prefix: str) -> pd.DataFrame:\n",
+    "    \"\"\"Return a copy of the feature block with a consistent prefix.\"\"\"\n",
+    "    block = frame.copy()\n",
+    "    if 'Unnamed: 0' in block.columns:\n",
+    "        block = block.drop(columns='Unnamed: 0')\n",
+    "    block = block.drop_duplicates(subset='Date').sort_values('Date')\n",
+    "    rename_map = {col: f\"{prefix}{col}\" for col in block.columns if col != 'Date'}\n",
+    "    block = block.rename(columns=rename_map)\n",
+    "    return block\n",
+    "\n",
+    "feature_blocks = {\n",
+    "    'M5_raw': prepare_feature_block(raw_feat_5min, 'M5_raw_'),\n",
+    "    'M5_scale': prepare_feature_block(scale_feat_5min, 'M5_scale_'),\n",
+    "    'M10_raw': prepare_feature_block(raw_feat_10min, 'M10_raw_'),\n",
+    "    'M10_scale': prepare_feature_block(scale_feat_10min, 'M10_scale_'),\n",
+    "    'M15_raw': prepare_feature_block(raw_feat_15min, 'M15_raw_'),\n",
+    "    'M15_scale': prepare_feature_block(scale_feat_15min, 'M15_scale_'),\n",
+    "}\n",
+    "\n",
+    "feature_df = lab[['Date']].drop_duplicates().copy()\n",
+    "\n",
+    "print('Feature blocks merged:')\n",
+    "for name, block in feature_blocks.items():\n",
+    "    feature_df = feature_df.merge(block, on='Date', how='left')\n",
+    "    print(f\" - {name}: {block.shape[1] - 1} columns\")\n",
+    "\n",
+    "feature_df = feature_df.sort_values('Date').set_index('Date').ffill().reset_index()\n",
+    "\n",
+    "df = lab[['Date', 'label', 'Open_Trade']].merge(feature_df, on='Date', how='left')\n",
+    "\n",
+    "cols = df.columns.tolist()\n",
+    "cols.remove('label')\n",
+    "cols.insert(1, 'label')\n",
+    "df = df[cols]\n",
+    "\n",
+    "combined_feature_path = os.path.join(root_data, 'Results', f\"{symbol}_{direction}_AllFeatures.csv\")\n",
+    "df.to_csv(combined_feature_path, index=False)\n",
+    "\n",
+    "print(f\"Combined feature dataframe shape: {df.shape}\")\n",
+    "print(f\"Saved combined feature dataframe to: {combined_feature_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fQPfQroWYLRM",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "fQPfQroWYLRM",
+    "outputId": "dd1cbd5e-8b0e-40fc-ec7f-57c1caf2cfc1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M5_raw_: 454 columns\n",
+      "M5_scale_: 454 columns\n",
+      "M10_raw_: 454 columns\n",
+      "M10_scale_: 454 columns\n",
+      "M15_raw_: 454 columns\n",
+      "M15_scale_: 454 columns\n",
+      "No duplicated feature columns detected.\n"
+     ]
+    }
+   ],
+   "source": [
+    "expected_prefixes = ['M5_raw_', 'M5_scale_', 'M10_raw_', 'M10_scale_', 'M15_raw_', 'M15_scale_']\n",
+    "for prefix in expected_prefixes:\n",
+    "    matching_cols = [col for col in df.columns if col.startswith(prefix)]\n",
+    "    print(f\"{prefix}: {len(matching_cols)} columns\")\n",
+    "\n",
+    "duplicated_columns = df.columns[df.columns.duplicated()].tolist()\n",
+    "if duplicated_columns:\n",
+    "    print('Duplicated feature columns detected:', duplicated_columns)\n",
+    "else:\n",
+    "    print('No duplicated feature columns detected.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jXcXWty506Ur",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jXcXWty506Ur",
+    "outputId": "79d68240-6c14-403f-f12e-dfb1c562cfe8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(67770, 2727) \n",
+      "\n",
+      "Label_Counts :  label\n",
+      "1    34223\n",
+      "0    33547\n",
+      "Name: count, dtype: int64 \n",
+      "\n",
+      "['Date', 'label', 'Open_Trade', 'M5_raw_MACD_12_26_9', 'M5_raw_MACD_12_26_9_diff', 'M5_raw_MACD_signal_12_26_9', 'M5_raw_MACD_signal_12_26_9_diff', 'M5_raw_MACD_hist_12_26_9', 'M5_raw_MACD_hist_12_26_9_diff', 'M5_raw_RSI_basic_14', 'M5_raw_RSI_basic_14_diff', 'M5_raw_BB_upper_20', 'M5_raw_BB_upper_20_diff', 'M5_raw_BB_middle_20', 'M5_raw_BB_middle_20_diff', 'M5_raw_BB_lower_20', 'M5_raw_BB_lower_20_diff', 'M5_raw_ATR_14', 'M5_raw_ATR_14_diff', 'M5_raw_OBV_basic', 'M5_raw_OBV_basic_diff', 'M5_raw_VWAP_basic', 'M5_raw_VWAP_basic_diff', 'M5_raw_Momentum_10', 'M5_raw_Momentum_10_diff', 'M5_raw_ROC_10', 'M5_raw_ROC_10_diff', 'M5_raw_Stoch_K_14_3_3', 'M5_raw_Stoch_K_14_3_3_diff', 'M5_raw_Stoch_D_14_3_3', 'M5_raw_Stoch_D_14_3_3_diff', 'M5_raw_CCI_20', 'M5_raw_CCI_20_diff', 'M5_raw_MFI_basic_14', 'M5_raw_MFI_basic_14_diff', 'M5_raw_ADX_14', 'M5_raw_ADX_14_diff', 'M5_raw_WilliamsR_14', 'M5_raw_WilliamsR_14_diff', 'M5_raw_CMF', 'M5_raw_CMF_diff', 'M5_raw_TMF', 'M5_raw_TMF_diff', 'M5_raw_MFI_14_volume', 'M5_raw_MFI_14_volume_diff', 'M5_raw_KO', 'M5_raw_KO_diff', 'M5_raw_EFI', 'M5_raw_EFI_diff', 'M5_raw_EOM', 'M5_raw_EOM_diff', 'M5_raw_VPT', 'M5_raw_VPT_diff', 'M5_raw_NVI', 'M5_raw_NVI_diff', 'M5_raw_PVI', 'M5_raw_PVI_diff', 'M5_raw_VFI', 'M5_raw_VFI_diff', 'M5_raw_VWAP', 'M5_raw_VWAP_diff', 'M5_raw_Market_Facilitation_Index', 'M5_raw_Market_Facilitation_Index_diff', 'M5_raw_AD_Line', 'M5_raw_AD_Line_diff', 'M5_raw_WAD', 'M5_raw_WAD_diff', 'M5_raw_EMA_15', 'M5_raw_EMA_15_diff', 'M5_raw_Close_minus_EMA_15', 'M5_raw_EMA_21', 'M5_raw_EMA_21_diff', 'M5_raw_Close_minus_EMA_21', 'M5_raw_EMA_50', 'M5_raw_EMA_50_diff', 'M5_raw_Close_minus_EMA_50', 'M5_raw_EMA_100', 'M5_raw_EMA_100_diff', 'M5_raw_Close_minus_EMA_100', 'M5_raw_EMA_200', 'M5_raw_EMA_200_diff', 'M5_raw_Close_minus_EMA_200', 'M5_raw_EMA_15_above_EMA_21', 'M5_raw_EMA_15_above_EMA_50', 'M5_raw_EMA_15_above_EMA_100', 'M5_raw_EMA_15_above_EMA_200', 'M5_raw_EMA_21_above_EMA_50', 'M5_raw_EMA_21_above_EMA_100', 'M5_raw_EMA_21_above_EMA_200', 'M5_raw_EMA_50_above_EMA_100', 'M5_raw_EMA_50_above_EMA_200', 'M5_raw_EMA_100_above_EMA_200', 'M5_raw_OBV', 'M5_raw_RSI_3', 'M5_raw_MFI_3', 'M5_raw_RSI_7', 'M5_raw_MFI_7', 'M5_raw_RSI_14', 'M5_raw_MFI_14', 'M5_raw_RSI_3_diff', 'M5_raw_RSI_7_diff', 'M5_raw_RSI_14_diff', 'M5_raw_RSI_3 - RSI_7', 'M5_raw_RSI_3 - RSI_14', 'M5_raw_RSI_7 - RSI_14', 'M5_raw_MFI_3_diff', 'M5_raw_MFI_7_diff', 'M5_raw_MFI_14_diff', 'M5_raw_MFI_3 - MFI_7', 'M5_raw_MFI_3 - MFI_14', 'M5_raw_MFI_7 - MFI_14', 'M5_raw_OBV_diff', 'M5_raw_Kal_300', 'M5_raw_Close_Kal_300', 'M5_raw_Kal_change_300', 'M5_raw_Kal_prev_minus_now_300', 'M5_raw_Kal_prev2_minus_now_300', 'M5_raw_Kal_change2_300', 'M5_raw_Kal_600', 'M5_raw_Close_Kal_600', 'M5_raw_Kal_change_600', 'M5_raw_Kal_prev_minus_now_600', 'M5_raw_Kal_prev2_minus_now_600', 'M5_raw_Kal_change2_600', 'M5_raw_Kal_900', 'M5_raw_Close_Kal_900', 'M5_raw_Kal_change_900', 'M5_raw_Kal_prev_minus_now_900', 'M5_raw_Kal_prev2_minus_now_900', 'M5_raw_Kal_change2_900', 'M5_raw_Kal_300_minus_Kal_600', 'M5_raw_Kal_300_minus_Kal_900', 'M5_raw_Kal_600_minus_Kal_900', 'M5_raw_slope_div_300_3', 'M5_raw_slope_div_300_3_diff', 'M5_raw_slope_signal_300_3', 'M5_raw_slope_signal_300_3_diff', 'M5_raw_slope_angle_300_3', 'M5_raw_slope_angle_300_3_diff', 'M5_raw_slope_angle_signal_300_3', 'M5_raw_slope_angle_signal_300_3_diff', 'M5_raw_slope_lin_reg_300_3', 'M5_raw_slope_lin_reg_300_3_diff', 'M5_raw_slope_lin_reg_signal_300_3', 'M5_raw_slope_lin_reg_signal_300_3_diff', 'M5_raw_slope_div_300_6', 'M5_raw_slope_div_300_6_diff', 'M5_raw_slope_signal_300_6', 'M5_raw_slope_signal_300_6_diff', 'M5_raw_slope_angle_300_6', 'M5_raw_slope_angle_300_6_diff', 'M5_raw_slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_6_diff', 'M5_raw_slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_6_diff', 'M5_raw_slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_6_diff', 'M5_raw_slope_div_300_9', 'M5_raw_slope_div_300_9_diff', 'M5_raw_slope_signal_300_9', 'M5_raw_slope_signal_300_9_diff', 'M5_raw_slope_angle_300_9', 'M5_raw_slope_angle_300_9_diff', 'M5_raw_slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_9_diff', 'M5_raw_slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_9_diff', 'M5_raw_slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_9_diff', 'M5_raw_slope_div_600_3', 'M5_raw_slope_div_600_3_diff', 'M5_raw_slope_signal_600_3', 'M5_raw_slope_signal_600_3_diff', 'M5_raw_slope_angle_600_3', 'M5_raw_slope_angle_600_3_diff', 'M5_raw_slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_600_3_diff', 'M5_raw_slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_600_3_diff', 'M5_raw_slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_600_3_diff', 'M5_raw_slope_div_600_6', 'M5_raw_slope_div_600_6_diff', 'M5_raw_slope_signal_600_6', 'M5_raw_slope_signal_600_6_diff', 'M5_raw_slope_angle_600_6', 'M5_raw_slope_angle_600_6_diff', 'M5_raw_slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_6_diff', 'M5_raw_slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_6_diff', 'M5_raw_slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_6_diff', 'M5_raw_slope_div_600_9', 'M5_raw_slope_div_600_9_diff', 'M5_raw_slope_signal_600_9', 'M5_raw_slope_signal_600_9_diff', 'M5_raw_slope_angle_600_9', 'M5_raw_slope_angle_600_9_diff', 'M5_raw_slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_9_diff', 'M5_raw_slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_9_diff', 'M5_raw_slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_9_diff', 'M5_raw_slope_div_900_3', 'M5_raw_slope_div_900_3_diff', 'M5_raw_slope_signal_900_3', 'M5_raw_slope_signal_900_3_diff', 'M5_raw_slope_angle_900_3', 'M5_raw_slope_angle_900_3_diff', 'M5_raw_slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_900_3_diff', 'M5_raw_slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_900_3_diff', 'M5_raw_slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_900_3_diff', 'M5_raw_slope_div_900_6', 'M5_raw_slope_div_900_6_diff', 'M5_raw_slope_signal_900_6', 'M5_raw_slope_signal_900_6_diff', 'M5_raw_slope_angle_900_6', 'M5_raw_slope_angle_900_6_diff', 'M5_raw_slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_6_diff', 'M5_raw_slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_6_diff', 'M5_raw_slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_6_diff', 'M5_raw_slope_div_900_9', 'M5_raw_slope_div_900_9_diff', 'M5_raw_slope_signal_900_9', 'M5_raw_slope_signal_900_9_diff', 'M5_raw_slope_angle_900_9', 'M5_raw_slope_angle_900_9_diff', 'M5_raw_slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_9_diff', 'M5_raw_slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_9_diff', 'M5_raw_slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_9_diff', 'M5_raw_slope_div_300_3 - slope_div_300_6', 'M5_raw_slope_div_300_3 - slope_div_300_9', 'M5_raw_slope_div_300_3 - slope_div_600_3', 'M5_raw_slope_div_300_3 - slope_div_600_6', 'M5_raw_slope_div_300_3 - slope_div_600_9', 'M5_raw_slope_div_300_3 - slope_div_900_3', 'M5_raw_slope_div_300_3 - slope_div_900_6', 'M5_raw_slope_div_300_3 - slope_div_900_9', 'M5_raw_slope_div_300_6 - slope_div_300_9', 'M5_raw_slope_div_300_6 - slope_div_600_3', 'M5_raw_slope_div_300_6 - slope_div_600_6', 'M5_raw_slope_div_300_6 - slope_div_600_9', 'M5_raw_slope_div_300_6 - slope_div_900_3', 'M5_raw_slope_div_300_6 - slope_div_900_6', 'M5_raw_slope_div_300_6 - slope_div_900_9', 'M5_raw_slope_div_300_9 - slope_div_600_3', 'M5_raw_slope_div_300_9 - slope_div_600_6', 'M5_raw_slope_div_300_9 - slope_div_600_9', 'M5_raw_slope_div_300_9 - slope_div_900_3', 'M5_raw_slope_div_300_9 - slope_div_900_6', 'M5_raw_slope_div_300_9 - slope_div_900_9', 'M5_raw_slope_div_600_3 - slope_div_600_6', 'M5_raw_slope_div_600_3 - slope_div_600_9', 'M5_raw_slope_div_600_3 - slope_div_900_3', 'M5_raw_slope_div_600_3 - slope_div_900_6', 'M5_raw_slope_div_600_3 - slope_div_900_9', 'M5_raw_slope_div_600_6 - slope_div_600_9', 'M5_raw_slope_div_600_6 - slope_div_900_3', 'M5_raw_slope_div_600_6 - slope_div_900_6', 'M5_raw_slope_div_600_6 - slope_div_900_9', 'M5_raw_slope_div_600_9 - slope_div_900_3', 'M5_raw_slope_div_600_9 - slope_div_900_6', 'M5_raw_slope_div_600_9 - slope_div_900_9', 'M5_raw_slope_div_900_3 - slope_div_900_6', 'M5_raw_slope_div_900_3 - slope_div_900_9', 'M5_raw_slope_div_900_6 - slope_div_900_9', 'M5_raw_slope_signal_300_3 - slope_signal_300_6', 'M5_raw_slope_signal_300_3 - slope_signal_300_9', 'M5_raw_slope_signal_300_3 - slope_signal_600_3', 'M5_raw_slope_signal_300_3 - slope_signal_600_6', 'M5_raw_slope_signal_300_3 - slope_signal_600_9', 'M5_raw_slope_signal_300_3 - slope_signal_900_3', 'M5_raw_slope_signal_300_3 - slope_signal_900_6', 'M5_raw_slope_signal_300_3 - slope_signal_900_9', 'M5_raw_slope_signal_300_6 - slope_signal_300_9', 'M5_raw_slope_signal_300_6 - slope_signal_600_3', 'M5_raw_slope_signal_300_6 - slope_signal_600_6', 'M5_raw_slope_signal_300_6 - slope_signal_600_9', 'M5_raw_slope_signal_300_6 - slope_signal_900_3', 'M5_raw_slope_signal_300_6 - slope_signal_900_6', 'M5_raw_slope_signal_300_6 - slope_signal_900_9', 'M5_raw_slope_signal_300_9 - slope_signal_600_3', 'M5_raw_slope_signal_300_9 - slope_signal_600_6', 'M5_raw_slope_signal_300_9 - slope_signal_600_9', 'M5_raw_slope_signal_300_9 - slope_signal_900_3', 'M5_raw_slope_signal_300_9 - slope_signal_900_6', 'M5_raw_slope_signal_300_9 - slope_signal_900_9', 'M5_raw_slope_signal_600_3 - slope_signal_600_6', 'M5_raw_slope_signal_600_3 - slope_signal_600_9', 'M5_raw_slope_signal_600_3 - slope_signal_900_3', 'M5_raw_slope_signal_600_3 - slope_signal_900_6', 'M5_raw_slope_signal_600_3 - slope_signal_900_9', 'M5_raw_slope_signal_600_6 - slope_signal_600_9', 'M5_raw_slope_signal_600_6 - slope_signal_900_3', 'M5_raw_slope_signal_600_6 - slope_signal_900_6', 'M5_raw_slope_signal_600_6 - slope_signal_900_9', 'M5_raw_slope_signal_600_9 - slope_signal_900_3', 'M5_raw_slope_signal_600_9 - slope_signal_900_6', 'M5_raw_slope_signal_600_9 - slope_signal_900_9', 'M5_raw_slope_signal_900_3 - slope_signal_900_6', 'M5_raw_slope_signal_900_3 - slope_signal_900_9', 'M5_raw_slope_signal_900_6 - slope_signal_900_9', 'M5_raw_slope_angle_300_3 - slope_angle_300_6', 'M5_raw_slope_angle_300_3 - slope_angle_300_9', 'M5_raw_slope_angle_300_3 - slope_angle_600_3', 'M5_raw_slope_angle_300_3 - slope_angle_600_6', 'M5_raw_slope_angle_300_3 - slope_angle_600_9', 'M5_raw_slope_angle_300_3 - slope_angle_900_3', 'M5_raw_slope_angle_300_3 - slope_angle_900_6', 'M5_raw_slope_angle_300_3 - slope_angle_900_9', 'M5_raw_slope_angle_300_6 - slope_angle_300_9', 'M5_raw_slope_angle_300_6 - slope_angle_600_3', 'M5_raw_slope_angle_300_6 - slope_angle_600_6', 'M5_raw_slope_angle_300_6 - slope_angle_600_9', 'M5_raw_slope_angle_300_6 - slope_angle_900_3', 'M5_raw_slope_angle_300_6 - slope_angle_900_6', 'M5_raw_slope_angle_300_6 - slope_angle_900_9', 'M5_raw_slope_angle_300_9 - slope_angle_600_3', 'M5_raw_slope_angle_300_9 - slope_angle_600_6', 'M5_raw_slope_angle_300_9 - slope_angle_600_9', 'M5_raw_slope_angle_300_9 - slope_angle_900_3', 'M5_raw_slope_angle_300_9 - slope_angle_900_6', 'M5_raw_slope_angle_300_9 - slope_angle_900_9', 'M5_raw_slope_angle_600_3 - slope_angle_600_6', 'M5_raw_slope_angle_600_3 - slope_angle_600_9', 'M5_raw_slope_angle_600_3 - slope_angle_900_3', 'M5_raw_slope_angle_600_3 - slope_angle_900_6', 'M5_raw_slope_angle_600_3 - slope_angle_900_9', 'M5_raw_slope_angle_600_6 - slope_angle_600_9', 'M5_raw_slope_angle_600_6 - slope_angle_900_3', 'M5_raw_slope_angle_600_6 - slope_angle_900_6', 'M5_raw_slope_angle_600_6 - slope_angle_900_9', 'M5_raw_slope_angle_600_9 - slope_angle_900_3', 'M5_raw_slope_angle_600_9 - slope_angle_900_6', 'M5_raw_slope_angle_600_9 - slope_angle_900_9', 'M5_raw_slope_angle_900_3 - slope_angle_900_6', 'M5_raw_slope_angle_900_3 - slope_angle_900_9', 'M5_raw_slope_angle_900_6 - slope_angle_900_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M5_scale_MACD_12_26_9', 'M5_scale_MACD_12_26_9_diff', 'M5_scale_MACD_signal_12_26_9', 'M5_scale_MACD_signal_12_26_9_diff', 'M5_scale_MACD_hist_12_26_9', 'M5_scale_MACD_hist_12_26_9_diff', 'M5_scale_RSI_basic_14', 'M5_scale_RSI_basic_14_diff', 'M5_scale_BB_upper_20', 'M5_scale_BB_upper_20_diff', 'M5_scale_BB_middle_20', 'M5_scale_BB_middle_20_diff', 'M5_scale_BB_lower_20', 'M5_scale_BB_lower_20_diff', 'M5_scale_ATR_14', 'M5_scale_ATR_14_diff', 'M5_scale_OBV_basic', 'M5_scale_OBV_basic_diff', 'M5_scale_VWAP_basic', 'M5_scale_VWAP_basic_diff', 'M5_scale_Momentum_10', 'M5_scale_Momentum_10_diff', 'M5_scale_ROC_10', 'M5_scale_ROC_10_diff', 'M5_scale_Stoch_K_14_3_3', 'M5_scale_Stoch_K_14_3_3_diff', 'M5_scale_Stoch_D_14_3_3', 'M5_scale_Stoch_D_14_3_3_diff', 'M5_scale_CCI_20', 'M5_scale_CCI_20_diff', 'M5_scale_MFI_basic_14', 'M5_scale_MFI_basic_14_diff', 'M5_scale_ADX_14', 'M5_scale_ADX_14_diff', 'M5_scale_WilliamsR_14', 'M5_scale_WilliamsR_14_diff', 'M5_scale_CMF', 'M5_scale_CMF_diff', 'M5_scale_TMF', 'M5_scale_TMF_diff', 'M5_scale_MFI_14_volume', 'M5_scale_MFI_14_volume_diff', 'M5_scale_KO', 'M5_scale_KO_diff', 'M5_scale_EFI', 'M5_scale_EFI_diff', 'M5_scale_EOM', 'M5_scale_EOM_diff', 'M5_scale_VPT', 'M5_scale_VPT_diff', 'M5_scale_NVI', 'M5_scale_NVI_diff', 'M5_scale_PVI', 'M5_scale_PVI_diff', 'M5_scale_VFI', 'M5_scale_VFI_diff', 'M5_scale_VWAP', 'M5_scale_VWAP_diff', 'M5_scale_Market_Facilitation_Index', 'M5_scale_Market_Facilitation_Index_diff', 'M5_scale_AD_Line', 'M5_scale_AD_Line_diff', 'M5_scale_WAD', 'M5_scale_WAD_diff', 'M5_scale_EMA_15', 'M5_scale_EMA_15_diff', 'M5_scale_Close_minus_EMA_15', 'M5_scale_EMA_21', 'M5_scale_EMA_21_diff', 'M5_scale_Close_minus_EMA_21', 'M5_scale_EMA_50', 'M5_scale_EMA_50_diff', 'M5_scale_Close_minus_EMA_50', 'M5_scale_EMA_100', 'M5_scale_EMA_100_diff', 'M5_scale_Close_minus_EMA_100', 'M5_scale_EMA_200', 'M5_scale_EMA_200_diff', 'M5_scale_Close_minus_EMA_200', 'M5_scale_EMA_15_above_EMA_21', 'M5_scale_EMA_15_above_EMA_50', 'M5_scale_EMA_15_above_EMA_100', 'M5_scale_EMA_15_above_EMA_200', 'M5_scale_EMA_21_above_EMA_50', 'M5_scale_EMA_21_above_EMA_100', 'M5_scale_EMA_21_above_EMA_200', 'M5_scale_EMA_50_above_EMA_100', 'M5_scale_EMA_50_above_EMA_200', 'M5_scale_EMA_100_above_EMA_200', 'M5_scale_OBV', 'M5_scale_RSI_3', 'M5_scale_MFI_3', 'M5_scale_RSI_7', 'M5_scale_MFI_7', 'M5_scale_RSI_14', 'M5_scale_MFI_14', 'M5_scale_RSI_3_diff', 'M5_scale_RSI_7_diff', 'M5_scale_RSI_14_diff', 'M5_scale_RSI_3 - RSI_7', 'M5_scale_RSI_3 - RSI_14', 'M5_scale_RSI_7 - RSI_14', 'M5_scale_MFI_3_diff', 'M5_scale_MFI_7_diff', 'M5_scale_MFI_14_diff', 'M5_scale_MFI_3 - MFI_7', 'M5_scale_MFI_3 - MFI_14', 'M5_scale_MFI_7 - MFI_14', 'M5_scale_OBV_diff', 'M5_scale_Kal_300', 'M5_scale_Close_Kal_300', 'M5_scale_Kal_change_300', 'M5_scale_Kal_prev_minus_now_300', 'M5_scale_Kal_prev2_minus_now_300', 'M5_scale_Kal_change2_300', 'M5_scale_Kal_600', 'M5_scale_Close_Kal_600', 'M5_scale_Kal_change_600', 'M5_scale_Kal_prev_minus_now_600', 'M5_scale_Kal_prev2_minus_now_600', 'M5_scale_Kal_change2_600', 'M5_scale_Kal_900', 'M5_scale_Close_Kal_900', 'M5_scale_Kal_change_900', 'M5_scale_Kal_prev_minus_now_900', 'M5_scale_Kal_prev2_minus_now_900', 'M5_scale_Kal_change2_900', 'M5_scale_Kal_300_minus_Kal_600', 'M5_scale_Kal_300_minus_Kal_900', 'M5_scale_Kal_600_minus_Kal_900', 'M5_scale_slope_div_300_3', 'M5_scale_slope_div_300_3_diff', 'M5_scale_slope_signal_300_3', 'M5_scale_slope_signal_300_3_diff', 'M5_scale_slope_angle_300_3', 'M5_scale_slope_angle_300_3_diff', 'M5_scale_slope_angle_signal_300_3', 'M5_scale_slope_angle_signal_300_3_diff', 'M5_scale_slope_lin_reg_300_3', 'M5_scale_slope_lin_reg_300_3_diff', 'M5_scale_slope_lin_reg_signal_300_3', 'M5_scale_slope_lin_reg_signal_300_3_diff', 'M5_scale_slope_div_300_6', 'M5_scale_slope_div_300_6_diff', 'M5_scale_slope_signal_300_6', 'M5_scale_slope_signal_300_6_diff', 'M5_scale_slope_angle_300_6', 'M5_scale_slope_angle_300_6_diff', 'M5_scale_slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_6_diff', 'M5_scale_slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_6_diff', 'M5_scale_slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_6_diff', 'M5_scale_slope_div_300_9', 'M5_scale_slope_div_300_9_diff', 'M5_scale_slope_signal_300_9', 'M5_scale_slope_signal_300_9_diff', 'M5_scale_slope_angle_300_9', 'M5_scale_slope_angle_300_9_diff', 'M5_scale_slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_9_diff', 'M5_scale_slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_9_diff', 'M5_scale_slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_9_diff', 'M5_scale_slope_div_600_3', 'M5_scale_slope_div_600_3_diff', 'M5_scale_slope_signal_600_3', 'M5_scale_slope_signal_600_3_diff', 'M5_scale_slope_angle_600_3', 'M5_scale_slope_angle_600_3_diff', 'M5_scale_slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_600_3_diff', 'M5_scale_slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_600_3_diff', 'M5_scale_slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_600_3_diff', 'M5_scale_slope_div_600_6', 'M5_scale_slope_div_600_6_diff', 'M5_scale_slope_signal_600_6', 'M5_scale_slope_signal_600_6_diff', 'M5_scale_slope_angle_600_6', 'M5_scale_slope_angle_600_6_diff', 'M5_scale_slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_6_diff', 'M5_scale_slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_6_diff', 'M5_scale_slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_6_diff', 'M5_scale_slope_div_600_9', 'M5_scale_slope_div_600_9_diff', 'M5_scale_slope_signal_600_9', 'M5_scale_slope_signal_600_9_diff', 'M5_scale_slope_angle_600_9', 'M5_scale_slope_angle_600_9_diff', 'M5_scale_slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_9_diff', 'M5_scale_slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_9_diff', 'M5_scale_slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_9_diff', 'M5_scale_slope_div_900_3', 'M5_scale_slope_div_900_3_diff', 'M5_scale_slope_signal_900_3', 'M5_scale_slope_signal_900_3_diff', 'M5_scale_slope_angle_900_3', 'M5_scale_slope_angle_900_3_diff', 'M5_scale_slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_900_3_diff', 'M5_scale_slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_900_3_diff', 'M5_scale_slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_900_3_diff', 'M5_scale_slope_div_900_6', 'M5_scale_slope_div_900_6_diff', 'M5_scale_slope_signal_900_6', 'M5_scale_slope_signal_900_6_diff', 'M5_scale_slope_angle_900_6', 'M5_scale_slope_angle_900_6_diff', 'M5_scale_slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_6_diff', 'M5_scale_slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_6_diff', 'M5_scale_slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_6_diff', 'M5_scale_slope_div_900_9', 'M5_scale_slope_div_900_9_diff', 'M5_scale_slope_signal_900_9', 'M5_scale_slope_signal_900_9_diff', 'M5_scale_slope_angle_900_9', 'M5_scale_slope_angle_900_9_diff', 'M5_scale_slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_9_diff', 'M5_scale_slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_9_diff', 'M5_scale_slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_9_diff', 'M5_scale_slope_div_300_3 - slope_div_300_6', 'M5_scale_slope_div_300_3 - slope_div_300_9', 'M5_scale_slope_div_300_3 - slope_div_600_3', 'M5_scale_slope_div_300_3 - slope_div_600_6', 'M5_scale_slope_div_300_3 - slope_div_600_9', 'M5_scale_slope_div_300_3 - slope_div_900_3', 'M5_scale_slope_div_300_3 - slope_div_900_6', 'M5_scale_slope_div_300_3 - slope_div_900_9', 'M5_scale_slope_div_300_6 - slope_div_300_9', 'M5_scale_slope_div_300_6 - slope_div_600_3', 'M5_scale_slope_div_300_6 - slope_div_600_6', 'M5_scale_slope_div_300_6 - slope_div_600_9', 'M5_scale_slope_div_300_6 - slope_div_900_3', 'M5_scale_slope_div_300_6 - slope_div_900_6', 'M5_scale_slope_div_300_6 - slope_div_900_9', 'M5_scale_slope_div_300_9 - slope_div_600_3', 'M5_scale_slope_div_300_9 - slope_div_600_6', 'M5_scale_slope_div_300_9 - slope_div_600_9', 'M5_scale_slope_div_300_9 - slope_div_900_3', 'M5_scale_slope_div_300_9 - slope_div_900_6', 'M5_scale_slope_div_300_9 - slope_div_900_9', 'M5_scale_slope_div_600_3 - slope_div_600_6', 'M5_scale_slope_div_600_3 - slope_div_600_9', 'M5_scale_slope_div_600_3 - slope_div_900_3', 'M5_scale_slope_div_600_3 - slope_div_900_6', 'M5_scale_slope_div_600_3 - slope_div_900_9', 'M5_scale_slope_div_600_6 - slope_div_600_9', 'M5_scale_slope_div_600_6 - slope_div_900_3', 'M5_scale_slope_div_600_6 - slope_div_900_6', 'M5_scale_slope_div_600_6 - slope_div_900_9', 'M5_scale_slope_div_600_9 - slope_div_900_3', 'M5_scale_slope_div_600_9 - slope_div_900_6', 'M5_scale_slope_div_600_9 - slope_div_900_9', 'M5_scale_slope_div_900_3 - slope_div_900_6', 'M5_scale_slope_div_900_3 - slope_div_900_9', 'M5_scale_slope_div_900_6 - slope_div_900_9', 'M5_scale_slope_signal_300_3 - slope_signal_300_6', 'M5_scale_slope_signal_300_3 - slope_signal_300_9', 'M5_scale_slope_signal_300_3 - slope_signal_600_3', 'M5_scale_slope_signal_300_3 - slope_signal_600_6', 'M5_scale_slope_signal_300_3 - slope_signal_600_9', 'M5_scale_slope_signal_300_3 - slope_signal_900_3', 'M5_scale_slope_signal_300_3 - slope_signal_900_6', 'M5_scale_slope_signal_300_3 - slope_signal_900_9', 'M5_scale_slope_signal_300_6 - slope_signal_300_9', 'M5_scale_slope_signal_300_6 - slope_signal_600_3', 'M5_scale_slope_signal_300_6 - slope_signal_600_6', 'M5_scale_slope_signal_300_6 - slope_signal_600_9', 'M5_scale_slope_signal_300_6 - slope_signal_900_3', 'M5_scale_slope_signal_300_6 - slope_signal_900_6', 'M5_scale_slope_signal_300_6 - slope_signal_900_9', 'M5_scale_slope_signal_300_9 - slope_signal_600_3', 'M5_scale_slope_signal_300_9 - slope_signal_600_6', 'M5_scale_slope_signal_300_9 - slope_signal_600_9', 'M5_scale_slope_signal_300_9 - slope_signal_900_3', 'M5_scale_slope_signal_300_9 - slope_signal_900_6', 'M5_scale_slope_signal_300_9 - slope_signal_900_9', 'M5_scale_slope_signal_600_3 - slope_signal_600_6', 'M5_scale_slope_signal_600_3 - slope_signal_600_9', 'M5_scale_slope_signal_600_3 - slope_signal_900_3', 'M5_scale_slope_signal_600_3 - slope_signal_900_6', 'M5_scale_slope_signal_600_3 - slope_signal_900_9', 'M5_scale_slope_signal_600_6 - slope_signal_600_9', 'M5_scale_slope_signal_600_6 - slope_signal_900_3', 'M5_scale_slope_signal_600_6 - slope_signal_900_6', 'M5_scale_slope_signal_600_6 - slope_signal_900_9', 'M5_scale_slope_signal_600_9 - slope_signal_900_3', 'M5_scale_slope_signal_600_9 - slope_signal_900_6', 'M5_scale_slope_signal_600_9 - slope_signal_900_9', 'M5_scale_slope_signal_900_3 - slope_signal_900_6', 'M5_scale_slope_signal_900_3 - slope_signal_900_9', 'M5_scale_slope_signal_900_6 - slope_signal_900_9', 'M5_scale_slope_angle_300_3 - slope_angle_300_6', 'M5_scale_slope_angle_300_3 - slope_angle_300_9', 'M5_scale_slope_angle_300_3 - slope_angle_600_3', 'M5_scale_slope_angle_300_3 - slope_angle_600_6', 'M5_scale_slope_angle_300_3 - slope_angle_600_9', 'M5_scale_slope_angle_300_3 - slope_angle_900_3', 'M5_scale_slope_angle_300_3 - slope_angle_900_6', 'M5_scale_slope_angle_300_3 - slope_angle_900_9', 'M5_scale_slope_angle_300_6 - slope_angle_300_9', 'M5_scale_slope_angle_300_6 - slope_angle_600_3', 'M5_scale_slope_angle_300_6 - slope_angle_600_6', 'M5_scale_slope_angle_300_6 - slope_angle_600_9', 'M5_scale_slope_angle_300_6 - slope_angle_900_3', 'M5_scale_slope_angle_300_6 - slope_angle_900_6', 'M5_scale_slope_angle_300_6 - slope_angle_900_9', 'M5_scale_slope_angle_300_9 - slope_angle_600_3', 'M5_scale_slope_angle_300_9 - slope_angle_600_6', 'M5_scale_slope_angle_300_9 - slope_angle_600_9', 'M5_scale_slope_angle_300_9 - slope_angle_900_3', 'M5_scale_slope_angle_300_9 - slope_angle_900_6', 'M5_scale_slope_angle_300_9 - slope_angle_900_9', 'M5_scale_slope_angle_600_3 - slope_angle_600_6', 'M5_scale_slope_angle_600_3 - slope_angle_600_9', 'M5_scale_slope_angle_600_3 - slope_angle_900_3', 'M5_scale_slope_angle_600_3 - slope_angle_900_6', 'M5_scale_slope_angle_600_3 - slope_angle_900_9', 'M5_scale_slope_angle_600_6 - slope_angle_600_9', 'M5_scale_slope_angle_600_6 - slope_angle_900_3', 'M5_scale_slope_angle_600_6 - slope_angle_900_6', 'M5_scale_slope_angle_600_6 - slope_angle_900_9', 'M5_scale_slope_angle_600_9 - slope_angle_900_3', 'M5_scale_slope_angle_600_9 - slope_angle_900_6', 'M5_scale_slope_angle_600_9 - slope_angle_900_9', 'M5_scale_slope_angle_900_3 - slope_angle_900_6', 'M5_scale_slope_angle_900_3 - slope_angle_900_9', 'M5_scale_slope_angle_900_6 - slope_angle_900_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_MACD_12_26_9', 'M10_raw_10min_MACD_12_26_9_diff', 'M10_raw_10min_MACD_signal_12_26_9', 'M10_raw_10min_MACD_signal_12_26_9_diff', 'M10_raw_10min_MACD_hist_12_26_9', 'M10_raw_10min_MACD_hist_12_26_9_diff', 'M10_raw_10min_RSI_basic_14', 'M10_raw_10min_RSI_basic_14_diff', 'M10_raw_10min_BB_upper_20', 'M10_raw_10min_BB_upper_20_diff', 'M10_raw_10min_BB_middle_20', 'M10_raw_10min_BB_middle_20_diff', 'M10_raw_10min_BB_lower_20', 'M10_raw_10min_BB_lower_20_diff', 'M10_raw_10min_ATR_14', 'M10_raw_10min_ATR_14_diff', 'M10_raw_10min_OBV_basic', 'M10_raw_10min_OBV_basic_diff', 'M10_raw_10min_VWAP_basic', 'M10_raw_10min_VWAP_basic_diff', 'M10_raw_10min_Momentum_10', 'M10_raw_10min_Momentum_10_diff', 'M10_raw_10min_ROC_10', 'M10_raw_10min_ROC_10_diff', 'M10_raw_10min_Stoch_K_14_3_3', 'M10_raw_10min_Stoch_K_14_3_3_diff', 'M10_raw_10min_Stoch_D_14_3_3', 'M10_raw_10min_Stoch_D_14_3_3_diff', 'M10_raw_10min_CCI_20', 'M10_raw_10min_CCI_20_diff', 'M10_raw_10min_MFI_basic_14', 'M10_raw_10min_MFI_basic_14_diff', 'M10_raw_10min_ADX_14', 'M10_raw_10min_ADX_14_diff', 'M10_raw_10min_WilliamsR_14', 'M10_raw_10min_WilliamsR_14_diff', 'M10_raw_10min_CMF', 'M10_raw_10min_CMF_diff', 'M10_raw_10min_TMF', 'M10_raw_10min_TMF_diff', 'M10_raw_10min_MFI_14_volume', 'M10_raw_10min_MFI_14_volume_diff', 'M10_raw_10min_KO', 'M10_raw_10min_KO_diff', 'M10_raw_10min_EFI', 'M10_raw_10min_EFI_diff', 'M10_raw_10min_EOM', 'M10_raw_10min_EOM_diff', 'M10_raw_10min_VPT', 'M10_raw_10min_VPT_diff', 'M10_raw_10min_NVI', 'M10_raw_10min_NVI_diff', 'M10_raw_10min_PVI', 'M10_raw_10min_PVI_diff', 'M10_raw_10min_VFI', 'M10_raw_10min_VFI_diff', 'M10_raw_10min_VWAP', 'M10_raw_10min_VWAP_diff', 'M10_raw_10min_Market_Facilitation_Index', 'M10_raw_10min_Market_Facilitation_Index_diff', 'M10_raw_10min_AD_Line', 'M10_raw_10min_AD_Line_diff', 'M10_raw_10min_WAD', 'M10_raw_10min_WAD_diff', 'M10_raw_10min_EMA_15', 'M10_raw_10min_EMA_15_diff', 'M10_raw_10min_Close_minus_EMA_15', 'M10_raw_10min_EMA_21', 'M10_raw_10min_EMA_21_diff', 'M10_raw_10min_Close_minus_EMA_21', 'M10_raw_10min_EMA_50', 'M10_raw_10min_EMA_50_diff', 'M10_raw_10min_Close_minus_EMA_50', 'M10_raw_10min_EMA_100', 'M10_raw_10min_EMA_100_diff', 'M10_raw_10min_Close_minus_EMA_100', 'M10_raw_10min_EMA_200', 'M10_raw_10min_EMA_200_diff', 'M10_raw_10min_Close_minus_EMA_200', 'M10_raw_10min_EMA_15_above_EMA_21', 'M10_raw_10min_EMA_15_above_EMA_50', 'M10_raw_10min_EMA_15_above_EMA_100', 'M10_raw_10min_EMA_15_above_EMA_200', 'M10_raw_10min_EMA_21_above_EMA_50', 'M10_raw_10min_EMA_21_above_EMA_100', 'M10_raw_10min_EMA_21_above_EMA_200', 'M10_raw_10min_EMA_50_above_EMA_100', 'M10_raw_10min_EMA_50_above_EMA_200', 'M10_raw_10min_EMA_100_above_EMA_200', 'M10_raw_10min_OBV', 'M10_raw_10min_RSI_3', 'M10_raw_10min_MFI_3', 'M10_raw_10min_RSI_7', 'M10_raw_10min_MFI_7', 'M10_raw_10min_RSI_14', 'M10_raw_10min_MFI_14', 'M10_raw_10min_RSI_3_diff', 'M10_raw_10min_RSI_7_diff', 'M10_raw_10min_RSI_14_diff', 'M10_raw_10min_RSI_3 - RSI_7', 'M10_raw_10min_RSI_3 - RSI_14', 'M10_raw_10min_RSI_7 - RSI_14', 'M10_raw_10min_MFI_3_diff', 'M10_raw_10min_MFI_7_diff', 'M10_raw_10min_MFI_14_diff', 'M10_raw_10min_MFI_3 - MFI_7', 'M10_raw_10min_MFI_3 - MFI_14', 'M10_raw_10min_MFI_7 - MFI_14', 'M10_raw_10min_OBV_diff', 'M10_raw_10min_Kal_300', 'M10_raw_10min_Close_Kal_300', 'M10_raw_10min_Kal_change_300', 'M10_raw_10min_Kal_prev_minus_now_300', 'M10_raw_10min_Kal_prev2_minus_now_300', 'M10_raw_10min_Kal_change2_300', 'M10_raw_10min_Kal_600', 'M10_raw_10min_Close_Kal_600', 'M10_raw_10min_Kal_change_600', 'M10_raw_10min_Kal_prev_minus_now_600', 'M10_raw_10min_Kal_prev2_minus_now_600', 'M10_raw_10min_Kal_change2_600', 'M10_raw_10min_Kal_900', 'M10_raw_10min_Close_Kal_900', 'M10_raw_10min_Kal_change_900', 'M10_raw_10min_Kal_prev_minus_now_900', 'M10_raw_10min_Kal_prev2_minus_now_900', 'M10_raw_10min_Kal_change2_900', 'M10_raw_10min_Kal_300_minus_Kal_600', 'M10_raw_10min_Kal_300_minus_Kal_900', 'M10_raw_10min_Kal_600_minus_Kal_900', 'M10_raw_10min_slope_div_300_3', 'M10_raw_10min_slope_div_300_3_diff', 'M10_raw_10min_slope_signal_300_3', 'M10_raw_10min_slope_signal_300_3_diff', 'M10_raw_10min_slope_angle_300_3', 'M10_raw_10min_slope_angle_300_3_diff', 'M10_raw_10min_slope_angle_signal_300_3', 'M10_raw_10min_slope_angle_signal_300_3_diff', 'M10_raw_10min_slope_lin_reg_300_3', 'M10_raw_10min_slope_lin_reg_300_3_diff', 'M10_raw_10min_slope_lin_reg_signal_300_3', 'M10_raw_10min_slope_lin_reg_signal_300_3_diff', 'M10_raw_10min_slope_div_300_6', 'M10_raw_10min_slope_div_300_6_diff', 'M10_raw_10min_slope_signal_300_6', 'M10_raw_10min_slope_signal_300_6_diff', 'M10_raw_10min_slope_angle_300_6', 'M10_raw_10min_slope_angle_300_6_diff', 'M10_raw_10min_slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_6_diff', 'M10_raw_10min_slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_6_diff', 'M10_raw_10min_slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_6_diff', 'M10_raw_10min_slope_div_300_9', 'M10_raw_10min_slope_div_300_9_diff', 'M10_raw_10min_slope_signal_300_9', 'M10_raw_10min_slope_signal_300_9_diff', 'M10_raw_10min_slope_angle_300_9', 'M10_raw_10min_slope_angle_300_9_diff', 'M10_raw_10min_slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_9_diff', 'M10_raw_10min_slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_9_diff', 'M10_raw_10min_slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_9_diff', 'M10_raw_10min_slope_div_600_3', 'M10_raw_10min_slope_div_600_3_diff', 'M10_raw_10min_slope_signal_600_3', 'M10_raw_10min_slope_signal_600_3_diff', 'M10_raw_10min_slope_angle_600_3', 'M10_raw_10min_slope_angle_600_3_diff', 'M10_raw_10min_slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_600_3_diff', 'M10_raw_10min_slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_600_3_diff', 'M10_raw_10min_slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_600_3_diff', 'M10_raw_10min_slope_div_600_6', 'M10_raw_10min_slope_div_600_6_diff', 'M10_raw_10min_slope_signal_600_6', 'M10_raw_10min_slope_signal_600_6_diff', 'M10_raw_10min_slope_angle_600_6', 'M10_raw_10min_slope_angle_600_6_diff', 'M10_raw_10min_slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_6_diff', 'M10_raw_10min_slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_6_diff', 'M10_raw_10min_slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_6_diff', 'M10_raw_10min_slope_div_600_9', 'M10_raw_10min_slope_div_600_9_diff', 'M10_raw_10min_slope_signal_600_9', 'M10_raw_10min_slope_signal_600_9_diff', 'M10_raw_10min_slope_angle_600_9', 'M10_raw_10min_slope_angle_600_9_diff', 'M10_raw_10min_slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_9_diff', 'M10_raw_10min_slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_9_diff', 'M10_raw_10min_slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_9_diff', 'M10_raw_10min_slope_div_900_3', 'M10_raw_10min_slope_div_900_3_diff', 'M10_raw_10min_slope_signal_900_3', 'M10_raw_10min_slope_signal_900_3_diff', 'M10_raw_10min_slope_angle_900_3', 'M10_raw_10min_slope_angle_900_3_diff', 'M10_raw_10min_slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_900_3_diff', 'M10_raw_10min_slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_900_3_diff', 'M10_raw_10min_slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_900_3_diff', 'M10_raw_10min_slope_div_900_6', 'M10_raw_10min_slope_div_900_6_diff', 'M10_raw_10min_slope_signal_900_6', 'M10_raw_10min_slope_signal_900_6_diff', 'M10_raw_10min_slope_angle_900_6', 'M10_raw_10min_slope_angle_900_6_diff', 'M10_raw_10min_slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_6_diff', 'M10_raw_10min_slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_6_diff', 'M10_raw_10min_slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_6_diff', 'M10_raw_10min_slope_div_900_9', 'M10_raw_10min_slope_div_900_9_diff', 'M10_raw_10min_slope_signal_900_9', 'M10_raw_10min_slope_signal_900_9_diff', 'M10_raw_10min_slope_angle_900_9', 'M10_raw_10min_slope_angle_900_9_diff', 'M10_raw_10min_slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_9_diff', 'M10_raw_10min_slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_9_diff', 'M10_raw_10min_slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_9_diff', 'M10_raw_10min_slope_div_300_3 - slope_div_300_6', 'M10_raw_10min_slope_div_300_3 - slope_div_300_9', 'M10_raw_10min_slope_div_300_3 - slope_div_600_3', 'M10_raw_10min_slope_div_300_3 - slope_div_600_6', 'M10_raw_10min_slope_div_300_3 - slope_div_600_9', 'M10_raw_10min_slope_div_300_3 - slope_div_900_3', 'M10_raw_10min_slope_div_300_3 - slope_div_900_6', 'M10_raw_10min_slope_div_300_3 - slope_div_900_9', 'M10_raw_10min_slope_div_300_6 - slope_div_300_9', 'M10_raw_10min_slope_div_300_6 - slope_div_600_3', 'M10_raw_10min_slope_div_300_6 - slope_div_600_6', 'M10_raw_10min_slope_div_300_6 - slope_div_600_9', 'M10_raw_10min_slope_div_300_6 - slope_div_900_3', 'M10_raw_10min_slope_div_300_6 - slope_div_900_6', 'M10_raw_10min_slope_div_300_6 - slope_div_900_9', 'M10_raw_10min_slope_div_300_9 - slope_div_600_3', 'M10_raw_10min_slope_div_300_9 - slope_div_600_6', 'M10_raw_10min_slope_div_300_9 - slope_div_600_9', 'M10_raw_10min_slope_div_300_9 - slope_div_900_3', 'M10_raw_10min_slope_div_300_9 - slope_div_900_6', 'M10_raw_10min_slope_div_300_9 - slope_div_900_9', 'M10_raw_10min_slope_div_600_3 - slope_div_600_6', 'M10_raw_10min_slope_div_600_3 - slope_div_600_9', 'M10_raw_10min_slope_div_600_3 - slope_div_900_3', 'M10_raw_10min_slope_div_600_3 - slope_div_900_6', 'M10_raw_10min_slope_div_600_3 - slope_div_900_9', 'M10_raw_10min_slope_div_600_6 - slope_div_600_9', 'M10_raw_10min_slope_div_600_6 - slope_div_900_3', 'M10_raw_10min_slope_div_600_6 - slope_div_900_6', 'M10_raw_10min_slope_div_600_6 - slope_div_900_9', 'M10_raw_10min_slope_div_600_9 - slope_div_900_3', 'M10_raw_10min_slope_div_600_9 - slope_div_900_6', 'M10_raw_10min_slope_div_600_9 - slope_div_900_9', 'M10_raw_10min_slope_div_900_3 - slope_div_900_6', 'M10_raw_10min_slope_div_900_3 - slope_div_900_9', 'M10_raw_10min_slope_div_900_6 - slope_div_900_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_MACD_12_26_9', 'M10_scale_10min_MACD_12_26_9_diff', 'M10_scale_10min_MACD_signal_12_26_9', 'M10_scale_10min_MACD_signal_12_26_9_diff', 'M10_scale_10min_MACD_hist_12_26_9', 'M10_scale_10min_MACD_hist_12_26_9_diff', 'M10_scale_10min_RSI_basic_14', 'M10_scale_10min_RSI_basic_14_diff', 'M10_scale_10min_BB_upper_20', 'M10_scale_10min_BB_upper_20_diff', 'M10_scale_10min_BB_middle_20', 'M10_scale_10min_BB_middle_20_diff', 'M10_scale_10min_BB_lower_20', 'M10_scale_10min_BB_lower_20_diff', 'M10_scale_10min_ATR_14', 'M10_scale_10min_ATR_14_diff', 'M10_scale_10min_OBV_basic', 'M10_scale_10min_OBV_basic_diff', 'M10_scale_10min_VWAP_basic', 'M10_scale_10min_VWAP_basic_diff', 'M10_scale_10min_Momentum_10', 'M10_scale_10min_Momentum_10_diff', 'M10_scale_10min_ROC_10', 'M10_scale_10min_ROC_10_diff', 'M10_scale_10min_Stoch_K_14_3_3', 'M10_scale_10min_Stoch_K_14_3_3_diff', 'M10_scale_10min_Stoch_D_14_3_3', 'M10_scale_10min_Stoch_D_14_3_3_diff', 'M10_scale_10min_CCI_20', 'M10_scale_10min_CCI_20_diff', 'M10_scale_10min_MFI_basic_14', 'M10_scale_10min_MFI_basic_14_diff', 'M10_scale_10min_ADX_14', 'M10_scale_10min_ADX_14_diff', 'M10_scale_10min_WilliamsR_14', 'M10_scale_10min_WilliamsR_14_diff', 'M10_scale_10min_CMF', 'M10_scale_10min_CMF_diff', 'M10_scale_10min_TMF', 'M10_scale_10min_TMF_diff', 'M10_scale_10min_MFI_14_volume', 'M10_scale_10min_MFI_14_volume_diff', 'M10_scale_10min_KO', 'M10_scale_10min_KO_diff', 'M10_scale_10min_EFI', 'M10_scale_10min_EFI_diff', 'M10_scale_10min_EOM', 'M10_scale_10min_EOM_diff', 'M10_scale_10min_VPT', 'M10_scale_10min_VPT_diff', 'M10_scale_10min_NVI', 'M10_scale_10min_NVI_diff', 'M10_scale_10min_PVI', 'M10_scale_10min_PVI_diff', 'M10_scale_10min_VFI', 'M10_scale_10min_VFI_diff', 'M10_scale_10min_VWAP', 'M10_scale_10min_VWAP_diff', 'M10_scale_10min_Market_Facilitation_Index', 'M10_scale_10min_Market_Facilitation_Index_diff', 'M10_scale_10min_AD_Line', 'M10_scale_10min_AD_Line_diff', 'M10_scale_10min_WAD', 'M10_scale_10min_WAD_diff', 'M10_scale_10min_EMA_15', 'M10_scale_10min_EMA_15_diff', 'M10_scale_10min_Close_minus_EMA_15', 'M10_scale_10min_EMA_21', 'M10_scale_10min_EMA_21_diff', 'M10_scale_10min_Close_minus_EMA_21', 'M10_scale_10min_EMA_50', 'M10_scale_10min_EMA_50_diff', 'M10_scale_10min_Close_minus_EMA_50', 'M10_scale_10min_EMA_100', 'M10_scale_10min_EMA_100_diff', 'M10_scale_10min_Close_minus_EMA_100', 'M10_scale_10min_EMA_200', 'M10_scale_10min_EMA_200_diff', 'M10_scale_10min_Close_minus_EMA_200', 'M10_scale_10min_EMA_15_above_EMA_21', 'M10_scale_10min_EMA_15_above_EMA_50', 'M10_scale_10min_EMA_15_above_EMA_100', 'M10_scale_10min_EMA_15_above_EMA_200', 'M10_scale_10min_EMA_21_above_EMA_50', 'M10_scale_10min_EMA_21_above_EMA_100', 'M10_scale_10min_EMA_21_above_EMA_200', 'M10_scale_10min_EMA_50_above_EMA_100', 'M10_scale_10min_EMA_50_above_EMA_200', 'M10_scale_10min_EMA_100_above_EMA_200', 'M10_scale_10min_OBV', 'M10_scale_10min_RSI_3', 'M10_scale_10min_MFI_3', 'M10_scale_10min_RSI_7', 'M10_scale_10min_MFI_7', 'M10_scale_10min_RSI_14', 'M10_scale_10min_MFI_14', 'M10_scale_10min_RSI_3_diff', 'M10_scale_10min_RSI_7_diff', 'M10_scale_10min_RSI_14_diff', 'M10_scale_10min_RSI_3 - RSI_7', 'M10_scale_10min_RSI_3 - RSI_14', 'M10_scale_10min_RSI_7 - RSI_14', 'M10_scale_10min_MFI_3_diff', 'M10_scale_10min_MFI_7_diff', 'M10_scale_10min_MFI_14_diff', 'M10_scale_10min_MFI_3 - MFI_7', 'M10_scale_10min_MFI_3 - MFI_14', 'M10_scale_10min_MFI_7 - MFI_14', 'M10_scale_10min_OBV_diff', 'M10_scale_10min_Kal_300', 'M10_scale_10min_Close_Kal_300', 'M10_scale_10min_Kal_change_300', 'M10_scale_10min_Kal_prev_minus_now_300', 'M10_scale_10min_Kal_prev2_minus_now_300', 'M10_scale_10min_Kal_change2_300', 'M10_scale_10min_Kal_600', 'M10_scale_10min_Close_Kal_600', 'M10_scale_10min_Kal_change_600', 'M10_scale_10min_Kal_prev_minus_now_600', 'M10_scale_10min_Kal_prev2_minus_now_600', 'M10_scale_10min_Kal_change2_600', 'M10_scale_10min_Kal_900', 'M10_scale_10min_Close_Kal_900', 'M10_scale_10min_Kal_change_900', 'M10_scale_10min_Kal_prev_minus_now_900', 'M10_scale_10min_Kal_prev2_minus_now_900', 'M10_scale_10min_Kal_change2_900', 'M10_scale_10min_Kal_300_minus_Kal_600', 'M10_scale_10min_Kal_300_minus_Kal_900', 'M10_scale_10min_Kal_600_minus_Kal_900', 'M10_scale_10min_slope_div_300_3', 'M10_scale_10min_slope_div_300_3_diff', 'M10_scale_10min_slope_signal_300_3', 'M10_scale_10min_slope_signal_300_3_diff', 'M10_scale_10min_slope_angle_300_3', 'M10_scale_10min_slope_angle_300_3_diff', 'M10_scale_10min_slope_angle_signal_300_3', 'M10_scale_10min_slope_angle_signal_300_3_diff', 'M10_scale_10min_slope_lin_reg_300_3', 'M10_scale_10min_slope_lin_reg_300_3_diff', 'M10_scale_10min_slope_lin_reg_signal_300_3', 'M10_scale_10min_slope_lin_reg_signal_300_3_diff', 'M10_scale_10min_slope_div_300_6', 'M10_scale_10min_slope_div_300_6_diff', 'M10_scale_10min_slope_signal_300_6', 'M10_scale_10min_slope_signal_300_6_diff', 'M10_scale_10min_slope_angle_300_6', 'M10_scale_10min_slope_angle_300_6_diff', 'M10_scale_10min_slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_6_diff', 'M10_scale_10min_slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_6_diff', 'M10_scale_10min_slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_6_diff', 'M10_scale_10min_slope_div_300_9', 'M10_scale_10min_slope_div_300_9_diff', 'M10_scale_10min_slope_signal_300_9', 'M10_scale_10min_slope_signal_300_9_diff', 'M10_scale_10min_slope_angle_300_9', 'M10_scale_10min_slope_angle_300_9_diff', 'M10_scale_10min_slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_9_diff', 'M10_scale_10min_slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_9_diff', 'M10_scale_10min_slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_9_diff', 'M10_scale_10min_slope_div_600_3', 'M10_scale_10min_slope_div_600_3_diff', 'M10_scale_10min_slope_signal_600_3', 'M10_scale_10min_slope_signal_600_3_diff', 'M10_scale_10min_slope_angle_600_3', 'M10_scale_10min_slope_angle_600_3_diff', 'M10_scale_10min_slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_600_3_diff', 'M10_scale_10min_slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_600_3_diff', 'M10_scale_10min_slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_600_3_diff', 'M10_scale_10min_slope_div_600_6', 'M10_scale_10min_slope_div_600_6_diff', 'M10_scale_10min_slope_signal_600_6', 'M10_scale_10min_slope_signal_600_6_diff', 'M10_scale_10min_slope_angle_600_6', 'M10_scale_10min_slope_angle_600_6_diff', 'M10_scale_10min_slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_6_diff', 'M10_scale_10min_slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_6_diff', 'M10_scale_10min_slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_6_diff', 'M10_scale_10min_slope_div_600_9', 'M10_scale_10min_slope_div_600_9_diff', 'M10_scale_10min_slope_signal_600_9', 'M10_scale_10min_slope_signal_600_9_diff', 'M10_scale_10min_slope_angle_600_9', 'M10_scale_10min_slope_angle_600_9_diff', 'M10_scale_10min_slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_9_diff', 'M10_scale_10min_slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_9_diff', 'M10_scale_10min_slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_9_diff', 'M10_scale_10min_slope_div_900_3', 'M10_scale_10min_slope_div_900_3_diff', 'M10_scale_10min_slope_signal_900_3', 'M10_scale_10min_slope_signal_900_3_diff', 'M10_scale_10min_slope_angle_900_3', 'M10_scale_10min_slope_angle_900_3_diff', 'M10_scale_10min_slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_900_3_diff', 'M10_scale_10min_slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_900_3_diff', 'M10_scale_10min_slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_900_3_diff', 'M10_scale_10min_slope_div_900_6', 'M10_scale_10min_slope_div_900_6_diff', 'M10_scale_10min_slope_signal_900_6', 'M10_scale_10min_slope_signal_900_6_diff', 'M10_scale_10min_slope_angle_900_6', 'M10_scale_10min_slope_angle_900_6_diff', 'M10_scale_10min_slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_6_diff', 'M10_scale_10min_slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_6_diff', 'M10_scale_10min_slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_6_diff', 'M10_scale_10min_slope_div_900_9', 'M10_scale_10min_slope_div_900_9_diff', 'M10_scale_10min_slope_signal_900_9', 'M10_scale_10min_slope_signal_900_9_diff', 'M10_scale_10min_slope_angle_900_9', 'M10_scale_10min_slope_angle_900_9_diff', 'M10_scale_10min_slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_9_diff', 'M10_scale_10min_slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_9_diff', 'M10_scale_10min_slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_9_diff', 'M10_scale_10min_slope_div_300_3 - slope_div_300_6', 'M10_scale_10min_slope_div_300_3 - slope_div_300_9', 'M10_scale_10min_slope_div_300_3 - slope_div_600_3', 'M10_scale_10min_slope_div_300_3 - slope_div_600_6', 'M10_scale_10min_slope_div_300_3 - slope_div_600_9', 'M10_scale_10min_slope_div_300_3 - slope_div_900_3', 'M10_scale_10min_slope_div_300_3 - slope_div_900_6', 'M10_scale_10min_slope_div_300_3 - slope_div_900_9', 'M10_scale_10min_slope_div_300_6 - slope_div_300_9', 'M10_scale_10min_slope_div_300_6 - slope_div_600_3', 'M10_scale_10min_slope_div_300_6 - slope_div_600_6', 'M10_scale_10min_slope_div_300_6 - slope_div_600_9', 'M10_scale_10min_slope_div_300_6 - slope_div_900_3', 'M10_scale_10min_slope_div_300_6 - slope_div_900_6', 'M10_scale_10min_slope_div_300_6 - slope_div_900_9', 'M10_scale_10min_slope_div_300_9 - slope_div_600_3', 'M10_scale_10min_slope_div_300_9 - slope_div_600_6', 'M10_scale_10min_slope_div_300_9 - slope_div_600_9', 'M10_scale_10min_slope_div_300_9 - slope_div_900_3', 'M10_scale_10min_slope_div_300_9 - slope_div_900_6', 'M10_scale_10min_slope_div_300_9 - slope_div_900_9', 'M10_scale_10min_slope_div_600_3 - slope_div_600_6', 'M10_scale_10min_slope_div_600_3 - slope_div_600_9', 'M10_scale_10min_slope_div_600_3 - slope_div_900_3', 'M10_scale_10min_slope_div_600_3 - slope_div_900_6', 'M10_scale_10min_slope_div_600_3 - slope_div_900_9', 'M10_scale_10min_slope_div_600_6 - slope_div_600_9', 'M10_scale_10min_slope_div_600_6 - slope_div_900_3', 'M10_scale_10min_slope_div_600_6 - slope_div_900_6', 'M10_scale_10min_slope_div_600_6 - slope_div_900_9', 'M10_scale_10min_slope_div_600_9 - slope_div_900_3', 'M10_scale_10min_slope_div_600_9 - slope_div_900_6', 'M10_scale_10min_slope_div_600_9 - slope_div_900_9', 'M10_scale_10min_slope_div_900_3 - slope_div_900_6', 'M10_scale_10min_slope_div_900_3 - slope_div_900_9', 'M10_scale_10min_slope_div_900_6 - slope_div_900_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_MACD_12_26_9', 'M15_raw_15min_MACD_12_26_9_diff', 'M15_raw_15min_MACD_signal_12_26_9', 'M15_raw_15min_MACD_signal_12_26_9_diff', 'M15_raw_15min_MACD_hist_12_26_9', 'M15_raw_15min_MACD_hist_12_26_9_diff', 'M15_raw_15min_RSI_basic_14', 'M15_raw_15min_RSI_basic_14_diff', 'M15_raw_15min_BB_upper_20', 'M15_raw_15min_BB_upper_20_diff', 'M15_raw_15min_BB_middle_20', 'M15_raw_15min_BB_middle_20_diff', 'M15_raw_15min_BB_lower_20', 'M15_raw_15min_BB_lower_20_diff', 'M15_raw_15min_ATR_14', 'M15_raw_15min_ATR_14_diff', 'M15_raw_15min_OBV_basic', 'M15_raw_15min_OBV_basic_diff', 'M15_raw_15min_VWAP_basic', 'M15_raw_15min_VWAP_basic_diff', 'M15_raw_15min_Momentum_10', 'M15_raw_15min_Momentum_10_diff', 'M15_raw_15min_ROC_10', 'M15_raw_15min_ROC_10_diff', 'M15_raw_15min_Stoch_K_14_3_3', 'M15_raw_15min_Stoch_K_14_3_3_diff', 'M15_raw_15min_Stoch_D_14_3_3', 'M15_raw_15min_Stoch_D_14_3_3_diff', 'M15_raw_15min_CCI_20', 'M15_raw_15min_CCI_20_diff', 'M15_raw_15min_MFI_basic_14', 'M15_raw_15min_MFI_basic_14_diff', 'M15_raw_15min_ADX_14', 'M15_raw_15min_ADX_14_diff', 'M15_raw_15min_WilliamsR_14', 'M15_raw_15min_WilliamsR_14_diff', 'M15_raw_15min_CMF', 'M15_raw_15min_CMF_diff', 'M15_raw_15min_TMF', 'M15_raw_15min_TMF_diff', 'M15_raw_15min_MFI_14_volume', 'M15_raw_15min_MFI_14_volume_diff', 'M15_raw_15min_KO', 'M15_raw_15min_KO_diff', 'M15_raw_15min_EFI', 'M15_raw_15min_EFI_diff', 'M15_raw_15min_EOM', 'M15_raw_15min_EOM_diff', 'M15_raw_15min_VPT', 'M15_raw_15min_VPT_diff', 'M15_raw_15min_NVI', 'M15_raw_15min_NVI_diff', 'M15_raw_15min_PVI', 'M15_raw_15min_PVI_diff', 'M15_raw_15min_VFI', 'M15_raw_15min_VFI_diff', 'M15_raw_15min_VWAP', 'M15_raw_15min_VWAP_diff', 'M15_raw_15min_Market_Facilitation_Index', 'M15_raw_15min_Market_Facilitation_Index_diff', 'M15_raw_15min_AD_Line', 'M15_raw_15min_AD_Line_diff', 'M15_raw_15min_WAD', 'M15_raw_15min_WAD_diff', 'M15_raw_15min_EMA_15', 'M15_raw_15min_EMA_15_diff', 'M15_raw_15min_Close_minus_EMA_15', 'M15_raw_15min_EMA_21', 'M15_raw_15min_EMA_21_diff', 'M15_raw_15min_Close_minus_EMA_21', 'M15_raw_15min_EMA_50', 'M15_raw_15min_EMA_50_diff', 'M15_raw_15min_Close_minus_EMA_50', 'M15_raw_15min_EMA_100', 'M15_raw_15min_EMA_100_diff', 'M15_raw_15min_Close_minus_EMA_100', 'M15_raw_15min_EMA_200', 'M15_raw_15min_EMA_200_diff', 'M15_raw_15min_Close_minus_EMA_200', 'M15_raw_15min_EMA_15_above_EMA_21', 'M15_raw_15min_EMA_15_above_EMA_50', 'M15_raw_15min_EMA_15_above_EMA_100', 'M15_raw_15min_EMA_15_above_EMA_200', 'M15_raw_15min_EMA_21_above_EMA_50', 'M15_raw_15min_EMA_21_above_EMA_100', 'M15_raw_15min_EMA_21_above_EMA_200', 'M15_raw_15min_EMA_50_above_EMA_100', 'M15_raw_15min_EMA_50_above_EMA_200', 'M15_raw_15min_EMA_100_above_EMA_200', 'M15_raw_15min_OBV', 'M15_raw_15min_RSI_3', 'M15_raw_15min_MFI_3', 'M15_raw_15min_RSI_7', 'M15_raw_15min_MFI_7', 'M15_raw_15min_RSI_14', 'M15_raw_15min_MFI_14', 'M15_raw_15min_RSI_3_diff', 'M15_raw_15min_RSI_7_diff', 'M15_raw_15min_RSI_14_diff', 'M15_raw_15min_RSI_3 - RSI_7', 'M15_raw_15min_RSI_3 - RSI_14', 'M15_raw_15min_RSI_7 - RSI_14', 'M15_raw_15min_MFI_3_diff', 'M15_raw_15min_MFI_7_diff', 'M15_raw_15min_MFI_14_diff', 'M15_raw_15min_MFI_3 - MFI_7', 'M15_raw_15min_MFI_3 - MFI_14', 'M15_raw_15min_MFI_7 - MFI_14', 'M15_raw_15min_OBV_diff', 'M15_raw_15min_Kal_300', 'M15_raw_15min_Close_Kal_300', 'M15_raw_15min_Kal_change_300', 'M15_raw_15min_Kal_prev_minus_now_300', 'M15_raw_15min_Kal_prev2_minus_now_300', 'M15_raw_15min_Kal_change2_300', 'M15_raw_15min_Kal_600', 'M15_raw_15min_Close_Kal_600', 'M15_raw_15min_Kal_change_600', 'M15_raw_15min_Kal_prev_minus_now_600', 'M15_raw_15min_Kal_prev2_minus_now_600', 'M15_raw_15min_Kal_change2_600', 'M15_raw_15min_Kal_900', 'M15_raw_15min_Close_Kal_900', 'M15_raw_15min_Kal_change_900', 'M15_raw_15min_Kal_prev_minus_now_900', 'M15_raw_15min_Kal_prev2_minus_now_900', 'M15_raw_15min_Kal_change2_900', 'M15_raw_15min_Kal_300_minus_Kal_600', 'M15_raw_15min_Kal_300_minus_Kal_900', 'M15_raw_15min_Kal_600_minus_Kal_900', 'M15_raw_15min_slope_div_300_3', 'M15_raw_15min_slope_div_300_3_diff', 'M15_raw_15min_slope_signal_300_3', 'M15_raw_15min_slope_signal_300_3_diff', 'M15_raw_15min_slope_angle_300_3', 'M15_raw_15min_slope_angle_300_3_diff', 'M15_raw_15min_slope_angle_signal_300_3', 'M15_raw_15min_slope_angle_signal_300_3_diff', 'M15_raw_15min_slope_lin_reg_300_3', 'M15_raw_15min_slope_lin_reg_300_3_diff', 'M15_raw_15min_slope_lin_reg_signal_300_3', 'M15_raw_15min_slope_lin_reg_signal_300_3_diff', 'M15_raw_15min_slope_div_300_6', 'M15_raw_15min_slope_div_300_6_diff', 'M15_raw_15min_slope_signal_300_6', 'M15_raw_15min_slope_signal_300_6_diff', 'M15_raw_15min_slope_angle_300_6', 'M15_raw_15min_slope_angle_300_6_diff', 'M15_raw_15min_slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_6_diff', 'M15_raw_15min_slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_6_diff', 'M15_raw_15min_slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_6_diff', 'M15_raw_15min_slope_div_300_9', 'M15_raw_15min_slope_div_300_9_diff', 'M15_raw_15min_slope_signal_300_9', 'M15_raw_15min_slope_signal_300_9_diff', 'M15_raw_15min_slope_angle_300_9', 'M15_raw_15min_slope_angle_300_9_diff', 'M15_raw_15min_slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_9_diff', 'M15_raw_15min_slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_9_diff', 'M15_raw_15min_slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_9_diff', 'M15_raw_15min_slope_div_600_3', 'M15_raw_15min_slope_div_600_3_diff', 'M15_raw_15min_slope_signal_600_3', 'M15_raw_15min_slope_signal_600_3_diff', 'M15_raw_15min_slope_angle_600_3', 'M15_raw_15min_slope_angle_600_3_diff', 'M15_raw_15min_slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_600_3_diff', 'M15_raw_15min_slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_600_3_diff', 'M15_raw_15min_slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_600_3_diff', 'M15_raw_15min_slope_div_600_6', 'M15_raw_15min_slope_div_600_6_diff', 'M15_raw_15min_slope_signal_600_6', 'M15_raw_15min_slope_signal_600_6_diff', 'M15_raw_15min_slope_angle_600_6', 'M15_raw_15min_slope_angle_600_6_diff', 'M15_raw_15min_slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_6_diff', 'M15_raw_15min_slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_6_diff', 'M15_raw_15min_slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_6_diff', 'M15_raw_15min_slope_div_600_9', 'M15_raw_15min_slope_div_600_9_diff', 'M15_raw_15min_slope_signal_600_9', 'M15_raw_15min_slope_signal_600_9_diff', 'M15_raw_15min_slope_angle_600_9', 'M15_raw_15min_slope_angle_600_9_diff', 'M15_raw_15min_slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_9_diff', 'M15_raw_15min_slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_9_diff', 'M15_raw_15min_slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_9_diff', 'M15_raw_15min_slope_div_900_3', 'M15_raw_15min_slope_div_900_3_diff', 'M15_raw_15min_slope_signal_900_3', 'M15_raw_15min_slope_signal_900_3_diff', 'M15_raw_15min_slope_angle_900_3', 'M15_raw_15min_slope_angle_900_3_diff', 'M15_raw_15min_slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_900_3_diff', 'M15_raw_15min_slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_900_3_diff', 'M15_raw_15min_slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_900_3_diff', 'M15_raw_15min_slope_div_900_6', 'M15_raw_15min_slope_div_900_6_diff', 'M15_raw_15min_slope_signal_900_6', 'M15_raw_15min_slope_signal_900_6_diff', 'M15_raw_15min_slope_angle_900_6', 'M15_raw_15min_slope_angle_900_6_diff', 'M15_raw_15min_slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_6_diff', 'M15_raw_15min_slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_6_diff', 'M15_raw_15min_slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_6_diff', 'M15_raw_15min_slope_div_900_9', 'M15_raw_15min_slope_div_900_9_diff', 'M15_raw_15min_slope_signal_900_9', 'M15_raw_15min_slope_signal_900_9_diff', 'M15_raw_15min_slope_angle_900_9', 'M15_raw_15min_slope_angle_900_9_diff', 'M15_raw_15min_slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_9_diff', 'M15_raw_15min_slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_9_diff', 'M15_raw_15min_slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_9_diff', 'M15_raw_15min_slope_div_300_3 - slope_div_300_6', 'M15_raw_15min_slope_div_300_3 - slope_div_300_9', 'M15_raw_15min_slope_div_300_3 - slope_div_600_3', 'M15_raw_15min_slope_div_300_3 - slope_div_600_6', 'M15_raw_15min_slope_div_300_3 - slope_div_600_9', 'M15_raw_15min_slope_div_300_3 - slope_div_900_3', 'M15_raw_15min_slope_div_300_3 - slope_div_900_6', 'M15_raw_15min_slope_div_300_3 - slope_div_900_9', 'M15_raw_15min_slope_div_300_6 - slope_div_300_9', 'M15_raw_15min_slope_div_300_6 - slope_div_600_3', 'M15_raw_15min_slope_div_300_6 - slope_div_600_6', 'M15_raw_15min_slope_div_300_6 - slope_div_600_9', 'M15_raw_15min_slope_div_300_6 - slope_div_900_3', 'M15_raw_15min_slope_div_300_6 - slope_div_900_6', 'M15_raw_15min_slope_div_300_6 - slope_div_900_9', 'M15_raw_15min_slope_div_300_9 - slope_div_600_3', 'M15_raw_15min_slope_div_300_9 - slope_div_600_6', 'M15_raw_15min_slope_div_300_9 - slope_div_600_9', 'M15_raw_15min_slope_div_300_9 - slope_div_900_3', 'M15_raw_15min_slope_div_300_9 - slope_div_900_6', 'M15_raw_15min_slope_div_300_9 - slope_div_900_9', 'M15_raw_15min_slope_div_600_3 - slope_div_600_6', 'M15_raw_15min_slope_div_600_3 - slope_div_600_9', 'M15_raw_15min_slope_div_600_3 - slope_div_900_3', 'M15_raw_15min_slope_div_600_3 - slope_div_900_6', 'M15_raw_15min_slope_div_600_3 - slope_div_900_9', 'M15_raw_15min_slope_div_600_6 - slope_div_600_9', 'M15_raw_15min_slope_div_600_6 - slope_div_900_3', 'M15_raw_15min_slope_div_600_6 - slope_div_900_6', 'M15_raw_15min_slope_div_600_6 - slope_div_900_9', 'M15_raw_15min_slope_div_600_9 - slope_div_900_3', 'M15_raw_15min_slope_div_600_9 - slope_div_900_6', 'M15_raw_15min_slope_div_600_9 - slope_div_900_9', 'M15_raw_15min_slope_div_900_3 - slope_div_900_6', 'M15_raw_15min_slope_div_900_3 - slope_div_900_9', 'M15_raw_15min_slope_div_900_6 - slope_div_900_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_MACD_12_26_9', 'M15_scale_15min_MACD_12_26_9_diff', 'M15_scale_15min_MACD_signal_12_26_9', 'M15_scale_15min_MACD_signal_12_26_9_diff', 'M15_scale_15min_MACD_hist_12_26_9', 'M15_scale_15min_MACD_hist_12_26_9_diff', 'M15_scale_15min_RSI_basic_14', 'M15_scale_15min_RSI_basic_14_diff', 'M15_scale_15min_BB_upper_20', 'M15_scale_15min_BB_upper_20_diff', 'M15_scale_15min_BB_middle_20', 'M15_scale_15min_BB_middle_20_diff', 'M15_scale_15min_BB_lower_20', 'M15_scale_15min_BB_lower_20_diff', 'M15_scale_15min_ATR_14', 'M15_scale_15min_ATR_14_diff', 'M15_scale_15min_OBV_basic', 'M15_scale_15min_OBV_basic_diff', 'M15_scale_15min_VWAP_basic', 'M15_scale_15min_VWAP_basic_diff', 'M15_scale_15min_Momentum_10', 'M15_scale_15min_Momentum_10_diff', 'M15_scale_15min_ROC_10', 'M15_scale_15min_ROC_10_diff', 'M15_scale_15min_Stoch_K_14_3_3', 'M15_scale_15min_Stoch_K_14_3_3_diff', 'M15_scale_15min_Stoch_D_14_3_3', 'M15_scale_15min_Stoch_D_14_3_3_diff', 'M15_scale_15min_CCI_20', 'M15_scale_15min_CCI_20_diff', 'M15_scale_15min_MFI_basic_14', 'M15_scale_15min_MFI_basic_14_diff', 'M15_scale_15min_ADX_14', 'M15_scale_15min_ADX_14_diff', 'M15_scale_15min_WilliamsR_14', 'M15_scale_15min_WilliamsR_14_diff', 'M15_scale_15min_CMF', 'M15_scale_15min_CMF_diff', 'M15_scale_15min_TMF', 'M15_scale_15min_TMF_diff', 'M15_scale_15min_MFI_14_volume', 'M15_scale_15min_MFI_14_volume_diff', 'M15_scale_15min_KO', 'M15_scale_15min_KO_diff', 'M15_scale_15min_EFI', 'M15_scale_15min_EFI_diff', 'M15_scale_15min_EOM', 'M15_scale_15min_EOM_diff', 'M15_scale_15min_VPT', 'M15_scale_15min_VPT_diff', 'M15_scale_15min_NVI', 'M15_scale_15min_NVI_diff', 'M15_scale_15min_PVI', 'M15_scale_15min_PVI_diff', 'M15_scale_15min_VFI', 'M15_scale_15min_VFI_diff', 'M15_scale_15min_VWAP', 'M15_scale_15min_VWAP_diff', 'M15_scale_15min_Market_Facilitation_Index', 'M15_scale_15min_Market_Facilitation_Index_diff', 'M15_scale_15min_AD_Line', 'M15_scale_15min_AD_Line_diff', 'M15_scale_15min_WAD', 'M15_scale_15min_WAD_diff', 'M15_scale_15min_EMA_15', 'M15_scale_15min_EMA_15_diff', 'M15_scale_15min_Close_minus_EMA_15', 'M15_scale_15min_EMA_21', 'M15_scale_15min_EMA_21_diff', 'M15_scale_15min_Close_minus_EMA_21', 'M15_scale_15min_EMA_50', 'M15_scale_15min_EMA_50_diff', 'M15_scale_15min_Close_minus_EMA_50', 'M15_scale_15min_EMA_100', 'M15_scale_15min_EMA_100_diff', 'M15_scale_15min_Close_minus_EMA_100', 'M15_scale_15min_EMA_200', 'M15_scale_15min_EMA_200_diff', 'M15_scale_15min_Close_minus_EMA_200', 'M15_scale_15min_EMA_15_above_EMA_21', 'M15_scale_15min_EMA_15_above_EMA_50', 'M15_scale_15min_EMA_15_above_EMA_100', 'M15_scale_15min_EMA_15_above_EMA_200', 'M15_scale_15min_EMA_21_above_EMA_50', 'M15_scale_15min_EMA_21_above_EMA_100', 'M15_scale_15min_EMA_21_above_EMA_200', 'M15_scale_15min_EMA_50_above_EMA_100', 'M15_scale_15min_EMA_50_above_EMA_200', 'M15_scale_15min_EMA_100_above_EMA_200', 'M15_scale_15min_OBV', 'M15_scale_15min_RSI_3', 'M15_scale_15min_MFI_3', 'M15_scale_15min_RSI_7', 'M15_scale_15min_MFI_7', 'M15_scale_15min_RSI_14', 'M15_scale_15min_MFI_14', 'M15_scale_15min_RSI_3_diff', 'M15_scale_15min_RSI_7_diff', 'M15_scale_15min_RSI_14_diff', 'M15_scale_15min_RSI_3 - RSI_7', 'M15_scale_15min_RSI_3 - RSI_14', 'M15_scale_15min_RSI_7 - RSI_14', 'M15_scale_15min_MFI_3_diff', 'M15_scale_15min_MFI_7_diff', 'M15_scale_15min_MFI_14_diff', 'M15_scale_15min_MFI_3 - MFI_7', 'M15_scale_15min_MFI_3 - MFI_14', 'M15_scale_15min_MFI_7 - MFI_14', 'M15_scale_15min_OBV_diff', 'M15_scale_15min_Kal_300', 'M15_scale_15min_Close_Kal_300', 'M15_scale_15min_Kal_change_300', 'M15_scale_15min_Kal_prev_minus_now_300', 'M15_scale_15min_Kal_prev2_minus_now_300', 'M15_scale_15min_Kal_change2_300', 'M15_scale_15min_Kal_600', 'M15_scale_15min_Close_Kal_600', 'M15_scale_15min_Kal_change_600', 'M15_scale_15min_Kal_prev_minus_now_600', 'M15_scale_15min_Kal_prev2_minus_now_600', 'M15_scale_15min_Kal_change2_600', 'M15_scale_15min_Kal_900', 'M15_scale_15min_Close_Kal_900', 'M15_scale_15min_Kal_change_900', 'M15_scale_15min_Kal_prev_minus_now_900', 'M15_scale_15min_Kal_prev2_minus_now_900', 'M15_scale_15min_Kal_change2_900', 'M15_scale_15min_Kal_300_minus_Kal_600', 'M15_scale_15min_Kal_300_minus_Kal_900', 'M15_scale_15min_Kal_600_minus_Kal_900', 'M15_scale_15min_slope_div_300_3', 'M15_scale_15min_slope_div_300_3_diff', 'M15_scale_15min_slope_signal_300_3', 'M15_scale_15min_slope_signal_300_3_diff', 'M15_scale_15min_slope_angle_300_3', 'M15_scale_15min_slope_angle_300_3_diff', 'M15_scale_15min_slope_angle_signal_300_3', 'M15_scale_15min_slope_angle_signal_300_3_diff', 'M15_scale_15min_slope_lin_reg_300_3', 'M15_scale_15min_slope_lin_reg_300_3_diff', 'M15_scale_15min_slope_lin_reg_signal_300_3', 'M15_scale_15min_slope_lin_reg_signal_300_3_diff', 'M15_scale_15min_slope_div_300_6', 'M15_scale_15min_slope_div_300_6_diff', 'M15_scale_15min_slope_signal_300_6', 'M15_scale_15min_slope_signal_300_6_diff', 'M15_scale_15min_slope_angle_300_6', 'M15_scale_15min_slope_angle_300_6_diff', 'M15_scale_15min_slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_6_diff', 'M15_scale_15min_slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_6_diff', 'M15_scale_15min_slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_6_diff', 'M15_scale_15min_slope_div_300_9', 'M15_scale_15min_slope_div_300_9_diff', 'M15_scale_15min_slope_signal_300_9', 'M15_scale_15min_slope_signal_300_9_diff', 'M15_scale_15min_slope_angle_300_9', 'M15_scale_15min_slope_angle_300_9_diff', 'M15_scale_15min_slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_9_diff', 'M15_scale_15min_slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_9_diff', 'M15_scale_15min_slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_9_diff', 'M15_scale_15min_slope_div_600_3', 'M15_scale_15min_slope_div_600_3_diff', 'M15_scale_15min_slope_signal_600_3', 'M15_scale_15min_slope_signal_600_3_diff', 'M15_scale_15min_slope_angle_600_3', 'M15_scale_15min_slope_angle_600_3_diff', 'M15_scale_15min_slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_600_3_diff', 'M15_scale_15min_slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_600_3_diff', 'M15_scale_15min_slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_600_3_diff', 'M15_scale_15min_slope_div_600_6', 'M15_scale_15min_slope_div_600_6_diff', 'M15_scale_15min_slope_signal_600_6', 'M15_scale_15min_slope_signal_600_6_diff', 'M15_scale_15min_slope_angle_600_6', 'M15_scale_15min_slope_angle_600_6_diff', 'M15_scale_15min_slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_6_diff', 'M15_scale_15min_slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_6_diff', 'M15_scale_15min_slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_6_diff', 'M15_scale_15min_slope_div_600_9', 'M15_scale_15min_slope_div_600_9_diff', 'M15_scale_15min_slope_signal_600_9', 'M15_scale_15min_slope_signal_600_9_diff', 'M15_scale_15min_slope_angle_600_9', 'M15_scale_15min_slope_angle_600_9_diff', 'M15_scale_15min_slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_9_diff', 'M15_scale_15min_slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_9_diff', 'M15_scale_15min_slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_9_diff', 'M15_scale_15min_slope_div_900_3', 'M15_scale_15min_slope_div_900_3_diff', 'M15_scale_15min_slope_signal_900_3', 'M15_scale_15min_slope_signal_900_3_diff', 'M15_scale_15min_slope_angle_900_3', 'M15_scale_15min_slope_angle_900_3_diff', 'M15_scale_15min_slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_900_3_diff', 'M15_scale_15min_slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_900_3_diff', 'M15_scale_15min_slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_900_3_diff', 'M15_scale_15min_slope_div_900_6', 'M15_scale_15min_slope_div_900_6_diff', 'M15_scale_15min_slope_signal_900_6', 'M15_scale_15min_slope_signal_900_6_diff', 'M15_scale_15min_slope_angle_900_6', 'M15_scale_15min_slope_angle_900_6_diff', 'M15_scale_15min_slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_6_diff', 'M15_scale_15min_slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_6_diff', 'M15_scale_15min_slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_6_diff', 'M15_scale_15min_slope_div_900_9', 'M15_scale_15min_slope_div_900_9_diff', 'M15_scale_15min_slope_signal_900_9', 'M15_scale_15min_slope_signal_900_9_diff', 'M15_scale_15min_slope_angle_900_9', 'M15_scale_15min_slope_angle_900_9_diff', 'M15_scale_15min_slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_9_diff', 'M15_scale_15min_slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_9_diff', 'M15_scale_15min_slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_9_diff', 'M15_scale_15min_slope_div_300_3 - slope_div_300_6', 'M15_scale_15min_slope_div_300_3 - slope_div_300_9', 'M15_scale_15min_slope_div_300_3 - slope_div_600_3', 'M15_scale_15min_slope_div_300_3 - slope_div_600_6', 'M15_scale_15min_slope_div_300_3 - slope_div_600_9', 'M15_scale_15min_slope_div_300_3 - slope_div_900_3', 'M15_scale_15min_slope_div_300_3 - slope_div_900_6', 'M15_scale_15min_slope_div_300_3 - slope_div_900_9', 'M15_scale_15min_slope_div_300_6 - slope_div_300_9', 'M15_scale_15min_slope_div_300_6 - slope_div_600_3', 'M15_scale_15min_slope_div_300_6 - slope_div_600_6', 'M15_scale_15min_slope_div_300_6 - slope_div_600_9', 'M15_scale_15min_slope_div_300_6 - slope_div_900_3', 'M15_scale_15min_slope_div_300_6 - slope_div_900_6', 'M15_scale_15min_slope_div_300_6 - slope_div_900_9', 'M15_scale_15min_slope_div_300_9 - slope_div_600_3', 'M15_scale_15min_slope_div_300_9 - slope_div_600_6', 'M15_scale_15min_slope_div_300_9 - slope_div_600_9', 'M15_scale_15min_slope_div_300_9 - slope_div_900_3', 'M15_scale_15min_slope_div_300_9 - slope_div_900_6', 'M15_scale_15min_slope_div_300_9 - slope_div_900_9', 'M15_scale_15min_slope_div_600_3 - slope_div_600_6', 'M15_scale_15min_slope_div_600_3 - slope_div_600_9', 'M15_scale_15min_slope_div_600_3 - slope_div_900_3', 'M15_scale_15min_slope_div_600_3 - slope_div_900_6', 'M15_scale_15min_slope_div_600_3 - slope_div_900_9', 'M15_scale_15min_slope_div_600_6 - slope_div_600_9', 'M15_scale_15min_slope_div_600_6 - slope_div_900_3', 'M15_scale_15min_slope_div_600_6 - slope_div_900_6', 'M15_scale_15min_slope_div_600_6 - slope_div_900_9', 'M15_scale_15min_slope_div_600_9 - slope_div_900_3', 'M15_scale_15min_slope_div_600_9 - slope_div_900_6', 'M15_scale_15min_slope_div_600_9 - slope_div_900_9', 'M15_scale_15min_slope_div_900_3 - slope_div_900_6', 'M15_scale_15min_slope_div_900_3 - slope_div_900_9', 'M15_scale_15min_slope_div_900_6 - slope_div_900_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
+      "\n",
+      "NaN counts per column (sorted):\n",
+      "M10_scale_10min_EMA_100_above_EMA_200                                      104\n",
+      "M15_scale_15min_EMA_100_above_EMA_200                                      104\n",
+      "M10_scale_10min_EMA_50_above_EMA_200                                        95\n",
+      "M15_scale_15min_EMA_50_above_EMA_200                                        95\n",
+      "M5_scale_slope_angle_signal_300_6                                           49\n",
+      "                                                                          ... \n",
+      "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6      0\n",
+      "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3      0\n",
+      "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9      0\n",
+      "Open_Trade                                                                   0\n",
+      "label                                                                        0\n",
+      "Length: 2727, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df.shape,'\\n')\n",
+    "print('Label_Counts : ',df.label.value_counts(),'\\n')\n",
+    "print(list(df.columns), '\\n')\n",
+    "\n",
+    "# Add NaN count per column, sorted\n",
+    "print(\"NaN counts per column (sorted):\")\n",
+    "print(df.isnull().sum().sort_values(ascending=False), '\\n')\n",
+    "\n",
+    "#df.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Suezit_quoZ1",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Suezit_quoZ1",
+    "outputId": "56d5d737-42db-4360-a0c8-6fede9c16a7e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataFrame with difference features:\n",
+      "(67770, 1922) \n",
+      "\n",
+      "Label_Counts :  label\n",
+      "1    34223\n",
+      "0    33547\n",
+      "Name: count, dtype: int64 \n",
+      "\n",
+      "['Date', 'label', 'M5_raw_MACD_12_26_9_diff', 'M5_raw_MACD_signal_12_26_9_diff', 'M5_raw_MACD_hist_12_26_9_diff', 'M5_raw_RSI_basic_14_diff', 'M5_raw_BB_upper_20_diff', 'M5_raw_BB_middle_20_diff', 'M5_raw_BB_lower_20_diff', 'M5_raw_ATR_14_diff', 'M5_raw_OBV_basic_diff', 'M5_raw_VWAP_basic_diff', 'M5_raw_Momentum_10_diff', 'M5_raw_ROC_10_diff', 'M5_raw_Stoch_K_14_3_3_diff', 'M5_raw_Stoch_D_14_3_3_diff', 'M5_raw_CCI_20_diff', 'M5_raw_MFI_basic_14_diff', 'M5_raw_ADX_14_diff', 'M5_raw_WilliamsR_14_diff', 'M5_raw_CMF_diff', 'M5_raw_TMF_diff', 'M5_raw_MFI_14_volume_diff', 'M5_raw_KO_diff', 'M5_raw_EFI_diff', 'M5_raw_EOM_diff', 'M5_raw_VPT_diff', 'M5_raw_NVI_diff', 'M5_raw_PVI_diff', 'M5_raw_VFI_diff', 'M5_raw_VWAP_diff', 'M5_raw_Market_Facilitation_Index_diff', 'M5_raw_AD_Line_diff', 'M5_raw_WAD_diff', 'M5_raw_EMA_15_diff', 'M5_raw_EMA_21_diff', 'M5_raw_EMA_50_diff', 'M5_raw_EMA_100_diff', 'M5_raw_EMA_200_diff', 'M5_raw_RSI_3_diff', 'M5_raw_RSI_7_diff', 'M5_raw_RSI_14_diff', 'M5_raw_RSI_3 - RSI_7', 'M5_raw_RSI_3 - RSI_14', 'M5_raw_RSI_7 - RSI_14', 'M5_raw_MFI_3_diff', 'M5_raw_MFI_7_diff', 'M5_raw_MFI_14_diff', 'M5_raw_MFI_3 - MFI_7', 'M5_raw_MFI_3 - MFI_14', 'M5_raw_MFI_7 - MFI_14', 'M5_raw_OBV_diff', 'M5_raw_slope_div_300_3_diff', 'M5_raw_slope_signal_300_3_diff', 'M5_raw_slope_angle_300_3_diff', 'M5_raw_slope_angle_signal_300_3_diff', 'M5_raw_slope_lin_reg_300_3_diff', 'M5_raw_slope_lin_reg_signal_300_3_diff', 'M5_raw_slope_div_300_6_diff', 'M5_raw_slope_signal_300_6_diff', 'M5_raw_slope_angle_300_6_diff', 'M5_raw_slope_angle_signal_300_6_diff', 'M5_raw_slope_lin_reg_300_6_diff', 'M5_raw_slope_lin_reg_signal_300_6_diff', 'M5_raw_slope_div_300_9_diff', 'M5_raw_slope_signal_300_9_diff', 'M5_raw_slope_angle_300_9_diff', 'M5_raw_slope_angle_signal_300_9_diff', 'M5_raw_slope_lin_reg_300_9_diff', 'M5_raw_slope_lin_reg_signal_300_9_diff', 'M5_raw_slope_div_600_3_diff', 'M5_raw_slope_signal_600_3_diff', 'M5_raw_slope_angle_600_3_diff', 'M5_raw_slope_angle_signal_600_3_diff', 'M5_raw_slope_lin_reg_600_3_diff', 'M5_raw_slope_lin_reg_signal_600_3_diff', 'M5_raw_slope_div_600_6_diff', 'M5_raw_slope_signal_600_6_diff', 'M5_raw_slope_angle_600_6_diff', 'M5_raw_slope_angle_signal_600_6_diff', 'M5_raw_slope_lin_reg_600_6_diff', 'M5_raw_slope_lin_reg_signal_600_6_diff', 'M5_raw_slope_div_600_9_diff', 'M5_raw_slope_signal_600_9_diff', 'M5_raw_slope_angle_600_9_diff', 'M5_raw_slope_angle_signal_600_9_diff', 'M5_raw_slope_lin_reg_600_9_diff', 'M5_raw_slope_lin_reg_signal_600_9_diff', 'M5_raw_slope_div_900_3_diff', 'M5_raw_slope_signal_900_3_diff', 'M5_raw_slope_angle_900_3_diff', 'M5_raw_slope_angle_signal_900_3_diff', 'M5_raw_slope_lin_reg_900_3_diff', 'M5_raw_slope_lin_reg_signal_900_3_diff', 'M5_raw_slope_div_900_6_diff', 'M5_raw_slope_signal_900_6_diff', 'M5_raw_slope_angle_900_6_diff', 'M5_raw_slope_angle_signal_900_6_diff', 'M5_raw_slope_lin_reg_900_6_diff', 'M5_raw_slope_lin_reg_signal_900_6_diff', 'M5_raw_slope_div_900_9_diff', 'M5_raw_slope_signal_900_9_diff', 'M5_raw_slope_angle_900_9_diff', 'M5_raw_slope_angle_signal_900_9_diff', 'M5_raw_slope_lin_reg_900_9_diff', 'M5_raw_slope_lin_reg_signal_900_9_diff', 'M5_raw_slope_div_300_3 - slope_div_300_6', 'M5_raw_slope_div_300_3 - slope_div_300_9', 'M5_raw_slope_div_300_3 - slope_div_600_3', 'M5_raw_slope_div_300_3 - slope_div_600_6', 'M5_raw_slope_div_300_3 - slope_div_600_9', 'M5_raw_slope_div_300_3 - slope_div_900_3', 'M5_raw_slope_div_300_3 - slope_div_900_6', 'M5_raw_slope_div_300_3 - slope_div_900_9', 'M5_raw_slope_div_300_6 - slope_div_300_9', 'M5_raw_slope_div_300_6 - slope_div_600_3', 'M5_raw_slope_div_300_6 - slope_div_600_6', 'M5_raw_slope_div_300_6 - slope_div_600_9', 'M5_raw_slope_div_300_6 - slope_div_900_3', 'M5_raw_slope_div_300_6 - slope_div_900_6', 'M5_raw_slope_div_300_6 - slope_div_900_9', 'M5_raw_slope_div_300_9 - slope_div_600_3', 'M5_raw_slope_div_300_9 - slope_div_600_6', 'M5_raw_slope_div_300_9 - slope_div_600_9', 'M5_raw_slope_div_300_9 - slope_div_900_3', 'M5_raw_slope_div_300_9 - slope_div_900_6', 'M5_raw_slope_div_300_9 - slope_div_900_9', 'M5_raw_slope_div_600_3 - slope_div_600_6', 'M5_raw_slope_div_600_3 - slope_div_600_9', 'M5_raw_slope_div_600_3 - slope_div_900_3', 'M5_raw_slope_div_600_3 - slope_div_900_6', 'M5_raw_slope_div_600_3 - slope_div_900_9', 'M5_raw_slope_div_600_6 - slope_div_600_9', 'M5_raw_slope_div_600_6 - slope_div_900_3', 'M5_raw_slope_div_600_6 - slope_div_900_6', 'M5_raw_slope_div_600_6 - slope_div_900_9', 'M5_raw_slope_div_600_9 - slope_div_900_3', 'M5_raw_slope_div_600_9 - slope_div_900_6', 'M5_raw_slope_div_600_9 - slope_div_900_9', 'M5_raw_slope_div_900_3 - slope_div_900_6', 'M5_raw_slope_div_900_3 - slope_div_900_9', 'M5_raw_slope_div_900_6 - slope_div_900_9', 'M5_raw_slope_signal_300_3 - slope_signal_300_6', 'M5_raw_slope_signal_300_3 - slope_signal_300_9', 'M5_raw_slope_signal_300_3 - slope_signal_600_3', 'M5_raw_slope_signal_300_3 - slope_signal_600_6', 'M5_raw_slope_signal_300_3 - slope_signal_600_9', 'M5_raw_slope_signal_300_3 - slope_signal_900_3', 'M5_raw_slope_signal_300_3 - slope_signal_900_6', 'M5_raw_slope_signal_300_3 - slope_signal_900_9', 'M5_raw_slope_signal_300_6 - slope_signal_300_9', 'M5_raw_slope_signal_300_6 - slope_signal_600_3', 'M5_raw_slope_signal_300_6 - slope_signal_600_6', 'M5_raw_slope_signal_300_6 - slope_signal_600_9', 'M5_raw_slope_signal_300_6 - slope_signal_900_3', 'M5_raw_slope_signal_300_6 - slope_signal_900_6', 'M5_raw_slope_signal_300_6 - slope_signal_900_9', 'M5_raw_slope_signal_300_9 - slope_signal_600_3', 'M5_raw_slope_signal_300_9 - slope_signal_600_6', 'M5_raw_slope_signal_300_9 - slope_signal_600_9', 'M5_raw_slope_signal_300_9 - slope_signal_900_3', 'M5_raw_slope_signal_300_9 - slope_signal_900_6', 'M5_raw_slope_signal_300_9 - slope_signal_900_9', 'M5_raw_slope_signal_600_3 - slope_signal_600_6', 'M5_raw_slope_signal_600_3 - slope_signal_600_9', 'M5_raw_slope_signal_600_3 - slope_signal_900_3', 'M5_raw_slope_signal_600_3 - slope_signal_900_6', 'M5_raw_slope_signal_600_3 - slope_signal_900_9', 'M5_raw_slope_signal_600_6 - slope_signal_600_9', 'M5_raw_slope_signal_600_6 - slope_signal_900_3', 'M5_raw_slope_signal_600_6 - slope_signal_900_6', 'M5_raw_slope_signal_600_6 - slope_signal_900_9', 'M5_raw_slope_signal_600_9 - slope_signal_900_3', 'M5_raw_slope_signal_600_9 - slope_signal_900_6', 'M5_raw_slope_signal_600_9 - slope_signal_900_9', 'M5_raw_slope_signal_900_3 - slope_signal_900_6', 'M5_raw_slope_signal_900_3 - slope_signal_900_9', 'M5_raw_slope_signal_900_6 - slope_signal_900_9', 'M5_raw_slope_angle_300_3 - slope_angle_300_6', 'M5_raw_slope_angle_300_3 - slope_angle_300_9', 'M5_raw_slope_angle_300_3 - slope_angle_600_3', 'M5_raw_slope_angle_300_3 - slope_angle_600_6', 'M5_raw_slope_angle_300_3 - slope_angle_600_9', 'M5_raw_slope_angle_300_3 - slope_angle_900_3', 'M5_raw_slope_angle_300_3 - slope_angle_900_6', 'M5_raw_slope_angle_300_3 - slope_angle_900_9', 'M5_raw_slope_angle_300_6 - slope_angle_300_9', 'M5_raw_slope_angle_300_6 - slope_angle_600_3', 'M5_raw_slope_angle_300_6 - slope_angle_600_6', 'M5_raw_slope_angle_300_6 - slope_angle_600_9', 'M5_raw_slope_angle_300_6 - slope_angle_900_3', 'M5_raw_slope_angle_300_6 - slope_angle_900_6', 'M5_raw_slope_angle_300_6 - slope_angle_900_9', 'M5_raw_slope_angle_300_9 - slope_angle_600_3', 'M5_raw_slope_angle_300_9 - slope_angle_600_6', 'M5_raw_slope_angle_300_9 - slope_angle_600_9', 'M5_raw_slope_angle_300_9 - slope_angle_900_3', 'M5_raw_slope_angle_300_9 - slope_angle_900_6', 'M5_raw_slope_angle_300_9 - slope_angle_900_9', 'M5_raw_slope_angle_600_3 - slope_angle_600_6', 'M5_raw_slope_angle_600_3 - slope_angle_600_9', 'M5_raw_slope_angle_600_3 - slope_angle_900_3', 'M5_raw_slope_angle_600_3 - slope_angle_900_6', 'M5_raw_slope_angle_600_3 - slope_angle_900_9', 'M5_raw_slope_angle_600_6 - slope_angle_600_9', 'M5_raw_slope_angle_600_6 - slope_angle_900_3', 'M5_raw_slope_angle_600_6 - slope_angle_900_6', 'M5_raw_slope_angle_600_6 - slope_angle_900_9', 'M5_raw_slope_angle_600_9 - slope_angle_900_3', 'M5_raw_slope_angle_600_9 - slope_angle_900_6', 'M5_raw_slope_angle_600_9 - slope_angle_900_9', 'M5_raw_slope_angle_900_3 - slope_angle_900_6', 'M5_raw_slope_angle_900_3 - slope_angle_900_9', 'M5_raw_slope_angle_900_6 - slope_angle_900_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_raw_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_raw_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_raw_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_raw_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_raw_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M5_scale_MACD_12_26_9_diff', 'M5_scale_MACD_signal_12_26_9_diff', 'M5_scale_MACD_hist_12_26_9_diff', 'M5_scale_RSI_basic_14_diff', 'M5_scale_BB_upper_20_diff', 'M5_scale_BB_middle_20_diff', 'M5_scale_BB_lower_20_diff', 'M5_scale_ATR_14_diff', 'M5_scale_OBV_basic_diff', 'M5_scale_VWAP_basic_diff', 'M5_scale_Momentum_10_diff', 'M5_scale_ROC_10_diff', 'M5_scale_Stoch_K_14_3_3_diff', 'M5_scale_Stoch_D_14_3_3_diff', 'M5_scale_CCI_20_diff', 'M5_scale_MFI_basic_14_diff', 'M5_scale_ADX_14_diff', 'M5_scale_WilliamsR_14_diff', 'M5_scale_CMF_diff', 'M5_scale_TMF_diff', 'M5_scale_MFI_14_volume_diff', 'M5_scale_KO_diff', 'M5_scale_EFI_diff', 'M5_scale_EOM_diff', 'M5_scale_VPT_diff', 'M5_scale_NVI_diff', 'M5_scale_PVI_diff', 'M5_scale_VFI_diff', 'M5_scale_VWAP_diff', 'M5_scale_Market_Facilitation_Index_diff', 'M5_scale_AD_Line_diff', 'M5_scale_WAD_diff', 'M5_scale_EMA_15_diff', 'M5_scale_EMA_21_diff', 'M5_scale_EMA_50_diff', 'M5_scale_EMA_100_diff', 'M5_scale_EMA_200_diff', 'M5_scale_RSI_3_diff', 'M5_scale_RSI_7_diff', 'M5_scale_RSI_14_diff', 'M5_scale_RSI_3 - RSI_7', 'M5_scale_RSI_3 - RSI_14', 'M5_scale_RSI_7 - RSI_14', 'M5_scale_MFI_3_diff', 'M5_scale_MFI_7_diff', 'M5_scale_MFI_14_diff', 'M5_scale_MFI_3 - MFI_7', 'M5_scale_MFI_3 - MFI_14', 'M5_scale_MFI_7 - MFI_14', 'M5_scale_OBV_diff', 'M5_scale_slope_div_300_3_diff', 'M5_scale_slope_signal_300_3_diff', 'M5_scale_slope_angle_300_3_diff', 'M5_scale_slope_angle_signal_300_3_diff', 'M5_scale_slope_lin_reg_300_3_diff', 'M5_scale_slope_lin_reg_signal_300_3_diff', 'M5_scale_slope_div_300_6_diff', 'M5_scale_slope_signal_300_6_diff', 'M5_scale_slope_angle_300_6_diff', 'M5_scale_slope_angle_signal_300_6_diff', 'M5_scale_slope_lin_reg_300_6_diff', 'M5_scale_slope_lin_reg_signal_300_6_diff', 'M5_scale_slope_div_300_9_diff', 'M5_scale_slope_signal_300_9_diff', 'M5_scale_slope_angle_300_9_diff', 'M5_scale_slope_angle_signal_300_9_diff', 'M5_scale_slope_lin_reg_300_9_diff', 'M5_scale_slope_lin_reg_signal_300_9_diff', 'M5_scale_slope_div_600_3_diff', 'M5_scale_slope_signal_600_3_diff', 'M5_scale_slope_angle_600_3_diff', 'M5_scale_slope_angle_signal_600_3_diff', 'M5_scale_slope_lin_reg_600_3_diff', 'M5_scale_slope_lin_reg_signal_600_3_diff', 'M5_scale_slope_div_600_6_diff', 'M5_scale_slope_signal_600_6_diff', 'M5_scale_slope_angle_600_6_diff', 'M5_scale_slope_angle_signal_600_6_diff', 'M5_scale_slope_lin_reg_600_6_diff', 'M5_scale_slope_lin_reg_signal_600_6_diff', 'M5_scale_slope_div_600_9_diff', 'M5_scale_slope_signal_600_9_diff', 'M5_scale_slope_angle_600_9_diff', 'M5_scale_slope_angle_signal_600_9_diff', 'M5_scale_slope_lin_reg_600_9_diff', 'M5_scale_slope_lin_reg_signal_600_9_diff', 'M5_scale_slope_div_900_3_diff', 'M5_scale_slope_signal_900_3_diff', 'M5_scale_slope_angle_900_3_diff', 'M5_scale_slope_angle_signal_900_3_diff', 'M5_scale_slope_lin_reg_900_3_diff', 'M5_scale_slope_lin_reg_signal_900_3_diff', 'M5_scale_slope_div_900_6_diff', 'M5_scale_slope_signal_900_6_diff', 'M5_scale_slope_angle_900_6_diff', 'M5_scale_slope_angle_signal_900_6_diff', 'M5_scale_slope_lin_reg_900_6_diff', 'M5_scale_slope_lin_reg_signal_900_6_diff', 'M5_scale_slope_div_900_9_diff', 'M5_scale_slope_signal_900_9_diff', 'M5_scale_slope_angle_900_9_diff', 'M5_scale_slope_angle_signal_900_9_diff', 'M5_scale_slope_lin_reg_900_9_diff', 'M5_scale_slope_lin_reg_signal_900_9_diff', 'M5_scale_slope_div_300_3 - slope_div_300_6', 'M5_scale_slope_div_300_3 - slope_div_300_9', 'M5_scale_slope_div_300_3 - slope_div_600_3', 'M5_scale_slope_div_300_3 - slope_div_600_6', 'M5_scale_slope_div_300_3 - slope_div_600_9', 'M5_scale_slope_div_300_3 - slope_div_900_3', 'M5_scale_slope_div_300_3 - slope_div_900_6', 'M5_scale_slope_div_300_3 - slope_div_900_9', 'M5_scale_slope_div_300_6 - slope_div_300_9', 'M5_scale_slope_div_300_6 - slope_div_600_3', 'M5_scale_slope_div_300_6 - slope_div_600_6', 'M5_scale_slope_div_300_6 - slope_div_600_9', 'M5_scale_slope_div_300_6 - slope_div_900_3', 'M5_scale_slope_div_300_6 - slope_div_900_6', 'M5_scale_slope_div_300_6 - slope_div_900_9', 'M5_scale_slope_div_300_9 - slope_div_600_3', 'M5_scale_slope_div_300_9 - slope_div_600_6', 'M5_scale_slope_div_300_9 - slope_div_600_9', 'M5_scale_slope_div_300_9 - slope_div_900_3', 'M5_scale_slope_div_300_9 - slope_div_900_6', 'M5_scale_slope_div_300_9 - slope_div_900_9', 'M5_scale_slope_div_600_3 - slope_div_600_6', 'M5_scale_slope_div_600_3 - slope_div_600_9', 'M5_scale_slope_div_600_3 - slope_div_900_3', 'M5_scale_slope_div_600_3 - slope_div_900_6', 'M5_scale_slope_div_600_3 - slope_div_900_9', 'M5_scale_slope_div_600_6 - slope_div_600_9', 'M5_scale_slope_div_600_6 - slope_div_900_3', 'M5_scale_slope_div_600_6 - slope_div_900_6', 'M5_scale_slope_div_600_6 - slope_div_900_9', 'M5_scale_slope_div_600_9 - slope_div_900_3', 'M5_scale_slope_div_600_9 - slope_div_900_6', 'M5_scale_slope_div_600_9 - slope_div_900_9', 'M5_scale_slope_div_900_3 - slope_div_900_6', 'M5_scale_slope_div_900_3 - slope_div_900_9', 'M5_scale_slope_div_900_6 - slope_div_900_9', 'M5_scale_slope_signal_300_3 - slope_signal_300_6', 'M5_scale_slope_signal_300_3 - slope_signal_300_9', 'M5_scale_slope_signal_300_3 - slope_signal_600_3', 'M5_scale_slope_signal_300_3 - slope_signal_600_6', 'M5_scale_slope_signal_300_3 - slope_signal_600_9', 'M5_scale_slope_signal_300_3 - slope_signal_900_3', 'M5_scale_slope_signal_300_3 - slope_signal_900_6', 'M5_scale_slope_signal_300_3 - slope_signal_900_9', 'M5_scale_slope_signal_300_6 - slope_signal_300_9', 'M5_scale_slope_signal_300_6 - slope_signal_600_3', 'M5_scale_slope_signal_300_6 - slope_signal_600_6', 'M5_scale_slope_signal_300_6 - slope_signal_600_9', 'M5_scale_slope_signal_300_6 - slope_signal_900_3', 'M5_scale_slope_signal_300_6 - slope_signal_900_6', 'M5_scale_slope_signal_300_6 - slope_signal_900_9', 'M5_scale_slope_signal_300_9 - slope_signal_600_3', 'M5_scale_slope_signal_300_9 - slope_signal_600_6', 'M5_scale_slope_signal_300_9 - slope_signal_600_9', 'M5_scale_slope_signal_300_9 - slope_signal_900_3', 'M5_scale_slope_signal_300_9 - slope_signal_900_6', 'M5_scale_slope_signal_300_9 - slope_signal_900_9', 'M5_scale_slope_signal_600_3 - slope_signal_600_6', 'M5_scale_slope_signal_600_3 - slope_signal_600_9', 'M5_scale_slope_signal_600_3 - slope_signal_900_3', 'M5_scale_slope_signal_600_3 - slope_signal_900_6', 'M5_scale_slope_signal_600_3 - slope_signal_900_9', 'M5_scale_slope_signal_600_6 - slope_signal_600_9', 'M5_scale_slope_signal_600_6 - slope_signal_900_3', 'M5_scale_slope_signal_600_6 - slope_signal_900_6', 'M5_scale_slope_signal_600_6 - slope_signal_900_9', 'M5_scale_slope_signal_600_9 - slope_signal_900_3', 'M5_scale_slope_signal_600_9 - slope_signal_900_6', 'M5_scale_slope_signal_600_9 - slope_signal_900_9', 'M5_scale_slope_signal_900_3 - slope_signal_900_6', 'M5_scale_slope_signal_900_3 - slope_signal_900_9', 'M5_scale_slope_signal_900_6 - slope_signal_900_9', 'M5_scale_slope_angle_300_3 - slope_angle_300_6', 'M5_scale_slope_angle_300_3 - slope_angle_300_9', 'M5_scale_slope_angle_300_3 - slope_angle_600_3', 'M5_scale_slope_angle_300_3 - slope_angle_600_6', 'M5_scale_slope_angle_300_3 - slope_angle_600_9', 'M5_scale_slope_angle_300_3 - slope_angle_900_3', 'M5_scale_slope_angle_300_3 - slope_angle_900_6', 'M5_scale_slope_angle_300_3 - slope_angle_900_9', 'M5_scale_slope_angle_300_6 - slope_angle_300_9', 'M5_scale_slope_angle_300_6 - slope_angle_600_3', 'M5_scale_slope_angle_300_6 - slope_angle_600_6', 'M5_scale_slope_angle_300_6 - slope_angle_600_9', 'M5_scale_slope_angle_300_6 - slope_angle_900_3', 'M5_scale_slope_angle_300_6 - slope_angle_900_6', 'M5_scale_slope_angle_300_6 - slope_angle_900_9', 'M5_scale_slope_angle_300_9 - slope_angle_600_3', 'M5_scale_slope_angle_300_9 - slope_angle_600_6', 'M5_scale_slope_angle_300_9 - slope_angle_600_9', 'M5_scale_slope_angle_300_9 - slope_angle_900_3', 'M5_scale_slope_angle_300_9 - slope_angle_900_6', 'M5_scale_slope_angle_300_9 - slope_angle_900_9', 'M5_scale_slope_angle_600_3 - slope_angle_600_6', 'M5_scale_slope_angle_600_3 - slope_angle_600_9', 'M5_scale_slope_angle_600_3 - slope_angle_900_3', 'M5_scale_slope_angle_600_3 - slope_angle_900_6', 'M5_scale_slope_angle_600_3 - slope_angle_900_9', 'M5_scale_slope_angle_600_6 - slope_angle_600_9', 'M5_scale_slope_angle_600_6 - slope_angle_900_3', 'M5_scale_slope_angle_600_6 - slope_angle_900_6', 'M5_scale_slope_angle_600_6 - slope_angle_900_9', 'M5_scale_slope_angle_600_9 - slope_angle_900_3', 'M5_scale_slope_angle_600_9 - slope_angle_900_6', 'M5_scale_slope_angle_600_9 - slope_angle_900_9', 'M5_scale_slope_angle_900_3 - slope_angle_900_6', 'M5_scale_slope_angle_900_3 - slope_angle_900_9', 'M5_scale_slope_angle_900_6 - slope_angle_900_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M5_scale_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M5_scale_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M5_scale_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_MACD_12_26_9_diff', 'M10_raw_10min_MACD_signal_12_26_9_diff', 'M10_raw_10min_MACD_hist_12_26_9_diff', 'M10_raw_10min_RSI_basic_14_diff', 'M10_raw_10min_BB_upper_20_diff', 'M10_raw_10min_BB_middle_20_diff', 'M10_raw_10min_BB_lower_20_diff', 'M10_raw_10min_ATR_14_diff', 'M10_raw_10min_OBV_basic_diff', 'M10_raw_10min_VWAP_basic_diff', 'M10_raw_10min_Momentum_10_diff', 'M10_raw_10min_ROC_10_diff', 'M10_raw_10min_Stoch_K_14_3_3_diff', 'M10_raw_10min_Stoch_D_14_3_3_diff', 'M10_raw_10min_CCI_20_diff', 'M10_raw_10min_MFI_basic_14_diff', 'M10_raw_10min_ADX_14_diff', 'M10_raw_10min_WilliamsR_14_diff', 'M10_raw_10min_CMF_diff', 'M10_raw_10min_TMF_diff', 'M10_raw_10min_MFI_14_volume_diff', 'M10_raw_10min_KO_diff', 'M10_raw_10min_EFI_diff', 'M10_raw_10min_EOM_diff', 'M10_raw_10min_VPT_diff', 'M10_raw_10min_NVI_diff', 'M10_raw_10min_PVI_diff', 'M10_raw_10min_VFI_diff', 'M10_raw_10min_VWAP_diff', 'M10_raw_10min_Market_Facilitation_Index_diff', 'M10_raw_10min_AD_Line_diff', 'M10_raw_10min_WAD_diff', 'M10_raw_10min_EMA_15_diff', 'M10_raw_10min_EMA_21_diff', 'M10_raw_10min_EMA_50_diff', 'M10_raw_10min_EMA_100_diff', 'M10_raw_10min_EMA_200_diff', 'M10_raw_10min_RSI_3_diff', 'M10_raw_10min_RSI_7_diff', 'M10_raw_10min_RSI_14_diff', 'M10_raw_10min_RSI_3 - RSI_7', 'M10_raw_10min_RSI_3 - RSI_14', 'M10_raw_10min_RSI_7 - RSI_14', 'M10_raw_10min_MFI_3_diff', 'M10_raw_10min_MFI_7_diff', 'M10_raw_10min_MFI_14_diff', 'M10_raw_10min_MFI_3 - MFI_7', 'M10_raw_10min_MFI_3 - MFI_14', 'M10_raw_10min_MFI_7 - MFI_14', 'M10_raw_10min_OBV_diff', 'M10_raw_10min_slope_div_300_3_diff', 'M10_raw_10min_slope_signal_300_3_diff', 'M10_raw_10min_slope_angle_300_3_diff', 'M10_raw_10min_slope_angle_signal_300_3_diff', 'M10_raw_10min_slope_lin_reg_300_3_diff', 'M10_raw_10min_slope_lin_reg_signal_300_3_diff', 'M10_raw_10min_slope_div_300_6_diff', 'M10_raw_10min_slope_signal_300_6_diff', 'M10_raw_10min_slope_angle_300_6_diff', 'M10_raw_10min_slope_angle_signal_300_6_diff', 'M10_raw_10min_slope_lin_reg_300_6_diff', 'M10_raw_10min_slope_lin_reg_signal_300_6_diff', 'M10_raw_10min_slope_div_300_9_diff', 'M10_raw_10min_slope_signal_300_9_diff', 'M10_raw_10min_slope_angle_300_9_diff', 'M10_raw_10min_slope_angle_signal_300_9_diff', 'M10_raw_10min_slope_lin_reg_300_9_diff', 'M10_raw_10min_slope_lin_reg_signal_300_9_diff', 'M10_raw_10min_slope_div_600_3_diff', 'M10_raw_10min_slope_signal_600_3_diff', 'M10_raw_10min_slope_angle_600_3_diff', 'M10_raw_10min_slope_angle_signal_600_3_diff', 'M10_raw_10min_slope_lin_reg_600_3_diff', 'M10_raw_10min_slope_lin_reg_signal_600_3_diff', 'M10_raw_10min_slope_div_600_6_diff', 'M10_raw_10min_slope_signal_600_6_diff', 'M10_raw_10min_slope_angle_600_6_diff', 'M10_raw_10min_slope_angle_signal_600_6_diff', 'M10_raw_10min_slope_lin_reg_600_6_diff', 'M10_raw_10min_slope_lin_reg_signal_600_6_diff', 'M10_raw_10min_slope_div_600_9_diff', 'M10_raw_10min_slope_signal_600_9_diff', 'M10_raw_10min_slope_angle_600_9_diff', 'M10_raw_10min_slope_angle_signal_600_9_diff', 'M10_raw_10min_slope_lin_reg_600_9_diff', 'M10_raw_10min_slope_lin_reg_signal_600_9_diff', 'M10_raw_10min_slope_div_900_3_diff', 'M10_raw_10min_slope_signal_900_3_diff', 'M10_raw_10min_slope_angle_900_3_diff', 'M10_raw_10min_slope_angle_signal_900_3_diff', 'M10_raw_10min_slope_lin_reg_900_3_diff', 'M10_raw_10min_slope_lin_reg_signal_900_3_diff', 'M10_raw_10min_slope_div_900_6_diff', 'M10_raw_10min_slope_signal_900_6_diff', 'M10_raw_10min_slope_angle_900_6_diff', 'M10_raw_10min_slope_angle_signal_900_6_diff', 'M10_raw_10min_slope_lin_reg_900_6_diff', 'M10_raw_10min_slope_lin_reg_signal_900_6_diff', 'M10_raw_10min_slope_div_900_9_diff', 'M10_raw_10min_slope_signal_900_9_diff', 'M10_raw_10min_slope_angle_900_9_diff', 'M10_raw_10min_slope_angle_signal_900_9_diff', 'M10_raw_10min_slope_lin_reg_900_9_diff', 'M10_raw_10min_slope_lin_reg_signal_900_9_diff', 'M10_raw_10min_slope_div_300_3 - slope_div_300_6', 'M10_raw_10min_slope_div_300_3 - slope_div_300_9', 'M10_raw_10min_slope_div_300_3 - slope_div_600_3', 'M10_raw_10min_slope_div_300_3 - slope_div_600_6', 'M10_raw_10min_slope_div_300_3 - slope_div_600_9', 'M10_raw_10min_slope_div_300_3 - slope_div_900_3', 'M10_raw_10min_slope_div_300_3 - slope_div_900_6', 'M10_raw_10min_slope_div_300_3 - slope_div_900_9', 'M10_raw_10min_slope_div_300_6 - slope_div_300_9', 'M10_raw_10min_slope_div_300_6 - slope_div_600_3', 'M10_raw_10min_slope_div_300_6 - slope_div_600_6', 'M10_raw_10min_slope_div_300_6 - slope_div_600_9', 'M10_raw_10min_slope_div_300_6 - slope_div_900_3', 'M10_raw_10min_slope_div_300_6 - slope_div_900_6', 'M10_raw_10min_slope_div_300_6 - slope_div_900_9', 'M10_raw_10min_slope_div_300_9 - slope_div_600_3', 'M10_raw_10min_slope_div_300_9 - slope_div_600_6', 'M10_raw_10min_slope_div_300_9 - slope_div_600_9', 'M10_raw_10min_slope_div_300_9 - slope_div_900_3', 'M10_raw_10min_slope_div_300_9 - slope_div_900_6', 'M10_raw_10min_slope_div_300_9 - slope_div_900_9', 'M10_raw_10min_slope_div_600_3 - slope_div_600_6', 'M10_raw_10min_slope_div_600_3 - slope_div_600_9', 'M10_raw_10min_slope_div_600_3 - slope_div_900_3', 'M10_raw_10min_slope_div_600_3 - slope_div_900_6', 'M10_raw_10min_slope_div_600_3 - slope_div_900_9', 'M10_raw_10min_slope_div_600_6 - slope_div_600_9', 'M10_raw_10min_slope_div_600_6 - slope_div_900_3', 'M10_raw_10min_slope_div_600_6 - slope_div_900_6', 'M10_raw_10min_slope_div_600_6 - slope_div_900_9', 'M10_raw_10min_slope_div_600_9 - slope_div_900_3', 'M10_raw_10min_slope_div_600_9 - slope_div_900_6', 'M10_raw_10min_slope_div_600_9 - slope_div_900_9', 'M10_raw_10min_slope_div_900_3 - slope_div_900_6', 'M10_raw_10min_slope_div_900_3 - slope_div_900_9', 'M10_raw_10min_slope_div_900_6 - slope_div_900_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_raw_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_raw_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_raw_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_raw_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_raw_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_raw_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_raw_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_raw_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_raw_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_raw_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_raw_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_MACD_12_26_9_diff', 'M10_scale_10min_MACD_signal_12_26_9_diff', 'M10_scale_10min_MACD_hist_12_26_9_diff', 'M10_scale_10min_RSI_basic_14_diff', 'M10_scale_10min_BB_upper_20_diff', 'M10_scale_10min_BB_middle_20_diff', 'M10_scale_10min_BB_lower_20_diff', 'M10_scale_10min_ATR_14_diff', 'M10_scale_10min_OBV_basic_diff', 'M10_scale_10min_VWAP_basic_diff', 'M10_scale_10min_Momentum_10_diff', 'M10_scale_10min_ROC_10_diff', 'M10_scale_10min_Stoch_K_14_3_3_diff', 'M10_scale_10min_Stoch_D_14_3_3_diff', 'M10_scale_10min_CCI_20_diff', 'M10_scale_10min_MFI_basic_14_diff', 'M10_scale_10min_ADX_14_diff', 'M10_scale_10min_WilliamsR_14_diff', 'M10_scale_10min_CMF_diff', 'M10_scale_10min_TMF_diff', 'M10_scale_10min_MFI_14_volume_diff', 'M10_scale_10min_KO_diff', 'M10_scale_10min_EFI_diff', 'M10_scale_10min_EOM_diff', 'M10_scale_10min_VPT_diff', 'M10_scale_10min_NVI_diff', 'M10_scale_10min_PVI_diff', 'M10_scale_10min_VFI_diff', 'M10_scale_10min_VWAP_diff', 'M10_scale_10min_Market_Facilitation_Index_diff', 'M10_scale_10min_AD_Line_diff', 'M10_scale_10min_WAD_diff', 'M10_scale_10min_EMA_15_diff', 'M10_scale_10min_EMA_21_diff', 'M10_scale_10min_EMA_50_diff', 'M10_scale_10min_EMA_100_diff', 'M10_scale_10min_EMA_200_diff', 'M10_scale_10min_RSI_3_diff', 'M10_scale_10min_RSI_7_diff', 'M10_scale_10min_RSI_14_diff', 'M10_scale_10min_RSI_3 - RSI_7', 'M10_scale_10min_RSI_3 - RSI_14', 'M10_scale_10min_RSI_7 - RSI_14', 'M10_scale_10min_MFI_3_diff', 'M10_scale_10min_MFI_7_diff', 'M10_scale_10min_MFI_14_diff', 'M10_scale_10min_MFI_3 - MFI_7', 'M10_scale_10min_MFI_3 - MFI_14', 'M10_scale_10min_MFI_7 - MFI_14', 'M10_scale_10min_OBV_diff', 'M10_scale_10min_slope_div_300_3_diff', 'M10_scale_10min_slope_signal_300_3_diff', 'M10_scale_10min_slope_angle_300_3_diff', 'M10_scale_10min_slope_angle_signal_300_3_diff', 'M10_scale_10min_slope_lin_reg_300_3_diff', 'M10_scale_10min_slope_lin_reg_signal_300_3_diff', 'M10_scale_10min_slope_div_300_6_diff', 'M10_scale_10min_slope_signal_300_6_diff', 'M10_scale_10min_slope_angle_300_6_diff', 'M10_scale_10min_slope_angle_signal_300_6_diff', 'M10_scale_10min_slope_lin_reg_300_6_diff', 'M10_scale_10min_slope_lin_reg_signal_300_6_diff', 'M10_scale_10min_slope_div_300_9_diff', 'M10_scale_10min_slope_signal_300_9_diff', 'M10_scale_10min_slope_angle_300_9_diff', 'M10_scale_10min_slope_angle_signal_300_9_diff', 'M10_scale_10min_slope_lin_reg_300_9_diff', 'M10_scale_10min_slope_lin_reg_signal_300_9_diff', 'M10_scale_10min_slope_div_600_3_diff', 'M10_scale_10min_slope_signal_600_3_diff', 'M10_scale_10min_slope_angle_600_3_diff', 'M10_scale_10min_slope_angle_signal_600_3_diff', 'M10_scale_10min_slope_lin_reg_600_3_diff', 'M10_scale_10min_slope_lin_reg_signal_600_3_diff', 'M10_scale_10min_slope_div_600_6_diff', 'M10_scale_10min_slope_signal_600_6_diff', 'M10_scale_10min_slope_angle_600_6_diff', 'M10_scale_10min_slope_angle_signal_600_6_diff', 'M10_scale_10min_slope_lin_reg_600_6_diff', 'M10_scale_10min_slope_lin_reg_signal_600_6_diff', 'M10_scale_10min_slope_div_600_9_diff', 'M10_scale_10min_slope_signal_600_9_diff', 'M10_scale_10min_slope_angle_600_9_diff', 'M10_scale_10min_slope_angle_signal_600_9_diff', 'M10_scale_10min_slope_lin_reg_600_9_diff', 'M10_scale_10min_slope_lin_reg_signal_600_9_diff', 'M10_scale_10min_slope_div_900_3_diff', 'M10_scale_10min_slope_signal_900_3_diff', 'M10_scale_10min_slope_angle_900_3_diff', 'M10_scale_10min_slope_angle_signal_900_3_diff', 'M10_scale_10min_slope_lin_reg_900_3_diff', 'M10_scale_10min_slope_lin_reg_signal_900_3_diff', 'M10_scale_10min_slope_div_900_6_diff', 'M10_scale_10min_slope_signal_900_6_diff', 'M10_scale_10min_slope_angle_900_6_diff', 'M10_scale_10min_slope_angle_signal_900_6_diff', 'M10_scale_10min_slope_lin_reg_900_6_diff', 'M10_scale_10min_slope_lin_reg_signal_900_6_diff', 'M10_scale_10min_slope_div_900_9_diff', 'M10_scale_10min_slope_signal_900_9_diff', 'M10_scale_10min_slope_angle_900_9_diff', 'M10_scale_10min_slope_angle_signal_900_9_diff', 'M10_scale_10min_slope_lin_reg_900_9_diff', 'M10_scale_10min_slope_lin_reg_signal_900_9_diff', 'M10_scale_10min_slope_div_300_3 - slope_div_300_6', 'M10_scale_10min_slope_div_300_3 - slope_div_300_9', 'M10_scale_10min_slope_div_300_3 - slope_div_600_3', 'M10_scale_10min_slope_div_300_3 - slope_div_600_6', 'M10_scale_10min_slope_div_300_3 - slope_div_600_9', 'M10_scale_10min_slope_div_300_3 - slope_div_900_3', 'M10_scale_10min_slope_div_300_3 - slope_div_900_6', 'M10_scale_10min_slope_div_300_3 - slope_div_900_9', 'M10_scale_10min_slope_div_300_6 - slope_div_300_9', 'M10_scale_10min_slope_div_300_6 - slope_div_600_3', 'M10_scale_10min_slope_div_300_6 - slope_div_600_6', 'M10_scale_10min_slope_div_300_6 - slope_div_600_9', 'M10_scale_10min_slope_div_300_6 - slope_div_900_3', 'M10_scale_10min_slope_div_300_6 - slope_div_900_6', 'M10_scale_10min_slope_div_300_6 - slope_div_900_9', 'M10_scale_10min_slope_div_300_9 - slope_div_600_3', 'M10_scale_10min_slope_div_300_9 - slope_div_600_6', 'M10_scale_10min_slope_div_300_9 - slope_div_600_9', 'M10_scale_10min_slope_div_300_9 - slope_div_900_3', 'M10_scale_10min_slope_div_300_9 - slope_div_900_6', 'M10_scale_10min_slope_div_300_9 - slope_div_900_9', 'M10_scale_10min_slope_div_600_3 - slope_div_600_6', 'M10_scale_10min_slope_div_600_3 - slope_div_600_9', 'M10_scale_10min_slope_div_600_3 - slope_div_900_3', 'M10_scale_10min_slope_div_600_3 - slope_div_900_6', 'M10_scale_10min_slope_div_600_3 - slope_div_900_9', 'M10_scale_10min_slope_div_600_6 - slope_div_600_9', 'M10_scale_10min_slope_div_600_6 - slope_div_900_3', 'M10_scale_10min_slope_div_600_6 - slope_div_900_6', 'M10_scale_10min_slope_div_600_6 - slope_div_900_9', 'M10_scale_10min_slope_div_600_9 - slope_div_900_3', 'M10_scale_10min_slope_div_600_9 - slope_div_900_6', 'M10_scale_10min_slope_div_600_9 - slope_div_900_9', 'M10_scale_10min_slope_div_900_3 - slope_div_900_6', 'M10_scale_10min_slope_div_900_3 - slope_div_900_9', 'M10_scale_10min_slope_div_900_6 - slope_div_900_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_300_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_600_9', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_300_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_600_9', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_6 - slope_signal_900_9', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_3', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_6', 'M10_scale_10min_slope_signal_600_9 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_6', 'M10_scale_10min_slope_signal_900_3 - slope_signal_900_9', 'M10_scale_10min_slope_signal_900_6 - slope_signal_900_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_300_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_600_9', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_300_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_600_9', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_3', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_6', 'M10_scale_10min_slope_angle_600_9 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_6', 'M10_scale_10min_slope_angle_900_3 - slope_angle_900_9', 'M10_scale_10min_slope_angle_900_6 - slope_angle_900_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M10_scale_10min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M10_scale_10min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M10_scale_10min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M10_scale_10min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M10_scale_10min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_MACD_12_26_9_diff', 'M15_raw_15min_MACD_signal_12_26_9_diff', 'M15_raw_15min_MACD_hist_12_26_9_diff', 'M15_raw_15min_RSI_basic_14_diff', 'M15_raw_15min_BB_upper_20_diff', 'M15_raw_15min_BB_middle_20_diff', 'M15_raw_15min_BB_lower_20_diff', 'M15_raw_15min_ATR_14_diff', 'M15_raw_15min_OBV_basic_diff', 'M15_raw_15min_VWAP_basic_diff', 'M15_raw_15min_Momentum_10_diff', 'M15_raw_15min_ROC_10_diff', 'M15_raw_15min_Stoch_K_14_3_3_diff', 'M15_raw_15min_Stoch_D_14_3_3_diff', 'M15_raw_15min_CCI_20_diff', 'M15_raw_15min_MFI_basic_14_diff', 'M15_raw_15min_ADX_14_diff', 'M15_raw_15min_WilliamsR_14_diff', 'M15_raw_15min_CMF_diff', 'M15_raw_15min_TMF_diff', 'M15_raw_15min_MFI_14_volume_diff', 'M15_raw_15min_KO_diff', 'M15_raw_15min_EFI_diff', 'M15_raw_15min_EOM_diff', 'M15_raw_15min_VPT_diff', 'M15_raw_15min_NVI_diff', 'M15_raw_15min_PVI_diff', 'M15_raw_15min_VFI_diff', 'M15_raw_15min_VWAP_diff', 'M15_raw_15min_Market_Facilitation_Index_diff', 'M15_raw_15min_AD_Line_diff', 'M15_raw_15min_WAD_diff', 'M15_raw_15min_EMA_15_diff', 'M15_raw_15min_EMA_21_diff', 'M15_raw_15min_EMA_50_diff', 'M15_raw_15min_EMA_100_diff', 'M15_raw_15min_EMA_200_diff', 'M15_raw_15min_RSI_3_diff', 'M15_raw_15min_RSI_7_diff', 'M15_raw_15min_RSI_14_diff', 'M15_raw_15min_RSI_3 - RSI_7', 'M15_raw_15min_RSI_3 - RSI_14', 'M15_raw_15min_RSI_7 - RSI_14', 'M15_raw_15min_MFI_3_diff', 'M15_raw_15min_MFI_7_diff', 'M15_raw_15min_MFI_14_diff', 'M15_raw_15min_MFI_3 - MFI_7', 'M15_raw_15min_MFI_3 - MFI_14', 'M15_raw_15min_MFI_7 - MFI_14', 'M15_raw_15min_OBV_diff', 'M15_raw_15min_slope_div_300_3_diff', 'M15_raw_15min_slope_signal_300_3_diff', 'M15_raw_15min_slope_angle_300_3_diff', 'M15_raw_15min_slope_angle_signal_300_3_diff', 'M15_raw_15min_slope_lin_reg_300_3_diff', 'M15_raw_15min_slope_lin_reg_signal_300_3_diff', 'M15_raw_15min_slope_div_300_6_diff', 'M15_raw_15min_slope_signal_300_6_diff', 'M15_raw_15min_slope_angle_300_6_diff', 'M15_raw_15min_slope_angle_signal_300_6_diff', 'M15_raw_15min_slope_lin_reg_300_6_diff', 'M15_raw_15min_slope_lin_reg_signal_300_6_diff', 'M15_raw_15min_slope_div_300_9_diff', 'M15_raw_15min_slope_signal_300_9_diff', 'M15_raw_15min_slope_angle_300_9_diff', 'M15_raw_15min_slope_angle_signal_300_9_diff', 'M15_raw_15min_slope_lin_reg_300_9_diff', 'M15_raw_15min_slope_lin_reg_signal_300_9_diff', 'M15_raw_15min_slope_div_600_3_diff', 'M15_raw_15min_slope_signal_600_3_diff', 'M15_raw_15min_slope_angle_600_3_diff', 'M15_raw_15min_slope_angle_signal_600_3_diff', 'M15_raw_15min_slope_lin_reg_600_3_diff', 'M15_raw_15min_slope_lin_reg_signal_600_3_diff', 'M15_raw_15min_slope_div_600_6_diff', 'M15_raw_15min_slope_signal_600_6_diff', 'M15_raw_15min_slope_angle_600_6_diff', 'M15_raw_15min_slope_angle_signal_600_6_diff', 'M15_raw_15min_slope_lin_reg_600_6_diff', 'M15_raw_15min_slope_lin_reg_signal_600_6_diff', 'M15_raw_15min_slope_div_600_9_diff', 'M15_raw_15min_slope_signal_600_9_diff', 'M15_raw_15min_slope_angle_600_9_diff', 'M15_raw_15min_slope_angle_signal_600_9_diff', 'M15_raw_15min_slope_lin_reg_600_9_diff', 'M15_raw_15min_slope_lin_reg_signal_600_9_diff', 'M15_raw_15min_slope_div_900_3_diff', 'M15_raw_15min_slope_signal_900_3_diff', 'M15_raw_15min_slope_angle_900_3_diff', 'M15_raw_15min_slope_angle_signal_900_3_diff', 'M15_raw_15min_slope_lin_reg_900_3_diff', 'M15_raw_15min_slope_lin_reg_signal_900_3_diff', 'M15_raw_15min_slope_div_900_6_diff', 'M15_raw_15min_slope_signal_900_6_diff', 'M15_raw_15min_slope_angle_900_6_diff', 'M15_raw_15min_slope_angle_signal_900_6_diff', 'M15_raw_15min_slope_lin_reg_900_6_diff', 'M15_raw_15min_slope_lin_reg_signal_900_6_diff', 'M15_raw_15min_slope_div_900_9_diff', 'M15_raw_15min_slope_signal_900_9_diff', 'M15_raw_15min_slope_angle_900_9_diff', 'M15_raw_15min_slope_angle_signal_900_9_diff', 'M15_raw_15min_slope_lin_reg_900_9_diff', 'M15_raw_15min_slope_lin_reg_signal_900_9_diff', 'M15_raw_15min_slope_div_300_3 - slope_div_300_6', 'M15_raw_15min_slope_div_300_3 - slope_div_300_9', 'M15_raw_15min_slope_div_300_3 - slope_div_600_3', 'M15_raw_15min_slope_div_300_3 - slope_div_600_6', 'M15_raw_15min_slope_div_300_3 - slope_div_600_9', 'M15_raw_15min_slope_div_300_3 - slope_div_900_3', 'M15_raw_15min_slope_div_300_3 - slope_div_900_6', 'M15_raw_15min_slope_div_300_3 - slope_div_900_9', 'M15_raw_15min_slope_div_300_6 - slope_div_300_9', 'M15_raw_15min_slope_div_300_6 - slope_div_600_3', 'M15_raw_15min_slope_div_300_6 - slope_div_600_6', 'M15_raw_15min_slope_div_300_6 - slope_div_600_9', 'M15_raw_15min_slope_div_300_6 - slope_div_900_3', 'M15_raw_15min_slope_div_300_6 - slope_div_900_6', 'M15_raw_15min_slope_div_300_6 - slope_div_900_9', 'M15_raw_15min_slope_div_300_9 - slope_div_600_3', 'M15_raw_15min_slope_div_300_9 - slope_div_600_6', 'M15_raw_15min_slope_div_300_9 - slope_div_600_9', 'M15_raw_15min_slope_div_300_9 - slope_div_900_3', 'M15_raw_15min_slope_div_300_9 - slope_div_900_6', 'M15_raw_15min_slope_div_300_9 - slope_div_900_9', 'M15_raw_15min_slope_div_600_3 - slope_div_600_6', 'M15_raw_15min_slope_div_600_3 - slope_div_600_9', 'M15_raw_15min_slope_div_600_3 - slope_div_900_3', 'M15_raw_15min_slope_div_600_3 - slope_div_900_6', 'M15_raw_15min_slope_div_600_3 - slope_div_900_9', 'M15_raw_15min_slope_div_600_6 - slope_div_600_9', 'M15_raw_15min_slope_div_600_6 - slope_div_900_3', 'M15_raw_15min_slope_div_600_6 - slope_div_900_6', 'M15_raw_15min_slope_div_600_6 - slope_div_900_9', 'M15_raw_15min_slope_div_600_9 - slope_div_900_3', 'M15_raw_15min_slope_div_600_9 - slope_div_900_6', 'M15_raw_15min_slope_div_600_9 - slope_div_900_9', 'M15_raw_15min_slope_div_900_3 - slope_div_900_6', 'M15_raw_15min_slope_div_900_3 - slope_div_900_9', 'M15_raw_15min_slope_div_900_6 - slope_div_900_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_raw_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_raw_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_raw_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_raw_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_raw_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_raw_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_raw_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_raw_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_raw_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_raw_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_raw_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_MACD_12_26_9_diff', 'M15_scale_15min_MACD_signal_12_26_9_diff', 'M15_scale_15min_MACD_hist_12_26_9_diff', 'M15_scale_15min_RSI_basic_14_diff', 'M15_scale_15min_BB_upper_20_diff', 'M15_scale_15min_BB_middle_20_diff', 'M15_scale_15min_BB_lower_20_diff', 'M15_scale_15min_ATR_14_diff', 'M15_scale_15min_OBV_basic_diff', 'M15_scale_15min_VWAP_basic_diff', 'M15_scale_15min_Momentum_10_diff', 'M15_scale_15min_ROC_10_diff', 'M15_scale_15min_Stoch_K_14_3_3_diff', 'M15_scale_15min_Stoch_D_14_3_3_diff', 'M15_scale_15min_CCI_20_diff', 'M15_scale_15min_MFI_basic_14_diff', 'M15_scale_15min_ADX_14_diff', 'M15_scale_15min_WilliamsR_14_diff', 'M15_scale_15min_CMF_diff', 'M15_scale_15min_TMF_diff', 'M15_scale_15min_MFI_14_volume_diff', 'M15_scale_15min_KO_diff', 'M15_scale_15min_EFI_diff', 'M15_scale_15min_EOM_diff', 'M15_scale_15min_VPT_diff', 'M15_scale_15min_NVI_diff', 'M15_scale_15min_PVI_diff', 'M15_scale_15min_VFI_diff', 'M15_scale_15min_VWAP_diff', 'M15_scale_15min_Market_Facilitation_Index_diff', 'M15_scale_15min_AD_Line_diff', 'M15_scale_15min_WAD_diff', 'M15_scale_15min_EMA_15_diff', 'M15_scale_15min_EMA_21_diff', 'M15_scale_15min_EMA_50_diff', 'M15_scale_15min_EMA_100_diff', 'M15_scale_15min_EMA_200_diff', 'M15_scale_15min_RSI_3_diff', 'M15_scale_15min_RSI_7_diff', 'M15_scale_15min_RSI_14_diff', 'M15_scale_15min_RSI_3 - RSI_7', 'M15_scale_15min_RSI_3 - RSI_14', 'M15_scale_15min_RSI_7 - RSI_14', 'M15_scale_15min_MFI_3_diff', 'M15_scale_15min_MFI_7_diff', 'M15_scale_15min_MFI_14_diff', 'M15_scale_15min_MFI_3 - MFI_7', 'M15_scale_15min_MFI_3 - MFI_14', 'M15_scale_15min_MFI_7 - MFI_14', 'M15_scale_15min_OBV_diff', 'M15_scale_15min_slope_div_300_3_diff', 'M15_scale_15min_slope_signal_300_3_diff', 'M15_scale_15min_slope_angle_300_3_diff', 'M15_scale_15min_slope_angle_signal_300_3_diff', 'M15_scale_15min_slope_lin_reg_300_3_diff', 'M15_scale_15min_slope_lin_reg_signal_300_3_diff', 'M15_scale_15min_slope_div_300_6_diff', 'M15_scale_15min_slope_signal_300_6_diff', 'M15_scale_15min_slope_angle_300_6_diff', 'M15_scale_15min_slope_angle_signal_300_6_diff', 'M15_scale_15min_slope_lin_reg_300_6_diff', 'M15_scale_15min_slope_lin_reg_signal_300_6_diff', 'M15_scale_15min_slope_div_300_9_diff', 'M15_scale_15min_slope_signal_300_9_diff', 'M15_scale_15min_slope_angle_300_9_diff', 'M15_scale_15min_slope_angle_signal_300_9_diff', 'M15_scale_15min_slope_lin_reg_300_9_diff', 'M15_scale_15min_slope_lin_reg_signal_300_9_diff', 'M15_scale_15min_slope_div_600_3_diff', 'M15_scale_15min_slope_signal_600_3_diff', 'M15_scale_15min_slope_angle_600_3_diff', 'M15_scale_15min_slope_angle_signal_600_3_diff', 'M15_scale_15min_slope_lin_reg_600_3_diff', 'M15_scale_15min_slope_lin_reg_signal_600_3_diff', 'M15_scale_15min_slope_div_600_6_diff', 'M15_scale_15min_slope_signal_600_6_diff', 'M15_scale_15min_slope_angle_600_6_diff', 'M15_scale_15min_slope_angle_signal_600_6_diff', 'M15_scale_15min_slope_lin_reg_600_6_diff', 'M15_scale_15min_slope_lin_reg_signal_600_6_diff', 'M15_scale_15min_slope_div_600_9_diff', 'M15_scale_15min_slope_signal_600_9_diff', 'M15_scale_15min_slope_angle_600_9_diff', 'M15_scale_15min_slope_angle_signal_600_9_diff', 'M15_scale_15min_slope_lin_reg_600_9_diff', 'M15_scale_15min_slope_lin_reg_signal_600_9_diff', 'M15_scale_15min_slope_div_900_3_diff', 'M15_scale_15min_slope_signal_900_3_diff', 'M15_scale_15min_slope_angle_900_3_diff', 'M15_scale_15min_slope_angle_signal_900_3_diff', 'M15_scale_15min_slope_lin_reg_900_3_diff', 'M15_scale_15min_slope_lin_reg_signal_900_3_diff', 'M15_scale_15min_slope_div_900_6_diff', 'M15_scale_15min_slope_signal_900_6_diff', 'M15_scale_15min_slope_angle_900_6_diff', 'M15_scale_15min_slope_angle_signal_900_6_diff', 'M15_scale_15min_slope_lin_reg_900_6_diff', 'M15_scale_15min_slope_lin_reg_signal_900_6_diff', 'M15_scale_15min_slope_div_900_9_diff', 'M15_scale_15min_slope_signal_900_9_diff', 'M15_scale_15min_slope_angle_900_9_diff', 'M15_scale_15min_slope_angle_signal_900_9_diff', 'M15_scale_15min_slope_lin_reg_900_9_diff', 'M15_scale_15min_slope_lin_reg_signal_900_9_diff', 'M15_scale_15min_slope_div_300_3 - slope_div_300_6', 'M15_scale_15min_slope_div_300_3 - slope_div_300_9', 'M15_scale_15min_slope_div_300_3 - slope_div_600_3', 'M15_scale_15min_slope_div_300_3 - slope_div_600_6', 'M15_scale_15min_slope_div_300_3 - slope_div_600_9', 'M15_scale_15min_slope_div_300_3 - slope_div_900_3', 'M15_scale_15min_slope_div_300_3 - slope_div_900_6', 'M15_scale_15min_slope_div_300_3 - slope_div_900_9', 'M15_scale_15min_slope_div_300_6 - slope_div_300_9', 'M15_scale_15min_slope_div_300_6 - slope_div_600_3', 'M15_scale_15min_slope_div_300_6 - slope_div_600_6', 'M15_scale_15min_slope_div_300_6 - slope_div_600_9', 'M15_scale_15min_slope_div_300_6 - slope_div_900_3', 'M15_scale_15min_slope_div_300_6 - slope_div_900_6', 'M15_scale_15min_slope_div_300_6 - slope_div_900_9', 'M15_scale_15min_slope_div_300_9 - slope_div_600_3', 'M15_scale_15min_slope_div_300_9 - slope_div_600_6', 'M15_scale_15min_slope_div_300_9 - slope_div_600_9', 'M15_scale_15min_slope_div_300_9 - slope_div_900_3', 'M15_scale_15min_slope_div_300_9 - slope_div_900_6', 'M15_scale_15min_slope_div_300_9 - slope_div_900_9', 'M15_scale_15min_slope_div_600_3 - slope_div_600_6', 'M15_scale_15min_slope_div_600_3 - slope_div_600_9', 'M15_scale_15min_slope_div_600_3 - slope_div_900_3', 'M15_scale_15min_slope_div_600_3 - slope_div_900_6', 'M15_scale_15min_slope_div_600_3 - slope_div_900_9', 'M15_scale_15min_slope_div_600_6 - slope_div_600_9', 'M15_scale_15min_slope_div_600_6 - slope_div_900_3', 'M15_scale_15min_slope_div_600_6 - slope_div_900_6', 'M15_scale_15min_slope_div_600_6 - slope_div_900_9', 'M15_scale_15min_slope_div_600_9 - slope_div_900_3', 'M15_scale_15min_slope_div_600_9 - slope_div_900_6', 'M15_scale_15min_slope_div_600_9 - slope_div_900_9', 'M15_scale_15min_slope_div_900_3 - slope_div_900_6', 'M15_scale_15min_slope_div_900_3 - slope_div_900_9', 'M15_scale_15min_slope_div_900_6 - slope_div_900_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_300_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_600_9', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_300_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_600_9', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_6 - slope_signal_900_9', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_3', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_6', 'M15_scale_15min_slope_signal_600_9 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_6', 'M15_scale_15min_slope_signal_900_3 - slope_signal_900_9', 'M15_scale_15min_slope_signal_900_6 - slope_signal_900_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_300_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_600_9', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_300_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_600_9', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_3', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_6', 'M15_scale_15min_slope_angle_600_9 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_6', 'M15_scale_15min_slope_angle_900_3 - slope_angle_900_9', 'M15_scale_15min_slope_angle_900_6 - slope_angle_900_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_300_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_300_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_600_9', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_3', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_600_9 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_6', 'M15_scale_15min_slope_angle_signal_900_3 - slope_angle_signal_900_9', 'M15_scale_15min_slope_angle_signal_900_6 - slope_angle_signal_900_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_300_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_300_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_600_9', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_3', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_600_9 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_6', 'M15_scale_15min_slope_lin_reg_900_3 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_900_6 - slope_lin_reg_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_300_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_300_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_600_9', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_6 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_3', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6', 'M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9', 'M15_scale_15min_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9'] \n",
+      "\n",
+      "NaN counts per column (sorted):\n",
+      "M5_scale_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9           49\n",
+      "M5_scale_slope_lin_reg_signal_900_6 - slope_lin_reg_signal_900_9           49\n",
+      "M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9           49\n",
+      "M5_scale_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6           49\n",
+      "M5_scale_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9           49\n",
+      "                                                                           ..\n",
+      "M15_scale_15min_slope_lin_reg_signal_600_9 - slope_lin_reg_signal_900_9     0\n",
+      "M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_6     0\n",
+      "M15_scale_15min_slope_lin_reg_signal_900_3 - slope_lin_reg_signal_900_9     0\n",
+      "label                                                                       0\n",
+      "M15_scale_15min_slope_lin_reg_signal_300_3 - slope_lin_reg_signal_600_9     0\n",
+      "Length: 1922, dtype: int64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "### Select features containing 'diff' or '-' in their names\n",
+    "#diff_features = df.filter(regex='diff|-')\n",
+    "\n",
+    "### Create a new dataframe with the Date column, label and the selected features\n",
+    "#df_diff = pd.concat([df[['Date', 'label']], diff_features], axis=1)\n",
+    "\n",
+    "#print(\"DataFrame with difference features:\")\n",
+    "#print(df_diff.shape,'\\n')\n",
+    "#print('Label_Counts : ',df_diff.label.value_counts(),'\\n')\n",
+    "#print(list(df_diff.columns), '\\n')\n",
+    "\n",
+    "# Add NaN count per column, sorted\n",
+    "#print(\"NaN counts per column (sorted):\")\n",
+    "#print(df_diff.isnull().sum().sort_values(ascending=False), '\\n')\n",
+    "\n",
+    "#df_diff.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4TPpba7UChUY",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4TPpba7UChUY",
+    "outputId": "97597da2-64f7-4d48-9f53-22766d4e9fdc"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flipped 33857 rows with Open_Trade = -1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "### Align feature directions so that shorts mirror longs\n",
+    "#if 'Open_Trade' not in df.columns:\n",
+    " #   raise KeyError(\"'Open_Trade' column is required in df to flip feature signs.\")\n",
+    "\n",
+    "### Attach the trade direction to the diff dataframe (kept for reference).\n",
+    "#df_diff = df_diff.merge(df[['Date', 'Open_Trade']], on='Date', how='left')\n",
+    "\n",
+    "### Identify feature columns to flip (exclude identifiers/targets).\n",
+    "#feature_cols = [col for col in df_diff.columns if col not in ['Date', 'label', 'Open_Trade']]\n",
+    "#short_mask = df_diff['Open_Trade'] == -1\n",
+    "\n",
+    "#if short_mask.any():\n",
+    "#    df_diff.loc[short_mask, feature_cols] = df_diff.loc[short_mask, feature_cols] * -1\n",
+    "#    print(f\"Flipped {short_mask.sum()} rows with Open_Trade = -1.\")\n",
+    "#else:\n",
+    "#    print(\"No rows with Open_Trade = -1 were found.\")\n",
+    "\n",
+    "### Reorder columns so Open_Trade stays next to the label for downstream steps.\n",
+    "#ordered_cols = ['Date', 'label', 'Open_Trade'] + [col for col in feature_cols]\n",
+    "#df_diff = df_diff[ordered_cols]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pQa8_4GpvRRf",
+   "metadata": {
+    "id": "pQa8_4GpvRRf"
+   },
+   "outputs": [],
+   "source": [
+    "#df = df_diff.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lBtQecOO08zB",
+   "metadata": {
+    "id": "lBtQecOO08zB"
+   },
+   "source": [
+    "## ML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8rlkmypd9DJj",
+   "metadata": {
+    "id": "8rlkmypd9DJj"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 1. ENTRENAR Y OBTENER IMPORTANCIAS =====================\n",
+    "def compute_xgb_importance(\n",
+    "    X: pd.DataFrame,\n",
+    "    y: pd.Series,\n",
+    "    task: str = \"classification\",\n",
+    "    random_state: int = 42,\n",
+    "    **xgb_params: Any\n",
+    ") -> Tuple[pd.DataFrame, Any]:\n",
+    "    \"\"\"\n",
+    "    Entrena un modelo XGBoost y devuelve:\n",
+    "      - imp_df: DataFrame con 'feature', 'importance' y 'cum_importance'.\n",
+    "      - model : modelo ya entrenado.\n",
+    "\n",
+    "    Soporta:\n",
+    "      • Clasificación binaria o multiclase (detecta nº de clases).\n",
+    "      • Regresión (si task != 'classification').\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X : pd.DataFrame\n",
+    "        Matriz de características (sin la columna objetivo).\n",
+    "    y : pd.Series\n",
+    "        Etiquetas objetivo. Puede ser binaria (0/1) o multiclase (0..K-1).\n",
+    "    task : str, opcional\n",
+    "        \"classification\" (default) o \"regression\".\n",
+    "    random_state : int, opcional\n",
+    "        Semilla para reproducibilidad.\n",
+    "    **xgb_params : dict\n",
+    "        Parámetros adicionales para el estimador de XGBoost.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (imp_df, model)\n",
+    "        imp_df : DataFrame con importancias y su acumulado.\n",
+    "        model  : instancia entrenada de XGBClassifier / XGBRegressor.\n",
+    "    \"\"\"\n",
+    "    default_params: Dict[str, Any] = dict(\n",
+    "        n_estimators=500,\n",
+    "        max_depth=6,\n",
+    "        learning_rate=0.05,\n",
+    "        subsample=0.8,\n",
+    "        colsample_bytree=0.8,\n",
+    "        random_state=random_state,\n",
+    "        n_jobs=-1,\n",
+    "        tree_method=\"hist\",\n",
+    "    )\n",
+    "    default_params.update(xgb_params)\n",
+    "\n",
+    "    if task == \"classification\":\n",
+    "        # Detectar nº de clases\n",
+    "        classes = np.unique(y)\n",
+    "        n_classes = len(classes)\n",
+    "\n",
+    "        # XGBClassifier ajusta objetivo automáticamente, pero lo explicitamos:\n",
+    "        if n_classes > 2:\n",
+    "            default_params.setdefault(\"objective\", \"multi:softprob\")\n",
+    "            default_params.setdefault(\"num_class\", n_classes)\n",
+    "            eval_metric = \"mlogloss\"\n",
+    "        else:\n",
+    "            default_params.setdefault(\"objective\", \"binary:logistic\")\n",
+    "            eval_metric = \"logloss\"\n",
+    "\n",
+    "        model = XGBClassifier(eval_metric=eval_metric, **default_params)\n",
+    "\n",
+    "    else:\n",
+    "        model = XGBRegressor(**default_params)\n",
+    "\n",
+    "    model.fit(X, y)\n",
+    "\n",
+    "    imp_df = (\n",
+    "        pd.DataFrame({\n",
+    "            \"feature\": X.columns,\n",
+    "            \"importance\": model.feature_importances_\n",
+    "        })\n",
+    "        .sort_values(\"importance\", ascending=False)\n",
+    "        .reset_index(drop=True)\n",
+    "    )\n",
+    "    total_imp = imp_df[\"importance\"].sum()\n",
+    "    if total_imp == 0:\n",
+    "        # Evitar división por cero si el modelo devuelve todo cero (raro, pero posible)\n",
+    "        imp_df[\"cum_importance\"] = 0.0\n",
+    "    else:\n",
+    "        imp_df[\"cum_importance\"] = imp_df[\"importance\"].cumsum() / total_imp\n",
+    "\n",
+    "    return imp_df, model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3r9Di4Xx9DOU",
+   "metadata": {
+    "id": "3r9Di4Xx9DOU"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 2. SELECCIÓN DE FEATURES =====================\n",
+    "def select_features_with_importance(\n",
+    "    X: pd.DataFrame,\n",
+    "    imp_df: pd.DataFrame,\n",
+    "    top_n: Optional[int] = None,\n",
+    "    threshold: Optional[str | float] = None,\n",
+    "    cum_threshold: Optional[float] = 0.8\n",
+    ") -> Tuple[pd.DataFrame, List[str]]:\n",
+    "    \"\"\"\n",
+    "    Selección flexible de variables a partir de importancias de XGBoost.\n",
+    "\n",
+    "    Reglas:\n",
+    "      - Si top_n no es None           => usa el top_n.\n",
+    "      - Else si cum_threshold no None => usa importancia acumulada (p.ej. 0.8 = 80%).\n",
+    "      - Else usa threshold ('median', 'mean' o valor numérico).\n",
+    "\n",
+    "    Devuelve (X_reducido, lista_de_features).\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X : pd.DataFrame\n",
+    "        Matriz de características original.\n",
+    "    imp_df : pd.DataFrame\n",
+    "        DataFrame devuelto por compute_xgb_importance.\n",
+    "    top_n : int | None\n",
+    "        Número fijo de variables a conservar.\n",
+    "    threshold : str | float | None\n",
+    "        Umbral de importancia. Si str, usar 'median' o 'mean'.\n",
+    "    cum_threshold : float | None\n",
+    "        Porcentaje acumulado de importancia (0-1). Si None, se ignora.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (X_sel, keep)\n",
+    "        X_sel : subset de X con columnas seleccionadas.\n",
+    "        keep  : lista de nombres de columnas seleccionadas.\n",
+    "    \"\"\"\n",
+    "    if top_n is not None:\n",
+    "        keep = imp_df.head(top_n)[\"feature\"].tolist()\n",
+    "\n",
+    "    elif cum_threshold is not None:\n",
+    "        keep_mask = imp_df[\"cum_importance\"] <= float(cum_threshold)\n",
+    "        keep = imp_df.loc[keep_mask, \"feature\"].tolist()\n",
+    "        # asegurar que haya al menos una más para no quedarnos exactamente en el corte\n",
+    "        if len(keep) < len(imp_df):\n",
+    "            keep.append(imp_df.iloc[len(keep)][\"feature\"])\n",
+    "\n",
+    "    else:\n",
+    "        if threshold is None:\n",
+    "            threshold = \"median\"\n",
+    "        if isinstance(threshold, str):\n",
+    "            thr_val = imp_df[\"importance\"].agg(threshold)\n",
+    "        else:\n",
+    "            thr_val = float(threshold)\n",
+    "        keep = imp_df.loc[imp_df[\"importance\"] >= thr_val, \"feature\"].tolist()\n",
+    "\n",
+    "    return X[keep], keep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tCDZCTz2_v9z",
+   "metadata": {
+    "id": "tCDZCTz2_v9z"
+   },
+   "outputs": [],
+   "source": [
+    "# ===================== 3. BÚSQUEDA DEL MEJOR UMBRAL ACUMULADO =====================\n",
+    "def find_best_cum_threshold(\n",
+    "    X_train: pd.DataFrame,\n",
+    "    y_train: pd.Series,\n",
+    "    X_valid: pd.DataFrame,\n",
+    "    y_valid: pd.Series,\n",
+    "    task: str = \"classification\",\n",
+    "    thresholds: Tuple[float, ...] = (0.6, 0.7, 0.8, 0.9),\n",
+    "    random_state: int = 42,\n",
+    "    metric: str = \"auto\",\n",
+    "    **xgb_params: Any\n",
+    ") -> Tuple[float, pd.DataFrame, pd.DataFrame]:\n",
+    "    \"\"\"\n",
+    "    Entrena un XGB en train, calcula importancias y prueba varios umbrales\n",
+    "    acumulados para ver cuál da la mejor métrica en valid.\n",
+    "\n",
+    "    Para CLASIFICACIÓN:\n",
+    "        - Detecta nº de clases.\n",
+    "        - Métrica por defecto (metric=\"auto\"):\n",
+    "            • Binaria: ROC-AUC (probabilidades de la clase positiva).\n",
+    "            • Multiclase: ROC-AUC macro OVR (usa predict_proba).\n",
+    "          Alternativas: metric=\"f1_macro\", \"accuracy\", \"logloss\" (se MINIMIZA).\n",
+    "    Para REGRESIÓN:\n",
+    "        - Usa R^2.\n",
+    "\n",
+    "    Devuelve:\n",
+    "        best_thr, res_df_ordenado_por_score_desc, imp_df\n",
+    "\n",
+    "    Parámetros\n",
+    "    ----------\n",
+    "    X_train, y_train, X_valid, y_valid : pd.DataFrame / pd.Series\n",
+    "        Particiones de entrenamiento y validación.\n",
+    "    task : str\n",
+    "        \"classification\" (default) o \"regression\".\n",
+    "    thresholds : tuple[float, ...]\n",
+    "        Valores de umbral de importancia acumulada a evaluar (0-1).\n",
+    "    random_state : int\n",
+    "        Semilla para reproducibilidad.\n",
+    "    metric : str\n",
+    "        \"auto\" (default), \"roc_auc\", \"f1_macro\", \"accuracy\", \"logloss\" (clasif) o \"r2\" (regresión).\n",
+    "    **xgb_params : dict\n",
+    "        Parámetros extra para el estimador de XGBoost (pasan a compute y a los modelos internos).\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    (best_thr, res_df, imp_df)\n",
+    "        best_thr : float\n",
+    "            Umbral con mejor score (o menor logloss si metric='logloss').\n",
+    "        res_df : pd.DataFrame\n",
+    "            Tabla con resultados por umbral (n_features, score).\n",
+    "        imp_df : pd.DataFrame\n",
+    "            Importancias calculadas en X_train / y_train.\n",
+    "    \"\"\"\n",
+    "    imp_df, _ = compute_xgb_importance(\n",
+    "        X_train, y_train, task=task, random_state=random_state, **xgb_params\n",
+    "    )\n",
+    "\n",
+    "    results = []\n",
+    "\n",
+    "    # Detectar nº de clases si es clasificación\n",
+    "    if task == \"classification\":\n",
+    "        classes = np.unique(y_train)\n",
+    "        n_classes = len(classes)\n",
+    "        if metric == \"auto\":\n",
+    "            metric_to_use = \"roc_auc\" if n_classes == 2 else \"roc_auc\"\n",
+    "        else:\n",
+    "            metric_to_use = metric\n",
+    "    else:\n",
+    "        metric_to_use = \"r2\" if metric == \"auto\" else metric\n",
+    "\n",
+    "    for thr in thresholds:\n",
+    "        X_tr_sel, cols = select_features_with_importance(\n",
+    "            X_train, imp_df, cum_threshold=thr, top_n=None, threshold=None\n",
+    "        )\n",
+    "        X_va_sel = X_valid[cols]\n",
+    "\n",
+    "        if task == \"classification\":\n",
+    "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
+    "            params.update(xgb_params)\n",
+    "\n",
+    "            if n_classes > 2:\n",
+    "                params.setdefault(\"objective\", \"multi:softprob\")\n",
+    "                params.setdefault(\"num_class\", n_classes)\n",
+    "                eval_metric = \"mlogloss\"\n",
+    "            else:\n",
+    "                params.setdefault(\"objective\", \"binary:logistic\")\n",
+    "                eval_metric = \"logloss\"\n",
+    "\n",
+    "            model_sel = XGBClassifier(eval_metric=eval_metric, **params)\n",
+    "            model_sel.fit(X_tr_sel, y_train)\n",
+    "\n",
+    "            # Probabilidades y predicciones\n",
+    "            proba = model_sel.predict_proba(X_va_sel)\n",
+    "            pred  = np.argmax(proba, axis=1) if n_classes > 2 else (proba[:, 1] >= 0.5).astype(int)\n",
+    "\n",
+    "            # Calcular métrica\n",
+    "            if metric_to_use == \"roc_auc\":\n",
+    "                if n_classes == 2:\n",
+    "                    score = roc_auc_score(y_valid, proba[:, 1])\n",
+    "                else:\n",
+    "                    # AUC macro One-vs-Rest\n",
+    "                    score = roc_auc_score(y_valid, proba, multi_class=\"ovr\", average=\"macro\")\n",
+    "            elif metric_to_use == \"f1_macro\":\n",
+    "                score = f1_score(y_valid, pred, average=\"macro\")\n",
+    "            elif metric_to_use == \"accuracy\":\n",
+    "                score = accuracy_score(y_valid, pred)\n",
+    "            elif metric_to_use == \"logloss\":\n",
+    "                # En este caso, menor es mejor. Guardamos negativo para mantener criterio \"mayor mejor\".\n",
+    "                score = -log_loss(y_valid, proba, labels=np.unique(y_train))\n",
+    "            else:\n",
+    "                raise ValueError(f\"Métrica no soportada: {metric_to_use}\")\n",
+    "\n",
+    "        else:\n",
+    "            # REGRESIÓN\n",
+    "            params = dict(random_state=random_state, n_jobs=-1, tree_method=\"hist\")\n",
+    "            params.update(xgb_params)\n",
+    "            model_sel = XGBRegressor(**params)\n",
+    "            model_sel.fit(X_tr_sel, y_train)\n",
+    "            pred = model_sel.predict(X_va_sel)\n",
+    "\n",
+    "            if metric_to_use == \"r2\":\n",
+    "                score = r2_score(y_valid, pred)\n",
+    "            else:\n",
+    "                raise ValueError(f\"Métrica de regresión no soportada: {metric_to_use}\")\n",
+    "\n",
+    "        results.append({\"cum_threshold\": thr, \"n_features\": len(cols), \"score\": score})\n",
+    "\n",
+    "    # Ordenar (si usamos logloss negado, mayor sigue siendo mejor)\n",
+    "    res_df = pd.DataFrame(results).sort_values(\"score\", ascending=False).reset_index(drop=True)\n",
+    "    best_thr = float(res_df.iloc[0][\"cum_threshold\"])\n",
+    "    return best_thr, res_df, imp_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "R0Dm8ZPGcBr7",
+   "metadata": {
+    "id": "R0Dm8ZPGcBr7"
+   },
+   "outputs": [],
+   "source": [
+    "def remove_highly_correlated_features(df, threshold=0.9):\n",
+    "\n",
+    "    # Solo numéricos para evitar errores y acelerar\n",
+    "    corr_matrix = df.corr(numeric_only=True).abs()\n",
+    "    upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape, dtype=bool), k=1))\n",
+    "\n",
+    "    to_drop = []\n",
+    "    for col in tqdm(upper.columns, desc=f\"Pruning corr > {threshold}\", unit=\"col\", leave=False):\n",
+    "        if (upper[col] > threshold).any():\n",
+    "            to_drop.append(col)\n",
+    "\n",
+    "    return df.drop(columns=to_drop, errors=\"ignore\"), to_drop\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WodcQEBJ_wAW",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 468,
+     "referenced_widgets": [
+      "5f836c62734d451386fd09b07cbbd5a5",
+      "63909e59276d48c6be533cb7ac6a4b51",
+      "56d0aa2bebd947769b766a99c7ab6c0e",
+      "e1af085ad9934b8599f3bb34509f3814",
+      "8786987a3a2448d5a696addc8f1ff179",
+      "2ec69da230984633b2c5bfc059c8d2c1",
+      "241af7b314f34423b4af560bcefc7007",
+      "42626100e2084ac79f1521e8d84b11b7",
+      "1f07ba6bb7864d4981aeba397cf633aa",
+      "152adcea029b4abdace26402ef4bd98d",
+      "e1d8854e112e4f608037b5080d7614e1"
+     ]
+    },
+    "id": "WodcQEBJ_wAW",
+    "outputId": "5805d7bc-9ec4-4c1c-c942-e5c1bcdaf4c7"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f836c62734d451386fd09b07cbbd5a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Pruning corr > 0.9:   0%|          | 0/2725 [00:00<?, ?col/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logistic regression CV accuracy: 0.5461760141875416\n",
+      "=== Importancias XGBoost ===\n",
+      "                                     feature  importance  cum_importance\n",
+      "0            M10_raw_10min_RSI_basic_14_diff    0.016185        0.016185\n",
+      "1                M10_scale_10min_ATR_14_diff    0.010048        0.026233\n",
+      "2                                 Open_Trade    0.009153        0.035386\n",
+      "3                 M5_scale_MACD_12_26_9_diff    0.005679        0.041065\n",
+      "4                        M10_raw_10min_RSI_3    0.005639        0.046704\n",
+      "5                      M5_raw_Kal_change_300    0.005598        0.052302\n",
+      "6   M10_raw_10min_slope_lin_reg_signal_900_3    0.005403        0.057705\n",
+      "7                  M10_raw_10min_CCI_20_diff    0.005398        0.063103\n",
+      "8                   M5_raw_MACD_12_26_9_diff    0.005299        0.068401\n",
+      "9           M10_raw_10min_slope_signal_900_3    0.005195        0.073596\n",
+      "10  M10_raw_10min_slope_lin_reg_signal_900_6    0.004901        0.078497\n",
+      "11  M10_raw_10min_slope_lin_reg_signal_600_6    0.004397        0.082895\n",
+      "12                 M5_raw_slope_signal_900_9    0.004084        0.086979\n",
+      "13                      M5_scale_ATR_14_diff    0.003975        0.090954\n",
+      "14                  M5_raw_RSI_basic_14_diff    0.003938        0.094892\n",
+      "15               M10_raw_10min_RSI_3 - RSI_7    0.003851        0.098743\n",
+      "16                    M10_raw_10min_TMF_diff    0.003577        0.102319\n",
+      "17                M5_raw_Stoch_K_14_3_3_diff    0.003375        0.105694\n",
+      "18                        M5_raw_EMA_15_diff    0.003321        0.109015\n",
+      "19                     M10_raw_10min_KO_diff    0.003318        0.112333\n",
+      "Total features: 486\n",
+      "Features seleccionadas: 340\n",
+      "XGBoost CV accuracy: 0.6015960984260695\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ===================== 3. PIPELINE PRINCIPAL =====================\n",
+    "df = df.dropna()\n",
+    "y = df['label']\n",
+    "X = df.iloc[:, 2:]\n",
+    "\n",
+    "# --- 3.3 Split temporal (ejemplo simple 80/20) ---\n",
+    "split_idx = int(len(X) * 0.8)\n",
+    "X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]\n",
+    "y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]\n",
+    "\n",
+    "# --- 3.4 Remove correlated features ---\n",
+    "X_train_filtered, dropped_features = remove_highly_correlated_features(X_train, threshold=0.9)\n",
+    "X_test_filtered = X_test.drop(columns=dropped_features)\n",
+    "\n",
+    "# Baseline logistic regression with time-series CV\n",
+    "scaler = StandardScaler()\n",
+    "X_scaled = scaler.fit_transform(X_train_filtered)\n",
+    "tscv = TimeSeriesSplit(n_splits=5)\n",
+    "baseline = cross_val_score(LogisticRegression(max_iter=1000), X_scaled, y_train, cv=tscv).mean()\n",
+    "print('Logistic regression CV accuracy:', baseline)\n",
+    "\n",
+    "# --- 3.5 Importancias con XGBoost ---\n",
+    "imp_df, xgb_model = compute_xgb_importance(X_train_filtered, y_train, task='classification')\n",
+    "\n",
+    "print('=== Importancias XGBoost ===')\n",
+    "print(imp_df.head(20))\n",
+    "print(f'Total features: {len(imp_df)}')\n",
+    "\n",
+    "# --- 3.6 Selección (elige una opción) ---\n",
+    "X_train_sel, keep_cols = select_features_with_importance(X_train_filtered, imp_df, cum_threshold=0.8)\n",
+    "X_test_sel = X_test_filtered[keep_cols]\n",
+    "\n",
+    "print(f'Features seleccionadas: {len(keep_cols)}')\n",
+    "importance_map = imp_df.set_index(\"feature\")[\"importance\"]\n",
+    "selected_importances = pd.DataFrame({\n",
+    "    \"feature\": keep_cols,\n",
+    "    \"importance\": importance_map.reindex(keep_cols).values\n",
+    "})\n",
+    "selected_importances.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_ImportantCols.csv', index=False)\n",
+    "\n",
+    "# Save dataset with selected features\n",
+    "df_selected = df[['Date', 'label'] + keep_cols]\n",
+    "df_selected.to_csv(root_data+'Results/'+symbol+'_'+direction+'_M5M10_'+data_type+'_Features.csv', index=False)\n",
+    "\n",
+    "# Time-series cross-validation with XGBoost\n",
+    "xgb_cv = XGBClassifier(eval_metric='logloss', n_estimators=500, max_depth=6, learning_rate=0.05, subsample=0.8, colsample_bytree=0.8, random_state=42, n_jobs=-1, tree_method='hist')\n",
+    "xgb_scores = cross_val_score(xgb_cv, X_train_sel, y_train, cv=tscv, scoring='accuracy')\n",
+    "print('XGBoost CV accuracy:', xgb_scores.mean())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [
+    "Ysa-7eLvEMpE",
+    "m8CIB8vltFfH",
+    "y6QRdBKwrX98",
+    "zhTndYVi1TEV",
+    "jh9-mi26wsya",
+    "Hv5bsrpc03z7",
+    "2RFfhHT2AwAJ"
+   ],
+   "gpuType": "T4",
+   "machine_shape": "hm",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "152adcea029b4abdace26402ef4bd98d": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "1f07ba6bb7864d4981aeba397cf633aa": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "241af7b314f34423b4af560bcefc7007": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "2ec69da230984633b2c5bfc059c8d2c1": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "42626100e2084ac79f1521e8d84b11b7": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "56d0aa2bebd947769b766a99c7ab6c0e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_42626100e2084ac79f1521e8d84b11b7",
+      "max": 2725,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_1f07ba6bb7864d4981aeba397cf633aa",
+      "value": 2725
+     }
+    },
+    "5f836c62734d451386fd09b07cbbd5a5": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_63909e59276d48c6be533cb7ac6a4b51",
+       "IPY_MODEL_56d0aa2bebd947769b766a99c7ab6c0e",
+       "IPY_MODEL_e1af085ad9934b8599f3bb34509f3814"
+      ],
+      "layout": "IPY_MODEL_8786987a3a2448d5a696addc8f1ff179"
+     }
+    },
+    "63909e59276d48c6be533cb7ac6a4b51": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_2ec69da230984633b2c5bfc059c8d2c1",
+      "placeholder": "​",
+      "style": "IPY_MODEL_241af7b314f34423b4af560bcefc7007",
+      "value": "Pruning corr &gt; 0.9:  93%"
+     }
+    },
+    "8786987a3a2448d5a696addc8f1ff179": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": "hidden",
+      "width": null
+     }
+    },
+    "e1af085ad9934b8599f3bb34509f3814": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_152adcea029b4abdace26402ef4bd98d",
+      "placeholder": "​",
+      "style": "IPY_MODEL_e1d8854e112e4f608037b5080d7614e1",
+      "value": " 2536/2725 [00:00&lt;00:00, 8538.79col/s]"
+     }
+    },
+    "e1d8854e112e4f608037b5080d7614e1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- remove the slope helper cells from the DRL feature notebook
- update create_features so it now only assembles Kalman- and RSI-based signals and component frames

## Testing
- not run (notebook change)

------
https://chatgpt.com/codex/tasks/task_e_68d5bde89dac832898d8fcdd324cef8e